### PR TITLE
Update to templated Field integration

### DIFF
--- a/src/Integrator/BaseField.H
+++ b/src/Integrator/BaseField.H
@@ -29,9 +29,9 @@ public:
 
     virtual int NComp() = 0;
     virtual void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) = 0;
-
     bool writeout = false;
-    std::string name;
+    virtual std::string Name(int) = 0;
+    virtual void setName(std::string a_name) = 0;
 };
 
 template<class T>
@@ -208,6 +208,12 @@ public:
     virtual void Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost) override
     {
         m_field.Copy(a_lev,a_dst,a_dstcomp,a_nghost);
+    }
+    virtual void setName(std::string a_name) override {
+        m_field.name = a_name;
+    }
+    virtual std::string Name(int i) override {
+        return m_field.Name(i);
     }
 };
 

--- a/src/Integrator/BaseField.H
+++ b/src/Integrator/BaseField.H
@@ -26,6 +26,7 @@ public:
                                         const amrex::BoxArray& cgrids,
                                         const amrex::DistributionMapping& dm) = 0;
     virtual void SetFinestLevel(const int a_finestlevel) = 0;
+    virtual void FillPatch(const int lev, const Set::Scalar time)=0;
 
     virtual int NComp() = 0;
     virtual void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) = 0;
@@ -102,6 +103,14 @@ public:
                                     mapper, bcs, 0);
         }
 
+    }
+    void 
+    FillPatch (int lev, amrex::Real time//,
+                //amrex::Vector<std::unique_ptr<amrex::FabArray<amrex::BaseFab<T>>>> &source_mf,
+                //amrex::FabArray<amrex::BaseFab<T>> &destination_mf, 
+                /*int icomp*/)
+    {
+        this->FillPatch(lev,time,m_field,*(m_field[lev]),0);
     }
     void
     FillCoarsePatch (int lev,

--- a/src/Integrator/BaseField.H
+++ b/src/Integrator/BaseField.H
@@ -1,6 +1,10 @@
 #ifndef INTEGRATOR_BASEFIELD_H
 #define INTEGRATOR_BASEFIELD_H
 
+#include "AMReX_FillPatchUtil.H"
+
+#include "Util/Util.H"
+#include "Set/Set.H"
 #include "Numeric/Interpolator/NodeBilinear.H"
 
 namespace Integrator
@@ -22,7 +26,12 @@ public:
                                         const amrex::BoxArray& cgrids,
                                         const amrex::DistributionMapping& dm) = 0;
     virtual void SetFinestLevel(const int a_finestlevel) = 0;
-                      
+
+    virtual int NComp() = 0;
+    virtual void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) = 0;
+
+    bool writeout = false;
+    std::string name;
 };
 
 template<class T>
@@ -191,6 +200,15 @@ private:
     const amrex::Vector<amrex::Geometry>  &m_geom;
     const amrex::Vector<amrex::IntVect> &m_refRatio;
     const int m_ncomp, m_nghost;
+    
+public:
+    virtual int NComp() override {
+        return m_field.NComp();
+    }    
+    virtual void Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost) override
+    {
+        m_field.Copy(a_lev,a_dst,a_dstcomp,a_nghost);
+    }
 };
 
 }

--- a/src/Integrator/Dynamics.H
+++ b/src/Integrator/Dynamics.H
@@ -22,95 +22,126 @@
 
 #include "Numeric/Stencil.H"
 
-#define TEMP_OLD(i, j, k) Temp_old_box(amrex::IntVect(AMREX_D_DECL(i, j, k)))
-#define TEMP(i, j, k) Temp_box(amrex::IntVect(AMREX_D_DECL(i, j, k)))
-
 namespace Integrator
 {
 class Dynamics : virtual public Integrator
 {
 public:
-    /// \brief Read in parameters and register field variables
-    Dynamics() : Integrator() {}
+    Dynamics() : Integrator() 
+    {
+        //RegisterNewFab(empty_mf,bc,1,2,"empty",true);
+        //RegisterNewFab(eta_new_mf, mybc, number_of_grains, number_of_ghost_cells, "Eta",true);
+        RegisterNodalFab(disp_mf, AMREX_SPACEDIM, 0, "disp",true);
+        
+        RegisterGeneralFab(unew_mf,1,2);
+        RegisterGeneralFab(u_mf,1,2);
+        RegisterGeneralFab(v_mf,1,2);
+        RegisterGeneralFab(eps_mf,1,2);
+        RegisterGeneralFab(sig_mf,1,2);
+        RegisterGeneralFab(b_mf,1,2);
+    }
 
     static void Parse(Dynamics &value, IO::ParmParse &pp)
     {
-        pp.queryclass("model",value);
+        //value.bc = new BC::Constant(1);
+        //pp.queryclass(*static_cast<BC::Constant *>(value.bc)); // See :ref:`BC::Constant`
+        pp.queryclass("model",value.model);
     }
 
 protected:
 
-    /// \brief Use the #ic object to initialize #Temp
     void Initialize(int lev)
     {
         Set::Vector b0(AMREX_D_DECL(1.0,0.0,0.0));
 
+        unew_mf[lev]->setVal(Set::Vector::Zero());
+
         u_mf[lev]->setVal(Set::Vector::Zero());
+        v_mf[lev]->setVal(Set::Vector::Zero());
         eps_mf[lev]->setVal(Set::Matrix::Zero());
         sig_mf[lev]->setVal(Set::Matrix::Zero());
+        
         b_mf[lev]->setVal(b0);
 
-        RegisterGeneralFab(unew_mf,1,2);
-
-        RegisterGeneralFab(u_mf,1,2);
-        RegisterGeneralFab(eps_mf,1,2);
-        RegisterGeneralFab(sig_mf,1,2);
-        RegisterGeneralFab(b_mf,1,2);
-
+        disp_mf[lev]->setVal(0.0);
         //ic->Initialize(lev,temp_old_mf);
     }
 
-    /// \brief Integrate the heat equation
     void Advance(int lev, amrex::Real /*time*/, amrex::Real dt)
     {
         std::swap(*unew_mf[lev], *u_mf[lev]);
+
+        amrex::Box domain = geom[lev].Domain();
+        domain.convert(amrex::IntVect::TheNodeVector());
+        domain.grow(-1);
         
         const amrex::Real *DX = geom[lev].CellSize();
 
         for (amrex::MFIter mfi(*unew_mf[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            const amrex::Box &bx = mfi.tilebox();
+            const amrex::Box bx = mfi.tilebox() & domain;
+
             amrex::Array4<Set::Vector>         const &unew = (*unew_mf[lev]).array(mfi);
+
             amrex::Array4<const Set::Vector>   const &u    = (*u_mf[lev]).array(mfi);
+            amrex::Array4<Set::Vector>         const &v    = (*v_mf[lev]).array(mfi);
             amrex::Array4<Set::Matrix>         const &eps  = (*eps_mf[lev]).array(mfi);
             amrex::Array4<Set::Matrix>         const &sig  = (*sig_mf[lev]).array(mfi);
             amrex::Array4<const Set::Vector>   const &b    = (*b_mf[lev]).array(mfi);
         
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
             {
+                //std::array<Numeric::StencilType,AMREX_SPACEDIM> sten = Numeric::GetStencil(i,j,k,bx);
+                
                 eps(i,j,k) = Numeric::Gradient(u,i,j,k,DX);
                 sig(i,j,k) = model.DW(eps(i,j,k));
             });
 
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
             {
-                Set::Vector rhoudotdot = Numeric::Divergence(sig,i,j,k,DX) + b(i,j,k);
+                //std::array<Numeric::StencilType,AMREX_SPACEDIM> sten = Numeric::GetStencil(i,j,k,bx);
+
+                Set::Vector udotdot = (Numeric::Divergence(sig,i,j,k,DX) + b(i,j,k)) / rho;
+                v(i,j,k) = v(i,j,k) + dt * udotdot;
+                unew(i,j,k) = u(i,j,k) + dt*v(i,j,k);
             });
 
+            amrex::Array4<Set::Scalar> const disp = (*disp_mf[lev]).array(mfi);
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
+            {
+                disp(i,j,k,0) = u(i,j,k)[0];
+                disp(i,j,k,1) = u(i,j,k)[1];
+            });
+            
         }
-
     }
 
-    /// \brief Tag cells for mesh refinement based on temperature gradient
     void TagCellsForRefinement(int lev, amrex::TagBoxArray &a_tags, amrex::Real /*time*/, int /*ngrow*/)
     {}
 
 protected:
 
+    Set::Field<Set::Scalar> disp_mf;
+
     Set::Field<Set::Vector> unew_mf;
 
     Set::Field<Set::Vector> u_mf;
+    Set::Field<Set::Vector> v_mf;
     Set::Field<Set::Matrix> eps_mf;
-    Model::Solid::Linear::Isotropic model;    
     Set::Field<Set::Matrix> sig_mf;
     Set::Field<Set::Vector> b_mf;
+
+    Model::Solid::Linear::Isotropic model;
+    Set::Scalar rho = 1.0;
 
 private:
     int number_of_components = 1;            ///< Number of components
     int number_of_ghost_cells = 2;           ///< Number of ghost cells
 
     //IC::IC *ic;                              ///< Object used to initialize temperature field
-    //BC::BC<Set::Vector> *bc;                 ///< Object used to update temp field boundary ghost cells
+//    BC::BC<Set::Vector> *bc;                 ///< Object used to update temp field boundary ghost cells
+    BC::BC<Set::Scalar> *bc;                 ///< Object used to update temp field boundary ghost cells
+
 };
 } // namespace Integrator
 #endif

--- a/src/Integrator/Dynamics.H
+++ b/src/Integrator/Dynamics.H
@@ -1,0 +1,116 @@
+#ifndef INTEGRATOR_DYNAMICS_H
+#define INTEGRATOR_DYNAMICS_H
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+
+#include "AMReX.H"
+#include "AMReX_ParallelDescriptor.H"
+#include "AMReX_ParmParse.H"
+
+#include "IO/ParmParse.H"
+#include "Integrator/Integrator.H"
+
+#include "IC/IC.H"
+#include "BC/Constant.H"
+
+#include "IC/Cylinder.H"
+#include "IC/Sphere.H"
+#include "IC/Constant.H"
+
+#include "Model/Solid/Linear/Isotropic.H"
+
+#include "Numeric/Stencil.H"
+
+#define TEMP_OLD(i, j, k) Temp_old_box(amrex::IntVect(AMREX_D_DECL(i, j, k)))
+#define TEMP(i, j, k) Temp_box(amrex::IntVect(AMREX_D_DECL(i, j, k)))
+
+namespace Integrator
+{
+class Dynamics : virtual public Integrator
+{
+public:
+    /// \brief Read in parameters and register field variables
+    Dynamics() : Integrator() {}
+
+    static void Parse(Dynamics &value, IO::ParmParse &pp)
+    {
+        pp.queryclass("model",value);
+    }
+
+protected:
+
+    /// \brief Use the #ic object to initialize #Temp
+    void Initialize(int lev)
+    {
+        Set::Vector b0(AMREX_D_DECL(1.0,0.0,0.0));
+
+        u_mf[lev]->setVal(Set::Vector::Zero());
+        eps_mf[lev]->setVal(Set::Matrix::Zero());
+        sig_mf[lev]->setVal(Set::Matrix::Zero());
+        b_mf[lev]->setVal(b0);
+
+        RegisterGeneralFab(unew_mf,1,2);
+
+        RegisterGeneralFab(u_mf,1,2);
+        RegisterGeneralFab(eps_mf,1,2);
+        RegisterGeneralFab(sig_mf,1,2);
+        RegisterGeneralFab(b_mf,1,2);
+
+        //ic->Initialize(lev,temp_old_mf);
+    }
+
+    /// \brief Integrate the heat equation
+    void Advance(int lev, amrex::Real /*time*/, amrex::Real dt)
+    {
+        std::swap(*unew_mf[lev], *u_mf[lev]);
+        
+        const amrex::Real *DX = geom[lev].CellSize();
+
+        for (amrex::MFIter mfi(*unew_mf[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const amrex::Box &bx = mfi.tilebox();
+            amrex::Array4<Set::Vector>         const &unew = (*unew_mf[lev]).array(mfi);
+            amrex::Array4<const Set::Vector>   const &u    = (*u_mf[lev]).array(mfi);
+            amrex::Array4<Set::Matrix>         const &eps  = (*eps_mf[lev]).array(mfi);
+            amrex::Array4<Set::Matrix>         const &sig  = (*sig_mf[lev]).array(mfi);
+            amrex::Array4<const Set::Vector>   const &b    = (*b_mf[lev]).array(mfi);
+        
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
+            {
+                eps(i,j,k) = Numeric::Gradient(u,i,j,k,DX);
+                sig(i,j,k) = model.DW(eps(i,j,k));
+            });
+
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
+            {
+                Set::Vector rhoudotdot = Numeric::Divergence(sig,i,j,k,DX) + b(i,j,k);
+            });
+
+        }
+
+    }
+
+    /// \brief Tag cells for mesh refinement based on temperature gradient
+    void TagCellsForRefinement(int lev, amrex::TagBoxArray &a_tags, amrex::Real /*time*/, int /*ngrow*/)
+    {}
+
+protected:
+
+    Set::Field<Set::Vector> unew_mf;
+
+    Set::Field<Set::Vector> u_mf;
+    Set::Field<Set::Matrix> eps_mf;
+    Model::Solid::Linear::Isotropic model;    
+    Set::Field<Set::Matrix> sig_mf;
+    Set::Field<Set::Vector> b_mf;
+
+private:
+    int number_of_components = 1;            ///< Number of components
+    int number_of_ghost_cells = 2;           ///< Number of ghost cells
+
+    //IC::IC *ic;                              ///< Object used to initialize temperature field
+    //BC::BC<Set::Vector> *bc;                 ///< Object used to update temp field boundary ghost cells
+};
+} // namespace Integrator
+#endif

--- a/src/Integrator/Dynamics.H
+++ b/src/Integrator/Dynamics.H
@@ -34,6 +34,7 @@ public:
         RegisterNodalFab(disp_mf, AMREX_SPACEDIM, 0, "disp",true);
         
         RegisterGeneralFab(unew_mf,1,2);
+        RegisterGeneralFab(vnew_mf,1,2);
         RegisterGeneralFab(u_mf,1,2);
         RegisterGeneralFab(v_mf,1,2);
         RegisterGeneralFab(eps_mf,1,2);
@@ -55,6 +56,7 @@ protected:
         Set::Vector b0(AMREX_D_DECL(1.0,0.0,0.0));
 
         unew_mf[lev]->setVal(Set::Vector::Zero());
+        vnew_mf[lev]->setVal(Set::Vector::Zero());
 
         u_mf[lev]->setVal(Set::Vector::Zero());
         v_mf[lev]->setVal(Set::Vector::Zero());
@@ -70,6 +72,7 @@ protected:
     void Advance(int lev, amrex::Real /*time*/, amrex::Real dt)
     {
         std::swap(*unew_mf[lev], *u_mf[lev]);
+        std::swap(*vnew_mf[lev], *v_mf[lev]);
 
         amrex::Box domain = geom[lev].Domain();
         domain.convert(amrex::IntVect::TheNodeVector());
@@ -82,6 +85,7 @@ protected:
             const amrex::Box bx = mfi.tilebox() & domain;
 
             amrex::Array4<Set::Vector>         const &unew = (*unew_mf[lev]).array(mfi);
+            amrex::Array4<Set::Vector>         const &vnew = (*vnew_mf[lev]).array(mfi);
 
             amrex::Array4<const Set::Vector>   const &u    = (*u_mf[lev]).array(mfi);
             amrex::Array4<Set::Vector>         const &v    = (*v_mf[lev]).array(mfi);
@@ -102,7 +106,7 @@ protected:
                 //std::array<Numeric::StencilType,AMREX_SPACEDIM> sten = Numeric::GetStencil(i,j,k,bx);
 
                 Set::Vector udotdot = (Numeric::Divergence(sig,i,j,k,DX) + b(i,j,k)) / rho;
-                v(i,j,k) = v(i,j,k) + dt * udotdot;
+                vnew(i,j,k) = v(i,j,k) + dt * udotdot;
                 unew(i,j,k) = u(i,j,k) + dt*v(i,j,k);
             });
 
@@ -124,6 +128,7 @@ protected:
     Set::Field<Set::Scalar> disp_mf;
 
     Set::Field<Set::Vector> unew_mf;
+    Set::Field<Set::Vector> vnew_mf;
 
     Set::Field<Set::Vector> u_mf;
     Set::Field<Set::Vector> v_mf;

--- a/src/Integrator/Dynamics.H
+++ b/src/Integrator/Dynamics.H
@@ -125,7 +125,7 @@ protected:
         }
     }
 
-    void TagCellsForRefinement(int lev, amrex::TagBoxArray &a_tags, amrex::Real /*time*/, int /*ngrow*/)
+    void TagCellsForRefinement(int /*lev*/, amrex::TagBoxArray &/*a_tags*/, amrex::Real /*time*/, int /*ngrow*/)
     {}
 
 protected:

--- a/src/Integrator/Dynamics.H
+++ b/src/Integrator/Dynamics.H
@@ -35,11 +35,11 @@ public:
         
         RegisterGeneralFab(unew_mf,1,2);
         RegisterGeneralFab(vnew_mf,1,2);
-        RegisterGeneralFab(u_mf,1,2);
-        RegisterGeneralFab(v_mf,1,2);
+        RegisterGeneralFab(u_mf,1,2,"u");
+        RegisterGeneralFab(v_mf,1,2,"v");
         RegisterGeneralFab(eps_mf,1,2);
         RegisterGeneralFab(sig_mf,1,2);
-        RegisterGeneralFab(b_mf,1,2);
+        RegisterGeneralFab(b_mf,1,2,"b");
     }
 
     static void Parse(Dynamics &value, IO::ParmParse &pp)
@@ -82,7 +82,7 @@ protected:
 
         for (amrex::MFIter mfi(*unew_mf[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            const amrex::Box bx = mfi.tilebox() & domain;
+            amrex::Box bx = mfi.tilebox() & domain;
 
             amrex::Array4<Set::Vector>         const &unew = (*unew_mf[lev]).array(mfi);
             amrex::Array4<Set::Vector>         const &vnew = (*vnew_mf[lev]).array(mfi);
@@ -105,7 +105,12 @@ protected:
             {
                 //std::array<Numeric::StencilType,AMREX_SPACEDIM> sten = Numeric::GetStencil(i,j,k,bx);
 
-                Set::Vector udotdot = (Numeric::Divergence(sig,i,j,k,DX) + b(i,j,k)) / rho;
+                //Set::Vector udotdot = (Numeric::Divergence(sig,i,j,k,DX) + b(i,j,k)) / rho;
+                Set::Matrix3 gradgradu = Numeric::Hessian(u,i,j,k,DX);
+                Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic> C = model.DDW(eps(i,j,k));
+
+                Set::Vector udotdot = (C * gradgradu + b(i,j,k)) / rho;
+
                 vnew(i,j,k) = v(i,j,k) + dt * udotdot;
                 unew(i,j,k) = u(i,j,k) + dt*v(i,j,k);
             });

--- a/src/Integrator/Integrator.H
+++ b/src/Integrator/Integrator.H
@@ -273,7 +273,7 @@ protected:
     {
         RegisterGeneralFab(new_fab, ncomp, nghost);
         m_basefields.back()->writeout = true;
-        m_basefields.back()->name = a_name;
+        m_basefields.back()->setName(a_name);
     }
 
     void SetFinestLevel(const int a_finestlevel)

--- a/src/Integrator/Integrator.H
+++ b/src/Integrator/Integrator.H
@@ -268,6 +268,13 @@ protected:
         new_fab.resize(nlevs_max); 
         m_basefields.push_back(new Field<T>(new_fab, geom, refRatio(),ncomp,nghost));
     }
+    template<class T>
+    void RegisterGeneralFab(Set::Field<T> &new_fab, int ncomp, int nghost, std::string a_name)
+    {
+        RegisterGeneralFab(new_fab, ncomp, nghost);
+        m_basefields.back()->writeout = true;
+        m_basefields.back()->name = a_name;
+    }
 
     void SetFinestLevel(const int a_finestlevel)
     {

--- a/src/Integrator/Integrator.cpp
+++ b/src/Integrator/Integrator.cpp
@@ -747,6 +747,18 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
         else
             nnames.push_back(node.name_array[i]);
     }
+    for (unsigned int i = 0; i< m_basefields.size(); i++)
+    {
+        if (m_basefields[i]->writeout)
+        {
+            ncomponents += m_basefields[i]->NComp();
+            if (m_basefields[i]->NComp() > 1)
+                for (int j = 0; j < m_basefields[i]->NComp(); j++)
+                    nnames.push_back(amrex::Concatenate(m_basefields[i]->name,j,3));
+            else
+                Util::Abort(INFO,"Not supported yet");
+        }
+    }
 
     amrex::Vector<amrex::MultiFab> cplotmf(nlevels), nplotmf(nlevels);
 
@@ -802,6 +814,15 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
                 amrex::MultiFab::Copy(nplotmf[ilev], *(*node.fab_array[i])[ilev], 0, n, node.ncomp_array[i], 0);
                 n += node.ncomp_array[i];
             }
+            for (int i = 0; i<m_basefields.size(); i++)
+            {
+                if (m_basefields[i]->writeout)
+                {
+                    m_basefields[i]->Copy(ilev, nplotmf[ilev], n, 0);
+                    n += m_basefields[i]->NComp();
+                }
+            }
+
             if (node.all)
             {
                 for (int i = 0; i < cell.number_of_fabs; i++)

--- a/src/Integrator/Integrator.cpp
+++ b/src/Integrator/Integrator.cpp
@@ -749,10 +749,13 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
     }
 
     amrex::Vector<amrex::MultiFab> cplotmf(nlevels), nplotmf(nlevels);
+
+    bool do_cell_plotfile = (ccomponents > 0 || (ncomponents > 0 && cell.all)) && cell.any;
+    bool do_node_plotfile = (ncomponents > 0 || (ccomponents > 0 && node.all)) && node.any;
   
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {
-        if ((ccomponents > 0 || cell.all) && cell.any)
+        if (do_cell_plotfile)
         {
             int ncomp = ccomponents;
             if (cell.all) ncomp += ncomponents;
@@ -782,7 +785,7 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
             }
         }
 
-        if ((ncomponents > 0 || node.all) && node.any)
+        if (do_node_plotfile)
         {
             amrex::BoxArray ngrids = grids[ilev];
             ngrids.convert(amrex::IntVect::TheNodeVector());
@@ -821,7 +824,7 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
     std::vector<std::string> plotfilename = PlotFileName(istep[0],prefix);
     if (initial) plotfilename[1] = plotfilename[1] + "init";
   
-    if ((ccomponents > 0 || cell.all) && cell.any)
+    if (do_cell_plotfile)
     {
         amrex::Vector<std::string> allnames = cnames;
         if (cell.all) allnames.insert(allnames.end(),nnames.begin(),nnames.end());
@@ -834,7 +837,7 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
         chkptfile.close();
     }
 
-    if ((ncomponents > 0 || node.all) && node.any)
+    if (do_node_plotfile)
     {
         amrex::Vector<std::string> allnames = nnames;
         if (node.all) allnames.insert(allnames.end(),cnames.begin(),cnames.end());

--- a/src/Integrator/Integrator.cpp
+++ b/src/Integrator/Integrator.cpp
@@ -725,8 +725,8 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
     int nlevels = finest_level+1;
     if (max_plot_level >= 0) nlevels = std::min(nlevels,max_plot_level);
 
-    int ccomponents = 0, ncomponents = 0;
-    amrex::Vector<std::string> cnames, nnames;
+    int ccomponents = 0, ncomponents = 0, bfcomponents = 0;
+    amrex::Vector<std::string> cnames, nnames, bfnames;
     for (int i = 0; i < cell.number_of_fabs; i++)
     {
         if (!cell.writeout_array[i]) continue;
@@ -751,10 +751,10 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
     {
         if (m_basefields[i]->writeout)
         {
-            ncomponents += m_basefields[i]->NComp();
+            bfcomponents += m_basefields[i]->NComp();
             if (m_basefields[i]->NComp() > 1)
                 for (int j = 0; j < m_basefields[i]->NComp(); j++)
-                    nnames.push_back(amrex::Concatenate(m_basefields[i]->name,j,3));
+                    bfnames.push_back(m_basefields[i]->Name(j));
             else
                 Util::Abort(INFO,"Not supported yet");
         }
@@ -762,15 +762,15 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
 
     amrex::Vector<amrex::MultiFab> cplotmf(nlevels), nplotmf(nlevels);
 
-    bool do_cell_plotfile = (ccomponents > 0 || (ncomponents > 0 && cell.all)) && cell.any;
-    bool do_node_plotfile = (ncomponents > 0 || (ccomponents > 0 && node.all)) && node.any;
+    bool do_cell_plotfile = (ccomponents > 0 || (ncomponents+bfcomponents > 0 && cell.all)) && cell.any;
+    bool do_node_plotfile = (ncomponents+bfcomponents > 0 || (ccomponents > 0 && node.all)) && node.any;
   
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {
         if (do_cell_plotfile)
         {
             int ncomp = ccomponents;
-            if (cell.all) ncomp += ncomponents;
+            if (cell.all) ncomp += ncomponents + bfcomponents;
             cplotmf[ilev].define(grids[ilev], dmap[ilev], ncomp, 0);
 
             int n = 0;
@@ -791,9 +791,26 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
                     if ((*node.fab_array[i])[ilev]->contains_nan()) Util::Abort(INFO,nnames[i]," contains nan (i=",i,")");
                     if ((*node.fab_array[i])[ilev]->contains_inf()) Util::Abort(INFO,nnames[i]," contains inf (i=",i,")");
                     amrex::average_node_to_cellcenter(cplotmf[ilev],n,*(*node.fab_array[i])[ilev],0,node.ncomp_array[i],0);
-                    //amrex::MultiFab::Copy(cplotmf[ilev], *(*cell.fab_array[i])[ilev], 0, n, cell.ncomp_array[i], 0);
                     n += node.ncomp_array[i];
                 } 
+                
+                if (bfcomponents > 0)
+                {
+                    amrex::BoxArray ngrids = grids[ilev];
+                    ngrids.convert(amrex::IntVect::TheNodeVector());
+                    amrex::MultiFab bfplotmf(ngrids,dmap[ilev],bfcomponents,0);
+                    int ctr = 0;
+                    for (unsigned int i = 0; i < m_basefields.size(); i++)
+                    {
+                        if (m_basefields[i]->writeout)
+                        {
+                            m_basefields[i]->Copy(ilev,bfplotmf,ctr,0);
+                            ctr += m_basefields[i]->NComp();
+                        }
+                    }
+                    amrex::average_node_to_cellcenter(cplotmf[ilev],n,bfplotmf,0,bfcomponents);
+                    n+=bfcomponents;
+                }
             }
         }
 
@@ -801,7 +818,7 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
         {
             amrex::BoxArray ngrids = grids[ilev];
             ngrids.convert(amrex::IntVect::TheNodeVector());
-            int ncomp = ncomponents;
+            int ncomp = ncomponents + bfcomponents;
             if (node.all) ncomp += ccomponents;
             nplotmf[ilev].define(ngrids, dmap[ilev], ncomp, 0);
             
@@ -814,7 +831,7 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
                 amrex::MultiFab::Copy(nplotmf[ilev], *(*node.fab_array[i])[ilev], 0, n, node.ncomp_array[i], 0);
                 n += node.ncomp_array[i];
             }
-            for (int i = 0; i<m_basefields.size(); i++)
+            for (unsigned int i = 0; i<m_basefields.size(); i++)
             {
                 if (m_basefields[i]->writeout)
                 {
@@ -848,7 +865,10 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
     if (do_cell_plotfile)
     {
         amrex::Vector<std::string> allnames = cnames;
-        if (cell.all) allnames.insert(allnames.end(),nnames.begin(),nnames.end());
+        if (cell.all) {
+            allnames.insert(allnames.end(),nnames.begin(),nnames.end());
+            allnames.insert(allnames.end(),bfnames.begin(),bfnames.end());
+        }
         WriteMultiLevelPlotfile(plotfilename[0]+plotfilename[1]+"cell", nlevels, amrex::GetVecOfConstPtrs(cplotmf), allnames,
                                 Geom(), time, iter, refRatio());
     
@@ -861,6 +881,7 @@ Integrator::WritePlotFile (Set::Scalar time, amrex::Vector<int> iter, bool initi
     if (do_node_plotfile)
     {
         amrex::Vector<std::string> allnames = nnames;
+        allnames.insert(allnames.end(),bfnames.begin(),bfnames.end());
         if (node.all) allnames.insert(allnames.end(),cnames.begin(),cnames.end());
         WriteMultiLevelPlotfile(plotfilename[0]+plotfilename[1]+"node", nlevels, amrex::GetVecOfConstPtrs(nplotmf), allnames,
                                 Geom(), time, iter, refRatio());

--- a/src/Integrator/Integrator.cpp
+++ b/src/Integrator/Integrator.cpp
@@ -1051,12 +1051,11 @@ SetFinestLevel(finest_level);
                                 geom[lev+1], geom[lev],
                                 0, (*cell.fab_array[n])[lev]->nComp(), refRatio(lev));
         }
-        // for (int n = 0; n < node.number_of_fabs; n++)
-        // {
-        //  amrex::average_down(*(*node.fab_array[n])[lev+1], *(*node.fab_array[n])[lev],
-        //              geom[lev+1], geom[lev],
-        //              0, (*node.fab_array[n])[lev]->nComp(), refRatio(lev));
-        // }
+        for (int n = 0; n < node.number_of_fabs; n++)
+        {
+            amrex::average_down(*(*node.fab_array[n])[lev+1], *(*node.fab_array[n])[lev],
+                                0, (*node.fab_array[n])[lev]->nComp(), refRatio(lev));
+        }
     }
 }
 }

--- a/src/Integrator/Integrator.cpp
+++ b/src/Integrator/Integrator.cpp
@@ -1071,6 +1071,8 @@ SetFinestLevel(finest_level);
         FillPatch(lev,time,*cell.fab_array[n],*(*cell.fab_array[n])[lev],*cell.physbc_array[n],0);
     for (int n = 0 ; n < node.number_of_fabs ; n++)
         FillPatch(lev,time,*node.fab_array[n],*(*node.fab_array[n])[lev],*node.physbc_array[n],0);
+    for (unsigned int n = 0 ; n < m_basefields.size(); n++)
+        m_basefields[n]->FillPatch(lev,time);
 
     Advance(lev, time, dt[lev]);
     ++istep[lev];

--- a/src/Integrator/Mechanics.H
+++ b/src/Integrator/Mechanics.H
@@ -40,7 +40,7 @@ public:
     {
         RegisterNodalFab(disp_mf, AMREX_SPACEDIM, 2, "disp",true);
         RegisterNodalFab(rhs_mf, AMREX_SPACEDIM, 2, "rhs",true);
-        RegisterNodalFab(stress_mf, AMREX_SPACEDIM * AMREX_SPACEDIM, 2, "stress",true);
+        RegisterGeneralFab(stress_mf, 1, 2, "stress");
         RegisterNodalFab(strain_mf, AMREX_SPACEDIM * AMREX_SPACEDIM, 2, "strain",true);
     }
 
@@ -199,12 +199,17 @@ protected:
 
         for (int lev = 0; lev <= disp_mf.finest_level; lev++)
         {
+            amrex::Box domain = geom[lev].Domain();
+            domain.convert(amrex::IntVect::TheNodeVector());
+
             const amrex::Real* DX = geom[lev].CellSize();
             for (MFIter mfi(*disp_mf[lev], false); mfi.isValid(); ++mfi)
             {
                 amrex::Box bx = mfi.nodaltilebox();
-                amrex::Array4<MODEL>        const &model = model_mf[lev]->array(mfi);
-                amrex::Array4<Set::Scalar>       const &stress  = stress_mf[lev]->array(mfi);
+                bx.grow(1);
+                bx = bx & domain;
+                amrex::Array4<MODEL>             const &model   = model_mf[lev]->array(mfi);
+                amrex::Array4<Set::Matrix>       const &stress  = stress_mf[lev]->array(mfi);
                 amrex::Array4<Set::Scalar>       const &strain  = strain_mf[lev]->array(mfi);
                 amrex::Array4<const Set::Scalar> const &disp  = disp_mf[lev]->array(mfi);
 
@@ -216,16 +221,16 @@ protected:
                                             if (model(i,j,k).kinvar == Model::Solid::KinematicVariable::F)
                                             {
                                                 Set::Matrix F = Set::Matrix::Identity() + Numeric::Gradient(disp,i,j,k,DX,sten);
-                                                Set::Matrix P = model(i,j,k).DW(F);
-                                                Numeric::MatrixToField(stress,i,j,k,P);
+                                                stress(i,j,k) = model(i,j,k).DW(F);
+                                                //Numeric::MatrixToField(stress,i,j,k,P);
                                                 Numeric::MatrixToField(strain,i,j,k,F);
                                             }
                                             else
                                             {                    
                                                 Set::Matrix gradu = Numeric::Gradient(disp,i,j,k,DX,sten);
-                                                Set::Matrix sigma = model(i,j,k).DW(gradu);
+                                                stress(i,j,k) = model(i,j,k).DW(gradu);
                                                 Set::Matrix eps = 0.5*(gradu + gradu.transpose());
-                                                Numeric::MatrixToField(stress,i,j,k,sigma);
+                                                //Numeric::MatrixToField(stress,i,j,k,sigma);
                                                 Numeric::MatrixToField(strain,i,j,k,eps);
                                             }
                                         });
@@ -258,19 +263,19 @@ protected:
         const Dim3 lo= amrex::lbound(domain)/*, hi = amrex::ubound(domain)*/;
         const Dim3 /*boxlo= amrex::lbound(box),*/ boxhi = amrex::ubound(box);
 
-        amrex::Array4<const amrex::Real> const &stress = (*stress_mf[amrlev]).array(mfi);
+        amrex::Array4<const Set::Matrix> const &stress = (*stress_mf[amrlev]).array(mfi);
         //amrex::Array4<const amrex::Real> const &disp   = (*disp_mf[amrlev]).array(mfi);
         amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 
 #if AMREX_SPACEDIM == 2
                                     if (i == lo.x && j < boxhi.y)
                                     {
-                                        trac_lo[0](0) += 0.5 * (stress(i,j,k,0) + stress(i,j+1,k,0)) * da(0);
+                                        trac_lo[0](0) += 0.5 * (stress(i,j,k)(0,0) + stress(i,j+1,k)(0,0)) * da(0);
                                     } 
 #elif AMREX_SPACEDIM == 3
                                     if (i == lo.x && (j < boxhi.y && k < boxhi.z))
                                     {
-                                        trac_lo[0](0) += 0.25 * (stress(i,j,k,0) + stress(i,j+1,k,0) + stress(i,j,k+1,0) + stress(i,j+1,k+1,0)) * da(0);
+                                        trac_lo[0](0) += 0.25 * (stress(i,j,k)(0,0) + stress(i,j+1,k)(0,0) + stress(i,j,k+1)(0,0) + stress(i,j+1,k+1)(0,0)) * da(0);
                                     } 
 #endif
 
@@ -314,7 +319,7 @@ private:
     Set::Field<Set::Scalar> disp_mf;
     Set::Field<Set::Scalar> rhs_mf;
     Set::Field<Set::Scalar> res_mf;
-    Set::Field<Set::Scalar> stress_mf;
+    Set::Field<Set::Matrix> stress_mf;
     Set::Field<Set::Scalar> strain_mf;
 
     Set::Vector trac_lo[AMREX_SPACEDIM];

--- a/src/Numeric/Stencil.H
+++ b/src/Numeric/Stencil.H
@@ -662,9 +662,36 @@ Hessian(const amrex::Array4<const Set::Vector> &f,
 {
     Set::Matrix3 ret;
 
-    Set::Vector d11 = Numeric::Stencil<Set::Scalar,2,0,0>::D(f,i,j,k,m,dx);
-    Set::Vector d12 = Numeric::Stencil<Set::Scalar,1,1,0>::D(f,i,j,k,m,dx);
-    Set::Vector d22 = Numeric::Stencil<Set::Scalar,0,2,0>::D(f,i,j,k,m,dx);
+    #if AMREX_SPACEDIM>0    
+    Set::Vector f_11 = Numeric::Stencil<Set::Vector,2,0,0>::D(f,i,j,k,0,dx);
+    ret[0](0,0) = f_11(0);
+    #endif
+    #if AMREX_SPACEDIM>1
+    ret[1](0,0) = f_11(1);
+    Set::Vector f_12 = Numeric::Stencil<Set::Vector,1,1,0>::D(f,i,j,k,0,dx);
+    ret[0](1,0) = ret[0](0,1) = f_12(0);
+    ret[1](1,0) = ret[1](0,1) = f_12(0);
+    Set::Vector f_22 = Numeric::Stencil<Set::Vector,0,2,0>::D(f,i,j,k,0,dx);
+    ret[0](1,1) = f_22(0);
+    ret[1](1,1) = f_22(1);
+    #endif
+    #if AMREX_SPACEDIM>2
+    ret[2](0,0) = f_11(2);
+    ret[2](1,0) = ret[2](0,1) = f_12(0);
+    Set::Vector f_13 = Numeric::Stencil<Set::Vector,1,0,1>::D(f,i,j,k,0,dx);
+    ret[0](2,0) = ret[0](0,2) = f_13(0);
+    ret[1](2,0) = ret[1](0,2) = f_13(0);
+    ret[2](2,0) = ret[2](0,2) = f_13(0);
+    ret[2](1,1) = f_22(2);
+    Set::Vector f_23 = Numeric::Stencil<Set::Vector,0,1,1>::D(f,i,j,k,0,dx);
+    ret[0](1,2) = ret[0](2,1) = f_23(0);
+    ret[1](1,2) = ret[1](2,1) = f_23(0);
+    ret[2](1,2) = ret[2](2,1) = f_23(0);
+    Set::Vector f_33 = Numeric::Stencil<Set::Vector,0,0,2>::D(f,i,j,k,0,dx);
+    ret[0](2,2) = f_33(0);
+    ret[1](2,2) = f_33(1);
+    ret[2](2,2) = f_33(2);
+    #endif
     
 //    ret[0] = Numeric::Gradient<Set::Vector,2,0,0>::D(f,i,j,k,dx);
 //#if AMREX_SPACEDIM > 1

--- a/src/Numeric/Stencil.H
+++ b/src/Numeric/Stencil.H
@@ -652,6 +652,38 @@ Hessian(const amrex::Array4<const Set::Scalar> &f,
     return ret;
 }
 
+// Returns Hessian of a vector field.
+// Return value: ret[i](j,k) = ret_{i,jk}
+AMREX_FORCE_INLINE
+Set::Matrix3
+Hessian(const amrex::Array4<const Set::Vector> &f,
+        const int &i, const int &j, const int &k,
+        const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    Set::Matrix3 ret;
+
+    Set::Vector d11 = Numeric::Stencil<Set::Scalar,2,0,0>::D(f,i,j,k,m,dx);
+    Set::Vector d12 = Numeric::Stencil<Set::Scalar,1,1,0>::D(f,i,j,k,m,dx);
+    Set::Vector d22 = Numeric::Stencil<Set::Scalar,0,2,0>::D(f,i,j,k,m,dx);
+    
+//    ret[0] = Numeric::Gradient<Set::Vector,2,0,0>::D(f,i,j,k,dx);
+//#if AMREX_SPACEDIM > 1
+//    ret[1] = 
+//    ret(1,1) = (Numeric::Stencil<Set::Scalar,0,2,0>::D(f,i,j,k,m,dx));
+//    ret(0,1) = (Numeric::Stencil<Set::Scalar,1,1,0>::D(f,i,j,k,m,dx));
+//    ret(1,0) = ret(0,1);
+//#if AMREX_SPACEDIM > 2
+//    ret(2,2) = (Numeric::Stencil<Set::Scalar,0,0,2>::D(f,i,j,k,m,dx));
+//    ret(1,2) = (Numeric::Stencil<Set::Scalar,0,1,1>::D(f,i,j,k,m,dx));
+//    ret(2,0) = (Numeric::Stencil<Set::Scalar,1,0,1>::D(f,i,j,k,m,dx));
+//    ret(2,1) = ret(1,2);
+//    ret(0,2) = ret(2,0);
+//#endif
+//#endif
+    return ret;
+}
+
+
 AMREX_FORCE_INLINE
 Set::Matrix
 FieldToMatrix(const amrex::Array4<const Set::Scalar> &f,

--- a/src/Numeric/Stencil.H
+++ b/src/Numeric/Stencil.H
@@ -556,6 +556,28 @@ Gradient(const amrex::Array4<const Set::Scalar> &f,
 }
 
 AMREX_FORCE_INLINE
+Set::Matrix
+Gradient(const amrex::Array4<const Set::Vector> &f,
+        const int &i, const int &j, const int &k,
+        const Set::Scalar dx[AMREX_SPACEDIM],
+        std::array<StencilType,AMREX_SPACEDIM> stencil = DefaultType)
+{
+    Set::Matrix ret;
+
+#if AMREX_SPACEDIM > 0
+    ret.col(0) = Numeric::Stencil<Set::Vector,1,0,0>::D(f,i,j,k,0,dx,stencil);
+#endif
+#if AMREX_SPACEDIM > 1
+    ret.col(1) = Numeric::Stencil<Set::Vector,0,1,0>::D(f,i,j,k,0,dx,stencil);
+#endif
+#if AMREX_SPACEDIM > 2
+    ret.col(2) = Numeric::Stencil<Set::Vector,0,0,1>::D(f,i,j,k,0,dx,stencil);
+#endif
+
+    return ret;
+}
+
+AMREX_FORCE_INLINE
 Set::Matrix3
 MatrixGradient(const amrex::Array4<const Set::Scalar> &f,
         const int &i, const int &j, const int &k,

--- a/src/Set/Set.H
+++ b/src/Set/Set.H
@@ -42,6 +42,8 @@ public:
     int finest_level = 0;
     void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) {}
     int NComp() {return 1;}
+    virtual std::string Name(int) {return name;}
+    std::string name;    
 };
 
 template<>
@@ -63,8 +65,21 @@ inline void Field<Set::Vector>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_ds
         }
     }    
 }
-template<>
-inline int Field<Set::Vector>::NComp() {return AMREX_SPACEDIM;} 
+template<> inline int         Field<Set::Vector>::NComp() {return AMREX_SPACEDIM;} 
+template<> inline std::string Field<Set::Vector>::Name(int i)
+{
+    #if AMREX_SPACEDIM>0
+    if (i==0) return name + "_x";
+    #endif
+    #if AMREX_SPACEDIM>1
+    else if (i==1) return name + "_y";
+    #endif
+    #if AMREX_SPACEDIM>2
+    else if (i==2) return name + "_z";
+    #endif
+    else Util::Abort(INFO,"Invalid component");
+    return "";
+}
 
 template<>
 inline void Field<Set::Matrix>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost)
@@ -118,6 +133,30 @@ public:
     int NComp() 
     {Util::Abort(INFO,"This should never be called");return -1;}
 };
+template<> inline std::string Field<Set::Matrix>::Name(int i)
+{
+    #if AMREX_SPACEDIM==0
+    if (i==0) return name + "_xx";
+    #elif AMREX_SPACEDIM==1
+    if (i==0)      return name + "_xx";
+    else if (i==1) return name + "_xy";
+    else if (i==2) return name + "_yx";
+    else if (i==3) return name + "_yy";
+    #elif AMREX_SPACEDIM==2
+    if (i==0)      return name + "_xx";
+    else if (i==1) return name + "_xy";
+    else if (i==2) return name + "_xz";
+    else if (i==3) return name + "_yx";
+    else if (i==4) return name + "_yy";
+    else if (i==5) return name + "_yz";
+    else if (i==6) return name + "_zx";
+    else if (i==7) return name + "_zy";
+    else if (i==8) return name + "_zz";
+    #endif
+    else Util::Abort(INFO, "Invalid component");
+    return "";
+}
+
 }
 
 namespace Util

--- a/src/Set/Set.H
+++ b/src/Set/Set.H
@@ -135,14 +135,14 @@ public:
 };
 template<> inline std::string Field<Set::Matrix>::Name(int i)
 {
-    #if AMREX_SPACEDIM==0
+    #if AMREX_SPACEDIM==1
     if (i==0) return name + "_xx";
-    #elif AMREX_SPACEDIM==1
+    #elif AMREX_SPACEDIM==2
     if (i==0)      return name + "_xx";
     else if (i==1) return name + "_xy";
     else if (i==2) return name + "_yx";
     else if (i==3) return name + "_yy";
-    #elif AMREX_SPACEDIM==2
+    #elif AMREX_SPACEDIM==3
     if (i==0)      return name + "_xx";
     else if (i==1) return name + "_xy";
     else if (i==2) return name + "_xz";

--- a/src/Set/Set.H
+++ b/src/Set/Set.H
@@ -40,7 +40,55 @@ public:
         (*this)[a_lev].reset(new amrex::FabArray<amrex::BaseFab<T>>(a_grid,a_dmap,a_ncomp,a_nghost));
     }
     int finest_level = 0;
+    void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) {}
+    int NComp() {return 1;}
 };
+
+template<>
+inline void Field<Set::Vector>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost)
+{
+    for (amrex::MFIter mfi(a_dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& bx = mfi.growntilebox(amrex::IntVect(a_nghost));
+        if (bx.ok())
+        {
+            amrex::Array4<const Set::Vector> const & src = ((*this)[a_lev])->array(mfi);
+            amrex::Array4<Set::Scalar> const & dst = a_dst.array(mfi);
+            for (int n = 0; n < AMREX_SPACEDIM; n++)
+            {
+                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    dst(i,j,k,a_dstcomp + n) = src(i,j,k)(n);
+                });
+            }
+        }
+    }    
+}
+template<>
+inline int Field<Set::Vector>::NComp() {return AMREX_SPACEDIM;} 
+
+template<>
+inline void Field<Set::Matrix>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost)
+{
+    for (amrex::MFIter mfi(a_dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& bx = mfi.growntilebox(amrex::IntVect(a_nghost));
+        if (bx.ok())
+        {
+            amrex::Array4<const Set::Matrix> const & src = ((*this)[a_lev])->array(mfi);
+            amrex::Array4<Set::Scalar> const & dst = a_dst.array(mfi);
+            for (int n = 0; n < AMREX_SPACEDIM*AMREX_SPACEDIM; n++)
+            {
+                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    dst(i,j,k,a_dstcomp + n) = src(i,j,k)(n/AMREX_SPACEDIM,n%AMREX_SPACEDIM);
+                });
+            }
+        }
+    }    
+}
+template<>
+inline int Field<Set::Matrix>::NComp() {return AMREX_SPACEDIM*AMREX_SPACEDIM;} 
+
+
 
 template <>
 class Field<Set::Scalar> : public amrex::Vector<std::unique_ptr<amrex::MultiFab>>
@@ -64,6 +112,11 @@ public:
         (*this)[a_lev].reset(new amrex::MultiFab(a_grid,a_dmap,a_ncomp,a_nghost));
     }
     int finest_level = 0;
+
+    void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) 
+    {Util::Abort(INFO,"This should never get called");}
+    int NComp() 
+    {Util::Abort(INFO,"This should never be called");return -1;}
 };
 }
 

--- a/src/alamo.cc
+++ b/src/alamo.cc
@@ -20,6 +20,7 @@
 #include "Integrator/HeatConduction.H"
 #include "Integrator/Fracture.H"
 #include "Integrator/ThermoElastic.H"
+#include "Integrator/Dynamics.H"
 
 int main (int argc, char* argv[])
 {
@@ -120,6 +121,14 @@ int main (int argc, char* argv[])
         pp.queryclass(te);
         te.InitData();
         te.Evolve();
+    }
+    else if (program == "dynamics")
+    {
+        IO::ParmParse pp;
+        Integrator::Dynamics integrator;
+        pp.queryclass(integrator);
+        integrator.InitData();
+        integrator.Evolve();
     }
     else
     {

--- a/tests/Dynamics/input
+++ b/tests/Dynamics/input
@@ -10,7 +10,7 @@ stop_time		      = 0.1
 
 # amr parameters
 amr.plot_int		      = 10
-amr.max_level		      = 0
+amr.max_level		      = 1
 amr.n_cell		      = 32 32 32
 amr.blocking_factor	      = 4
 amr.regrid_int		      = 1

--- a/tests/Dynamics/input
+++ b/tests/Dynamics/input
@@ -1,0 +1,51 @@
+alamo.program                 = dynamics
+#alamo.program.mechanics.model = linear.laplacian
+plot_file		      = tests/Dynamics/output
+
+
+# this is not a time integration, so do
+# exactly one timestep and then quit
+timestep		      = 0.001
+stop_time		      = 0.1
+
+# amr parameters
+amr.plot_int		      = 10
+amr.max_level		      = 0
+amr.n_cell		      = 32 32 32
+amr.blocking_factor	      = 4
+amr.regrid_int		      = 1
+amr.grid_eff		      = 1.0
+amr.cell.all                  = 1
+
+# use an explicit mesh (i.e. no adaptive meshing)
+explicitmesh.on               = 1
+explicitmesh.lo1              = 16 16 16
+explicitmesh.hi1              = 47 47 47
+explicitmesh.lo2              = 48 48 48
+explicitmesh.hi2              = 79 79 79
+
+# geometry
+geometry.prob_lo	      = 0 0 0
+geometry.prob_hi	      = 1 1 1
+geometry.is_periodic	      = 0 0 0
+
+rhs.type = trig
+rhs.trig.nr = 0 0 0
+rhs.trig.ni = 1 1 1
+rhs.dim = 1
+rhs.alpha = 1
+
+elastic.solver.verbose = 3
+elastic.solver.nriters = 1
+elastic.solver.max_iter = 20
+
+### UNIAXIAL TENSION ###
+elastic.bc.type = constant
+
+
+
+model.E  = 210 
+model.nu = 0.3
+
+
+

--- a/tests/Dynamics/input
+++ b/tests/Dynamics/input
@@ -5,7 +5,7 @@ plot_file		      = tests/Dynamics/output
 
 # this is not a time integration, so do
 # exactly one timestep and then quit
-timestep		      = 0.001
+timestep		      = 0.0001
 stop_time		      = 0.1
 
 # amr parameters

--- a/tests/Dynamics/input
+++ b/tests/Dynamics/input
@@ -6,7 +6,7 @@ plot_file		      = tests/Dynamics/output
 # this is not a time integration, so do
 # exactly one timestep and then quit
 timestep		      = 0.0001
-stop_time		      = 0.1
+stop_time		      = 0.05
 
 # amr parameters
 amr.plot_int		      = 10

--- a/tests/Eshelby/test
+++ b/tests/Eshelby/test
@@ -19,10 +19,10 @@ def integrate(x,y):
 if dim == 3:
     offset = -0.0000
     prof = ds.ray([0.25+offset,0.25+offset,-2],[0.25+offset,0.25+offset,2],)
-    df = prof.to_dataframe([("gas","x"),("gas","y"),("gas","z"),"disp001","disp002","disp003","stress001","stress005","stress009"])
+    df = prof.to_dataframe([("gas","x"),("gas","y"),("gas","z"),"disp001","disp002","disp003","stress_xx","stress_yy","stress_zz"])
 
     z,x,y,u1,u2,u3,sig11,sig22,sig33 = [numpy.array(_x) for _x in zip(*sorted(zip(
-        df["z"],df["x"],df["y"],df["disp001"],df["disp002"],df["disp003"],df["stress001"],df["stress005"],df["stress009"])))]
+        df["z"],df["x"],df["y"],df["disp001"],df["disp002"],df["disp003"],df["stress_xx"],df["stress_yy"],df["stress_zz"])))]
 
 
 

--- a/tests/UniaxialTension/test
+++ b/tests/UniaxialTension/test
@@ -12,13 +12,13 @@ ds = yt.load(path)
 dim = int(ds.domain_dimensions[0] > 1) + int(ds.domain_dimensions[1] > 1) + int(ds.domain_dimensions[2] > 1)
 
 prof = ds.ray([-8,0,0],[8,0,0],)
-df = prof.to_dataframe([("gas","x"),"disp001","stress001"])
+df = prof.to_dataframe([("gas","x"),"disp001","stress_xx"])
 
 x    = numpy.array(df["x"])
 u1   = numpy.array(df["disp001"])
 #u2   = numpy.array(df["disp002"])
 #u3   = numpy.array(df["disp003"])
-sig1 = numpy.array(df["stress001"])
+sig1 = numpy.array(df["stress_xx"])
 
 u1_exact                = (x + 8) * 0.100 / 16
 sig1_exact   = 0*x + E * (disp / L)


### PR DESCRIPTION
This PR makes several improvements to `Field<T>` type objects:
1. Certain templated fields will now be included in output - specifically, `Set::Field<Set::Vector>` and `Set::Field<Set::Matrix` type fields - and will include more informative names. To activate this, include a "name" in the `RegisterGeneralFab` call.
2. Templated fabs will now be more accurately evolved in time via an updated `FillPatch` method in `BaseFab`. 
3. There is an example of this behavior in `src/Integrator/Dynamics.H`. Please note, however, that this example will be eventually merged back into `src/Integrator/Mechanics.H`.