### PR TITLE
Template `Set::Field` update for `Solver::Nonlocal::Newton`

### DIFF
--- a/src/BC/Operator/Elastic/Constant.H
+++ b/src/BC/Operator/Elastic/Constant.H
@@ -74,6 +74,85 @@ public:
         Set(face,direction,type,value,pa_rhs,a_geom);
     }
 
+    //using Elastic::Init;
+    
+    virtual void
+    Init(amrex::FabArray<amrex::BaseFab<Set::Vector>> *a_rhs,
+        const amrex::Geometry &a_geom,
+        bool a_homogeneous = false) const
+    {
+            amrex::Box domain(a_geom.Domain());
+            domain.convert(amrex::IntVect::TheNodeVector());
+            const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
+            for (amrex::MFIter mfi(*a_rhs, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                amrex::Box bx = mfi.tilebox();
+                bx.grow(2);
+                bx = bx & domain;
+                amrex::Array4<Set::Vector> const& rhs       = a_rhs->array(mfi);
+                amrex::ParallelFor (bx,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    
+                for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
+                {
+                    Face face = Face::INT;
+                        
+                    #if AMREX_SPACEDIM == 2
+                        
+                    if      (i==lo.x && j==lo.y) face = Face::XLO_YLO;
+                    else if (i==lo.x && j==hi.y) face = Face::XLO_YHI;
+                    else if (i==hi.x && j==lo.y) face = Face::XHI_YLO;
+                    else if (i==hi.x && j==hi.y) face = Face::XHI_YHI;
+
+                    else if (i==lo.x) face = Face::XLO;
+                    else if (i==hi.x) face = Face::XHI;
+                    else if (j==lo.y) face = Face::YLO;
+                    else if (j==hi.y) face = Face::YHI;
+
+                    #elif AMREX_SPACEDIM == 3
+
+                    if      (i==lo.x && j==lo.y && k==lo.z) face = Face::XLO_YLO_ZLO;
+                    else if (i==lo.x && j==lo.y && k==hi.z) face = Face::XLO_YLO_ZHI;
+                    else if (i==lo.x && j==hi.y && k==lo.z) face = Face::XLO_YHI_ZLO;
+                    else if (i==lo.x && j==hi.y && k==hi.z) face = Face::XLO_YHI_ZHI;
+                    else if (i==hi.x && j==lo.y && k==lo.z) face = Face::XHI_YLO_ZLO;
+                    else if (i==hi.x && j==lo.y && k==hi.z) face = Face::XHI_YLO_ZHI;
+                    else if (i==hi.x && j==hi.y && k==lo.z) face = Face::XHI_YHI_ZLO;
+                    else if (i==hi.x && j==hi.y && k==hi.z) face = Face::XHI_YHI_ZHI;
+
+                    else if (j==lo.y && k==lo.z) face = Face::YLO_ZLO;
+                    else if (j==lo.y && k==hi.z) face = Face::YLO_ZHI;
+                    else if (j==hi.y && k==lo.z) face = Face::YHI_ZLO;
+                    else if (j==hi.y && k==hi.z) face = Face::YHI_ZHI;
+                    else if (k==lo.z && i==lo.x) face = Face::ZLO_XLO;
+                    else if (k==lo.z && i==hi.x) face = Face::ZLO_XHI;
+                    else if (k==hi.z && i==lo.x) face = Face::ZHI_XLO;
+                    else if (k==hi.z && i==hi.x) face = Face::ZHI_XHI;
+                    else if (i==lo.x && j==lo.y) face = Face::XLO_YLO;
+                    else if (i==lo.x && j==hi.y) face = Face::XLO_YHI;
+                    else if (i==hi.x && j==lo.y) face = Face::XHI_YLO;
+                    else if (i==hi.x && j==hi.y) face = Face::XHI_YHI;
+
+                    else if (i==lo.x) face = Face::XLO;
+                    else if (i==hi.x) face = Face::XHI;
+                    else if (j==lo.y) face = Face::YLO;
+                    else if (j==hi.y) face = Face::YHI;
+                    else if (k==lo.z) face = Face::ZLO;
+                    else if (k==hi.z) face = Face::ZHI;
+
+                    #endif
+
+                    if (!(face == Face::INT))
+                    {
+                        if (a_homogeneous && m_bc_type[face][dir] == Type::Displacement) 
+                            rhs(i,j,k)(dir) = 0.0;
+                        else 
+                            rhs(i,j,k)(dir) = m_bc_val[face][dir](m_time);
+                    }
+                }
+            });
+        }                    
+    }
+
     using Elastic::Init;
     virtual void
     Init(amrex::MultiFab * a_rhs,

--- a/src/BC/Operator/Elastic/Elastic.H
+++ b/src/BC/Operator/Elastic/Elastic.H
@@ -47,8 +47,22 @@ public:
         const amrex::Geometry &a_geom,
         bool a_homogeneous = false) const = 0;
 
+    virtual void
+    Init(amrex::FabArray<amrex::BaseFab<Set::Vector>> * a_rhs,
+        const amrex::Geometry &a_geom,
+        bool a_homogeneous = false) const = 0;
+
     void
     Init(Set::Field<Set::Scalar> &a_rhs,
+        const amrex::Vector<amrex::Geometry> &a_geom,
+        bool a_homogeneous = false) const
+    {
+        for (int ilev = 0; ilev <= a_rhs.finest_level; ilev++)
+            Init(a_rhs[ilev].get(),a_geom[ilev],a_homogeneous);
+    }
+
+    void
+    Init(Set::Field<Set::Vector> &a_rhs,
         const amrex::Vector<amrex::Geometry> &a_geom,
         bool a_homogeneous = false) const
     {

--- a/src/BC/Operator/Elastic/Expression.H
+++ b/src/BC/Operator/Elastic/Expression.H
@@ -22,7 +22,12 @@ class Expression : public Elastic
 #ifndef ALAMO_JIT
 public:
     Expression(){ Util::Abort(INFO,"You need to compile with JIT to use this BC"); }
-    virtual void Init(amrex::MultiFab * ,const amrex::Geometry &,bool) const {};
+    virtual void Init(amrex::MultiFab * ,const amrex::Geometry &,bool) 
+    const override
+    {};
+    virtual void Init(amrex::FabArray<amrex::BaseFab<Set::Vector>> *,const amrex::Geometry &,bool) 
+    const override
+    {}
     static void Parse(Expression &, IO::ParmParse & ) {} ;
     Set::Vector operator () (const Set::Vector &, const Set::Matrix &, const Set::Matrix &, const int &, const int &, const int &, const amrex::Box &) {return Set::Vector::Zero();};
 #else
@@ -48,6 +53,93 @@ public:
 
 
     using Elastic::Init;
+
+    virtual void
+    Init(amrex::FabArray<amrex::BaseFab<Set::Vector>> *a_rhs,
+        const amrex::Geometry &a_geom,
+        bool a_homogeneous = false) const override
+    {
+            amrex::Box domain(a_geom.Domain());
+            domain.convert(amrex::IntVect::TheNodeVector());
+            const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
+            for (amrex::MFIter mfi(*a_rhs, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                amrex::Box bx = mfi.tilebox();
+                bx.grow(2);
+                bx = bx & domain;
+                amrex::Array4<Set::Vector> const& rhs       = a_rhs->array(mfi);
+                amrex::ParallelFor (bx,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    
+                for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
+                {
+                    Face face = Face::INT;
+                        
+                    #if AMREX_SPACEDIM == 2
+                        
+                    if      (i==lo.x && j==lo.y) face = Face::XLO_YLO;
+                    else if (i==lo.x && j==hi.y) face = Face::XLO_YHI;
+                    else if (i==hi.x && j==lo.y) face = Face::XHI_YLO;
+                    else if (i==hi.x && j==hi.y) face = Face::XHI_YHI;
+
+                    else if (i==lo.x) face = Face::XLO;
+                    else if (i==hi.x) face = Face::XHI;
+                    else if (j==lo.y) face = Face::YLO;
+                    else if (j==hi.y) face = Face::YHI;
+
+                    #elif AMREX_SPACEDIM == 3
+
+                    if      (i==lo.x && j==lo.y && k==lo.z) face = Face::XLO_YLO_ZLO;
+                    else if (i==lo.x && j==lo.y && k==hi.z) face = Face::XLO_YLO_ZHI;
+                    else if (i==lo.x && j==hi.y && k==lo.z) face = Face::XLO_YHI_ZLO;
+                    else if (i==lo.x && j==hi.y && k==hi.z) face = Face::XLO_YHI_ZHI;
+                    else if (i==hi.x && j==lo.y && k==lo.z) face = Face::XHI_YLO_ZLO;
+                    else if (i==hi.x && j==lo.y && k==hi.z) face = Face::XHI_YLO_ZHI;
+                    else if (i==hi.x && j==hi.y && k==lo.z) face = Face::XHI_YHI_ZLO;
+                    else if (i==hi.x && j==hi.y && k==hi.z) face = Face::XHI_YHI_ZHI;
+
+                    else if (j==lo.y && k==lo.z) face = Face::YLO_ZLO;
+                    else if (j==lo.y && k==hi.z) face = Face::YLO_ZHI;
+                    else if (j==hi.y && k==lo.z) face = Face::YHI_ZLO;
+                    else if (j==hi.y && k==hi.z) face = Face::YHI_ZHI;
+                    else if (k==lo.z && i==lo.x) face = Face::ZLO_XLO;
+                    else if (k==lo.z && i==hi.x) face = Face::ZLO_XHI;
+                    else if (k==hi.z && i==lo.x) face = Face::ZHI_XLO;
+                    else if (k==hi.z && i==hi.x) face = Face::ZHI_XHI;
+                    else if (i==lo.x && j==lo.y) face = Face::XLO_YLO;
+                    else if (i==lo.x && j==hi.y) face = Face::XLO_YHI;
+                    else if (i==hi.x && j==lo.y) face = Face::XHI_YLO;
+                    else if (i==hi.x && j==hi.y) face = Face::XHI_YHI;
+
+                    else if (i==lo.x) face = Face::XLO;
+                    else if (i==hi.x) face = Face::XHI;
+                    else if (j==lo.y) face = Face::YLO;
+                    else if (j==hi.y) face = Face::YHI;
+                    else if (k==lo.z) face = Face::ZLO;
+                    else if (k==hi.z) face = Face::ZHI;
+
+                    #endif
+
+                    amrex::IndexType type = a_rhs->ixType();
+                    if (!(face == Face::INT))
+                    {
+                        if (a_homogeneous && m_bc_type[face][dir] == Type::Displacement) 
+                            rhs(i,j,k)(dir) = 0.0;
+                        else 
+                        {
+                            Set::Vector x = Set::Position(i, j, k, a_geom, type);
+                            double loc[4];
+                            AMREX_D_TERM(loc[0] = x(0);, loc[1] = x(1);, loc[2] = x(2););
+                            loc[3] = m_time; 
+                            FunctionParserAD & func = const_cast<FunctionParserAD&>(m_bc_func[face][dir]);
+                            rhs(i,j,k)(dir) = func.Eval(loc);
+                        }
+                    }
+                }
+            });
+        }                    
+    }
+
+    
     virtual void
     Init(amrex::MultiFab * a_rhs,
         const amrex::Geometry &a_geom,

--- a/src/IC/IC.H
+++ b/src/IC/IC.H
@@ -17,11 +17,20 @@ public:
     virtual ~IC() {}
 
     virtual void Add(const int &lev, Set::Field<Set::Scalar> &field) = 0;
+    virtual void Add(const int &, Set::Field<Set::Vector> &) 
+    {Util::Abort(INFO,"Not yet implemented");};
     void Initialize(const int &a_lev,
                     Set::Field<Set::Scalar> &a_field)
     {
         Util::Assert(INFO,TEST(a_lev < a_field.size())," a_lev=",a_lev," size=",a_field.size());
         a_field[a_lev]->setVal(0.0);
+        Add(a_lev,a_field);
+    };
+    void Initialize(const int &a_lev,
+                    Set::Field<Set::Vector> &a_field)
+    {
+        Util::Assert(INFO,TEST(a_lev < a_field.size())," a_lev=",a_lev," size=",a_field.size());
+        a_field[a_lev]->setVal(Set::Vector::Zero());
         Add(a_lev,a_field);
     };
 

--- a/src/IC/Trig.H
+++ b/src/IC/Trig.H
@@ -96,6 +96,60 @@ public:
             });
         }
     }
+    void Add(const int &lev, Set::Field<Set::Vector> &a_field)
+    {
+        bool cellcentered = (a_field[0]->boxArray().ixType() == amrex::IndexType(amrex::IntVect::TheCellVector()));
+
+        const Set::Scalar AMREX_D_DECL(L1 = geom[lev].ProbHi()[0] - geom[lev].ProbLo()[0],
+                            L2 = geom[lev].ProbHi()[1] - geom[lev].ProbLo()[1],
+                            L3 = geom[lev].ProbHi()[2] - geom[lev].ProbLo()[2]);
+
+
+        for (amrex::MFIter mfi(*a_field[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            amrex::Box bx;
+            if (cellcentered) bx = mfi.growntilebox();
+            else bx = mfi.grownnodaltilebox();
+
+            amrex::Array4<Set::Vector> const &field = a_field[lev]->array(mfi);
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+            {
+                Set::Scalar AMREX_D_DECL(x1,x2,x3);
+                if (cellcentered)
+                {
+                    AMREX_D_TERM(x1 = geom[lev].ProbLo()[0] + ((amrex::Real)(i) + 0.5) * geom[lev].CellSize()[0];,
+                                x2 = geom[lev].ProbLo()[1] + ((amrex::Real)(j) + 0.5) * geom[lev].CellSize()[1];,
+                                x3 = geom[lev].ProbLo()[2] + ((amrex::Real)(k) + 0.5) * geom[lev].CellSize()[2];);
+                }
+                else
+                {
+                    AMREX_D_TERM(x1 = geom[lev].ProbLo()[0] + (amrex::Real)(i) * geom[lev].CellSize()[0];,
+                                x2 = geom[lev].ProbLo()[1] + (amrex::Real)(j) * geom[lev].CellSize()[1];,
+                                x3 = geom[lev].ProbLo()[2] + (amrex::Real)(k) * geom[lev].CellSize()[2];);
+                }
+                                   
+                Set::Scalar trigfn = 1.0;
+                #if AMREX_SPACEDIM > 0
+                if (dim > 0)
+                    trigfn *= (fabs(std::cos(phi1))*std::cos(n1.real()*Set::Constant::Pi*x1 / L1) +
+                            fabs(std::sin(phi1))*std::sin(n1.imag()*Set::Constant::Pi*x1 / L1));
+                #endif
+                #if AMREX_SPACEDIM > 1
+                if (dim > 1)
+                    trigfn *= (fabs(std::cos(phi2))*std::cos(n2.real()*Set::Constant::Pi*x2 / L2) +
+                            fabs(std::sin(phi2))*std::sin(n2.imag()*Set::Constant::Pi*x2 / L2));
+                #endif
+                #if AMREX_SPACEDIM > 2
+                if (dim > 2)
+                    trigfn *= (fabs(std::cos(phi3))*std::cos(n3.real()*Set::Constant::Pi*x3 / L3) +
+                            fabs(std::sin(phi3))*std::sin(n3.imag()*Set::Constant::Pi*x3 / L3));
+                #endif
+                        
+                field(i,j,k)(comp) += alpha * trigfn;
+
+            });
+        }
+    }
     using IC::Add;
 
 public:

--- a/src/Integrator/Mechanics.H
+++ b/src/Integrator/Mechanics.H
@@ -33,21 +33,30 @@ namespace Integrator
 template<class MODEL>
 class Mechanics : virtual public Integrator
 {
-    //using model_type = Model::Solid::Affine::Isotropic;
+    enum Type{Static, Dynamic};
+    
 public:
     /// \brief Read in parameters and register field variables
     Mechanics()
     {
-        RegisterNodalFab(disp_mf, AMREX_SPACEDIM, 2, "disp",true);
-        RegisterNodalFab(rhs_mf, AMREX_SPACEDIM, 2, "rhs",true);
+        RegisterGeneralFab(disp_mf, 1, 2, "disp");
+        RegisterGeneralFab(rhs_mf, 1, 2, "rhs");
         RegisterGeneralFab(stress_mf, 1, 2, "stress");
-        RegisterNodalFab(strain_mf, AMREX_SPACEDIM * AMREX_SPACEDIM, 2, "strain",true);
+        RegisterGeneralFab(strain_mf, 1, 2, "strain");
     }
 
     // The mechanics integrator manages the solution of an elastic 
     // solve using the MLMG solver. 
     static void Parse(Mechanics &value, IO::ParmParse &pp)
     {
+        if (pp.contains("type"))
+        {
+            std::string type_str;
+            pp.query("type",type_str);
+            if (type_str == "static")       value.m_type = Type::Static;
+            else if (type_str == "dynamic") value.m_type = Type::Static;
+            else Util::Abort(INFO,"Invalid type ", type_str, " specified");
+        }
 
         int nmodels = 1;
         pp.query("elastic.nmodels",nmodels); // Number of elastic model varieties
@@ -80,7 +89,7 @@ public:
         }
         else if (bc_type == "expression")
         {
-            value.elastic.bc = new BC::Operator::Elastic::Expression();
+            //value.elastic.bc = new BC::Operator::Elastic::Expression();
             // Query :ref:`BC::Operator::Elastic::Expression`
             pp.queryclass("elastic.bc.expression",static_cast<BC::Operator::Elastic::Expression*>(value.elastic.bc));
         }
@@ -138,10 +147,10 @@ protected:
             eta_mf[lev]->setVal(1.0);
         }
 
-        disp_mf[lev]->setVal(0.);
+        disp_mf[lev]->setVal(Set::Vector::Zero());
 
         if (ic_rhs) ic_rhs->Initialize(lev,rhs_mf);
-        else rhs_mf[lev]->setVal(0.);
+        else rhs_mf[lev]->setVal(Set::Vector::Zero());
     }
 
     virtual void UpdateModel()
@@ -154,7 +163,7 @@ protected:
 
             eta_mf[lev]->FillBoundary();
 
-            disp_mf[lev]->setVal(0.0);
+            disp_mf[lev]->setVal(Set::Vector::Zero());
 
             Set::Vector DX(geom[lev].CellSize());
 
@@ -210,8 +219,8 @@ protected:
                 bx = bx & domain;
                 amrex::Array4<MODEL>             const &model   = model_mf[lev]->array(mfi);
                 amrex::Array4<Set::Matrix>       const &stress  = stress_mf[lev]->array(mfi);
-                amrex::Array4<Set::Scalar>       const &strain  = strain_mf[lev]->array(mfi);
-                amrex::Array4<const Set::Scalar> const &disp  = disp_mf[lev]->array(mfi);
+                amrex::Array4<Set::Matrix>       const &strain  = strain_mf[lev]->array(mfi);
+                amrex::Array4<const Set::Vector> const &disp  = disp_mf[lev]->array(mfi);
 
 
                 amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
@@ -222,16 +231,13 @@ protected:
                                             {
                                                 Set::Matrix F = Set::Matrix::Identity() + Numeric::Gradient(disp,i,j,k,DX,sten);
                                                 stress(i,j,k) = model(i,j,k).DW(F);
-                                                //Numeric::MatrixToField(stress,i,j,k,P);
-                                                Numeric::MatrixToField(strain,i,j,k,F);
+                                                strain(i,j,k) = F;
                                             }
                                             else
                                             {                    
                                                 Set::Matrix gradu = Numeric::Gradient(disp,i,j,k,DX,sten);
                                                 stress(i,j,k) = model(i,j,k).DW(gradu);
-                                                Set::Matrix eps = 0.5*(gradu + gradu.transpose());
-                                                //Numeric::MatrixToField(stress,i,j,k,sigma);
-                                                Numeric::MatrixToField(strain,i,j,k,eps);
+                                                strain(i,j,k) = 0.5*(gradu + gradu.transpose());
                                             }
                                         });
             }
@@ -293,7 +299,7 @@ protected:
             amrex::Box bx = mfi.tilebox();
             amrex::Array4<char> const &tags = a_tags.array(mfi);
             amrex::Array4<Set::Scalar> const &eta = eta_mf[lev]->array(mfi);
-            amrex::Array4<Set::Scalar> const &strain = strain_mf[lev]->array(mfi);
+            amrex::Array4<Set::Vector> const &u = disp_mf[lev]->array(mfi);
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                                         {
                                             Set::Vector grad = Numeric::Gradient(eta, i, j, k, 0, DX.data());
@@ -301,7 +307,7 @@ protected:
                                                 tags(i, j, k) = amrex::TagBox::SET;
                                         }
                                         {
-                                            Set::Matrix3 grad = Numeric::MatrixGradient(strain, i, j, k, DX.data());
+                                            Set::Matrix3 grad = Numeric::Hessian(u, i, j, k, DX.data());
                                             if (grad.norm() * DXnorm > m_elastic_ref_threshold)
                                                 tags(i, j, k) = amrex::TagBox::SET;
                                         }
@@ -315,12 +321,13 @@ protected:
 
 private:
     int m_interval = 0;
+    Type m_type = Type::Static;
 
-    Set::Field<Set::Scalar> disp_mf;
-    Set::Field<Set::Scalar> rhs_mf;
+    Set::Field<Set::Vector> disp_mf;
+    Set::Field<Set::Vector> rhs_mf;
     Set::Field<Set::Scalar> res_mf;
     Set::Field<Set::Matrix> stress_mf;
-    Set::Field<Set::Scalar> strain_mf;
+    Set::Field<Set::Matrix> strain_mf;
 
     Set::Vector trac_lo[AMREX_SPACEDIM];
     Set::Vector trac_hi[AMREX_SPACEDIM];

--- a/src/Numeric/Stencil.H
+++ b/src/Numeric/Stencil.H
@@ -692,21 +692,6 @@ Hessian(const amrex::Array4<const Set::Vector> &f,
     ret[1](2,2) = f_33(1);
     ret[2](2,2) = f_33(2);
     #endif
-    
-//    ret[0] = Numeric::Gradient<Set::Vector,2,0,0>::D(f,i,j,k,dx);
-//#if AMREX_SPACEDIM > 1
-//    ret[1] = 
-//    ret(1,1) = (Numeric::Stencil<Set::Scalar,0,2,0>::D(f,i,j,k,m,dx));
-//    ret(0,1) = (Numeric::Stencil<Set::Scalar,1,1,0>::D(f,i,j,k,m,dx));
-//    ret(1,0) = ret(0,1);
-//#if AMREX_SPACEDIM > 2
-//    ret(2,2) = (Numeric::Stencil<Set::Scalar,0,0,2>::D(f,i,j,k,m,dx));
-//    ret(1,2) = (Numeric::Stencil<Set::Scalar,0,1,1>::D(f,i,j,k,m,dx));
-//    ret(2,0) = (Numeric::Stencil<Set::Scalar,1,0,1>::D(f,i,j,k,m,dx));
-//    ret(2,1) = ret(1,2);
-//    ret(0,2) = ret(2,0);
-//#endif
-//#endif
     return ret;
 }
 

--- a/src/Set/Set.H
+++ b/src/Set/Set.H
@@ -40,14 +40,16 @@ public:
         (*this)[a_lev].reset(new amrex::FabArray<amrex::BaseFab<T>>(a_grid,a_dmap,a_ncomp,a_nghost));
     }
     int finest_level = 0;
-    void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) {}
-    int NComp() {return 1;}
-    virtual std::string Name(int) {return name;}
+    void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) const {}
+    void Add(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) const {}
+    void AddFrom(int /*a_lev*/, amrex::MultiFab &/*a_src*/, int /*a_srccomp*/, int /*a_nghost*/) const {}
+    int NComp() const {return 1;}
+    virtual std::string Name(int) const {return name;}
     std::string name;    
 };
 
 template<>
-inline void Field<Set::Vector>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost)
+inline void Field<Set::Vector>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost) const
 {
     for (amrex::MFIter mfi(a_dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -65,8 +67,47 @@ inline void Field<Set::Vector>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_ds
         }
     }    
 }
-template<> inline int         Field<Set::Vector>::NComp() {return AMREX_SPACEDIM;} 
-template<> inline std::string Field<Set::Vector>::Name(int i)
+template<>
+inline void Field<Set::Vector>::Add(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost) const
+{
+    for (amrex::MFIter mfi(a_dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& bx = mfi.growntilebox(amrex::IntVect(a_nghost));
+        if (bx.ok())
+        {
+            amrex::Array4<const Set::Vector> const & src = ((*this)[a_lev])->array(mfi);
+            amrex::Array4<Set::Scalar> const & dst = a_dst.array(mfi);
+            for (int n = 0; n < AMREX_SPACEDIM; n++)
+            {
+                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    dst(i,j,k,a_dstcomp + n) += src(i,j,k)(n);
+                });
+            }
+        }
+    }    
+}
+template<>
+inline void Field<Set::Vector>::AddFrom(int a_lev, amrex::MultiFab &a_src, int a_srccomp, int a_nghost) const
+{
+    for (amrex::MFIter mfi(a_src, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& bx = mfi.growntilebox(amrex::IntVect(a_nghost));
+        if (bx.ok())
+        {
+            amrex::Array4<Set::Vector> const & dst = ((*this)[a_lev])->array(mfi);
+            amrex::Array4<const Set::Scalar> const & src = a_src.array(mfi);
+            for (int n = 0; n < AMREX_SPACEDIM; n++)
+            {
+                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    dst(i,j,k)(n) += src(i,j,k,a_srccomp + n);
+                });
+            }
+        }
+    }    
+}
+
+template<> inline int         Field<Set::Vector>::NComp() const {return AMREX_SPACEDIM;} 
+template<> inline std::string Field<Set::Vector>::Name(int i) const
 {
     #if AMREX_SPACEDIM>0
     if (i==0) return name + "_x";
@@ -82,7 +123,7 @@ template<> inline std::string Field<Set::Vector>::Name(int i)
 }
 
 template<>
-inline void Field<Set::Matrix>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost)
+inline void Field<Set::Matrix>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, int a_nghost) const
 {
     for (amrex::MFIter mfi(a_dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -101,8 +142,30 @@ inline void Field<Set::Matrix>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_ds
     }    
 }
 template<>
-inline int Field<Set::Matrix>::NComp() {return AMREX_SPACEDIM*AMREX_SPACEDIM;} 
-
+inline int Field<Set::Matrix>::NComp() const {return AMREX_SPACEDIM*AMREX_SPACEDIM;} 
+template<> inline std::string Field<Set::Matrix>::Name(int i) const
+{
+    #if AMREX_SPACEDIM==1
+    if (i==0) return name + "_xx";
+    #elif AMREX_SPACEDIM==2
+    if (i==0)      return name + "_xx";
+    else if (i==1) return name + "_xy";
+    else if (i==2) return name + "_yx";
+    else if (i==3) return name + "_yy";
+    #elif AMREX_SPACEDIM==3
+    if (i==0)      return name + "_xx";
+    else if (i==1) return name + "_xy";
+    else if (i==2) return name + "_xz";
+    else if (i==3) return name + "_yx";
+    else if (i==4) return name + "_yy";
+    else if (i==5) return name + "_yz";
+    else if (i==6) return name + "_zx";
+    else if (i==7) return name + "_zy";
+    else if (i==8) return name + "_zz";
+    #endif
+    else Util::Abort(INFO, "Invalid component");
+    return "";
+}
 
 
 template <>
@@ -128,34 +191,11 @@ public:
     }
     int finest_level = 0;
 
-    void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) 
+    void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) const
     {Util::Abort(INFO,"This should never get called");}
-    int NComp() 
+    int NComp() const
     {Util::Abort(INFO,"This should never be called");return -1;}
 };
-template<> inline std::string Field<Set::Matrix>::Name(int i)
-{
-    #if AMREX_SPACEDIM==1
-    if (i==0) return name + "_xx";
-    #elif AMREX_SPACEDIM==2
-    if (i==0)      return name + "_xx";
-    else if (i==1) return name + "_xy";
-    else if (i==2) return name + "_yx";
-    else if (i==3) return name + "_yy";
-    #elif AMREX_SPACEDIM==3
-    if (i==0)      return name + "_xx";
-    else if (i==1) return name + "_xy";
-    else if (i==2) return name + "_xz";
-    else if (i==3) return name + "_yx";
-    else if (i==4) return name + "_yy";
-    else if (i==5) return name + "_yz";
-    else if (i==6) return name + "_zx";
-    else if (i==7) return name + "_zy";
-    else if (i==8) return name + "_zz";
-    #endif
-    else Util::Abort(INFO, "Invalid component");
-    return "";
-}
 
 }
 

--- a/src/Solver/Nonlocal/Newton.H
+++ b/src/Solver/Nonlocal/Newton.H
@@ -133,10 +133,185 @@ private:
             {
                 linop->Reflux(lev-1, *a_rhs_mf[lev-1], *a_u_mf[lev-1], *a_b_mf[lev-1], *a_rhs_mf[lev], *a_u_mf[lev], *a_b_mf[lev]);
             }
-
     }
 
+    void prepareForSolve(const Set::Field<Set::Vector>& a_u_mf, 
+                        const Set::Field<Set::Vector>& a_b_mf,
+                        Set::Field<Set::Scalar>& a_rhs_mf,
+                        Set::Field<Set::Matrix> &a_dw_mf,
+                        Set::Field<Set::Matrix4<AMREX_SPACEDIM,T::sym>> &a_ddw_mf,
+                        Set::Field<T> &a_model_mf)
+    {
+            for (int lev = 0; lev <= a_b_mf.finest_level; ++lev)
+            {
+                amrex::Box domain(linop->Geom(lev).Domain());
+                domain.convert(amrex::IntVect::TheNodeVector());
+                const Set::Scalar *dx = linop->Geom(lev).CellSize();
+                Set::Vector DX(linop->Geom(lev).CellSize());
+                for (MFIter mfi(*a_model_mf[lev], false); mfi.isValid(); ++mfi)
+                {
+                    amrex::Box bx = mfi.grownnodaltilebox();
+                    bx = bx & domain;
+
+                    amrex::Array4<const T>           const &model = a_model_mf[lev]->array(mfi);
+                    amrex::Array4<const Set::Vector> const &u     = a_u_mf[lev]->array(mfi);
+                    amrex::Array4<Set::Matrix>       const &dw    = a_dw_mf[lev]->array(mfi);
+                    amrex::Array4<Set::Matrix4<AMREX_SPACEDIM,T::sym>>  const &ddw = a_ddw_mf[lev]->array(mfi);
+
+                    // Set model internal dw and ddw.
+                    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                        std::array<Numeric::StencilType, AMREX_SPACEDIM> sten = Numeric::GetStencil(i, j, k, bx);
+
+                        Set::Matrix gradu = Numeric::Gradient(u, i, j, k, dx, sten);
+
+                        if (model(i,j,k).kinvar == Model::Solid::KinematicVariable::gradu)
+                        {
+                            dw(i,j,k) = model(i, j, k).DW(gradu);
+                            ddw(i,j,k) = model(i, j, k).DDW(gradu);
+                        }
+                        else if (model(i,j,k).kinvar == Model::Solid::KinematicVariable::epsilon)
+                        {
+                            Set::Matrix eps = 0.5 * (gradu + gradu.transpose());
+                            dw(i,j,k) = model(i, j, k).DW(eps);
+                            ddw(i,j,k) = model(i, j, k).DDW(eps);
+                        }
+                        else if (model(i,j,k).kinvar == Model::Solid::KinematicVariable::F)
+                        {
+                            Set::Matrix F = gradu + Set::Matrix::Identity();
+                            dw(i,j,k) = model(i, j, k).DW(F);
+                            ddw(i,j,k) = model(i, j, k).DDW(F);
+                        }
+                    });
+                }
+
+                Util::RealFillBoundary(*a_dw_mf[lev],m_elastic->Geom(lev));
+                Util::RealFillBoundary(*a_ddw_mf[lev],m_elastic->Geom(lev));
+            }
+
+            m_elastic->SetModel(a_ddw_mf);
+
+            for (int lev = 0; lev <= a_b_mf.finest_level; ++lev)
+            {
+                amrex::Box domain(linop->Geom(lev).Domain());
+                domain.convert(amrex::IntVect::TheNodeVector());
+                domain.grow(-1);
+                const Set::Scalar *dx = linop->Geom(lev).CellSize();
+                for (MFIter mfi(*a_model_mf[lev], false); mfi.isValid(); ++mfi)
+                {
+                    amrex::Box bx = mfi.nodaltilebox();
+                    bx = bx & domain;
+                    amrex::Array4<Set::Vector>        const &b     = a_b_mf[lev]->array(mfi);
+                    amrex::Array4<const Set::Matrix>  const &dw    = a_dw_mf[lev]->array(mfi);
+                    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                        b(i,j,k) -= Numeric::Divergence(dw,i,j,k,dx);
+                    });                    
+                }
+            }
+
+            for (int lev = 0; lev <= a_b_mf.finest_level; ++lev)
+            {
+                amrex::MultiFab u_tmp (a_rhs_mf[lev]->boxArray(), a_rhs_mf[lev]->DistributionMap(),
+                                       a_u_mf.NComp(), a_rhs_mf[lev]->nGrow());
+                a_u_mf.Copy(lev,u_tmp,0,2);
+                m_elastic->Apply(lev,0,*a_rhs_mf[lev],u_tmp);
+                a_rhs_mf[lev]->mult(-1.0,2);
+                a_b_mf.Add(lev,*a_rhs_mf[lev],0,2);
+                //amrex::MultiFab::Add(*a_rhs_mf[lev],*a_b_mf[lev],0,0,a_rhs_mf[lev]->nComp(),2);
+                Util::RealFillBoundary(*a_rhs_mf[lev],m_elastic->Geom(lev));
+            }
+            for (int lev = a_b_mf.finest_level; lev > 0; lev--)
+            {
+                amrex::MultiFab empty;
+                linop->Reflux(lev-1, 
+                              *a_rhs_mf[lev-1], empty, empty, 
+                              *a_rhs_mf[lev],   empty, empty);
+            }
+    }
+
+
 public:
+    Set::Scalar solve (const Set::Field<Set::Vector> & a_u_mf, 
+                        const Set::Field<Set::Vector> & a_b_mf,
+                        Set::Field<T> &a_model_mf,
+                        Real a_tol_rel, Real a_tol_abs, const char* checkpoint_file = nullptr)
+    {
+        Set::Field<Set::Scalar> dsol_mf, rhs_mf;
+        Set::Field<Set::Matrix> dw_mf;
+        Set::Field<Set::Matrix4<AMREX_SPACEDIM,T::sym>> ddw_mf;
+
+        dsol_mf.resize(a_u_mf.finest_level+1); dsol_mf.finest_level = a_u_mf.finest_level;
+        dw_mf.  resize(a_u_mf.finest_level+1); dw_mf  .finest_level = a_u_mf.finest_level;
+        ddw_mf. resize(a_u_mf.finest_level+1); ddw_mf .finest_level = a_u_mf.finest_level;
+        rhs_mf. resize(a_u_mf.finest_level+1); rhs_mf .finest_level = a_u_mf.finest_level;
+        for (int lev = 0; lev <= a_u_mf.finest_level; lev++)
+        {
+            dsol_mf.Define(lev, a_u_mf[lev]->boxArray(),
+                                a_u_mf[lev]->DistributionMap(),
+                                a_u_mf.NComp(), 
+                                a_u_mf[lev]->nGrow());
+            dw_mf.Define(lev,   a_b_mf[lev]->boxArray(),
+                                a_b_mf[lev]->DistributionMap(),
+                                1, 
+                                a_b_mf[lev]->nGrow());
+            ddw_mf.Define(lev,  a_b_mf[lev]->boxArray(),
+                                a_b_mf[lev]->DistributionMap(),
+                                1, 
+                                a_b_mf[lev]->nGrow());
+            rhs_mf.Define(lev,  a_b_mf[lev]->boxArray(),
+                                a_b_mf[lev]->DistributionMap(),
+                                a_b_mf.NComp(), 
+                                a_b_mf[lev]->nGrow());
+            
+            dsol_mf[lev]->setVal(0.0);
+            dw_mf[lev]->setVal(Set::Matrix::Zero());
+            ddw_mf[lev]->setVal(Set::Matrix4<AMREX_SPACEDIM,T::sym>::Zero());
+            
+            a_b_mf.Copy(lev,*rhs_mf[lev],0,2);
+            //amrex::MultiFab::Copy(*rhs_mf[lev], *a_b_mf[lev], 0, 0, AMREX_SPACEDIM, 2);
+        }
+
+        for (int nriter = 0; nriter < m_nriters; nriter++)
+        {
+            if (verbose > 0 && nriter < m_nriters) Util::Message(INFO, "Newton Iteration ", nriter+1, " of ", m_nriters);
+
+            prepareForSolve(a_u_mf, a_b_mf, rhs_mf, dw_mf, ddw_mf, a_model_mf);
+
+
+            if (nriter == m_nriters) break;
+            
+            Solver::Nonlocal::Linear::solve(dsol_mf, rhs_mf, a_tol_rel, a_tol_abs,checkpoint_file);
+            //Solver::Nonlocal::Linear::solve(GetVecOfPtrs(dsol_mf), GetVecOfConstPtrs(rhs_mf), a_tol_rel, a_tol_abs,checkpoint_file);
+
+            Set::Scalar cornorm = 0, solnorm = 0;
+            for (int lev = 0; lev < dsol_mf.size(); ++lev)
+            {
+                for (int comp = 0; comp < AMREX_SPACEDIM; comp++)
+                {
+                    Set::Scalar tmpcornorm = dsol_mf[lev]->norm0(comp,0);
+                    if (tmpcornorm > cornorm) cornorm = tmpcornorm;
+
+                    //Set::Scalar tmpsolnorm = a_u_mf[lev]->norm0(comp,0);
+                    //if (tmpsolnorm > solnorm) solnorm = tmpsolnorm;
+                }
+
+            }
+            Set::Scalar relnorm;
+            if (solnorm == 0) relnorm = cornorm;
+            else relnorm = cornorm / solnorm;
+            if (verbose > 0) Util::Message(INFO,"NR iteration ",nriter+1,", relative norm(ddisp) = ",relnorm);
+
+            for (int lev = 0; lev < dsol_mf.size(); ++lev)
+                a_u_mf.AddFrom(lev,*dsol_mf[lev],0,2);
+                //amrex::MultiFab::Add(*a_u_mf[lev], *dsol_mf[lev], 0, 0, AMREX_SPACEDIM, 2);
+
+            if (relnorm < m_nrtolerance)
+                return relnorm;
+
+        }
+
+        return 0.0;
+    }
+
     Set::Scalar solve (const Set::Field<Set::Scalar> & a_u_mf, 
                         const Set::Field<Set::Scalar> & a_b_mf,
                         Set::Field<T> &a_model_mf,

--- a/tests/Eshelby/test
+++ b/tests/Eshelby/test
@@ -19,10 +19,10 @@ def integrate(x,y):
 if dim == 3:
     offset = -0.0000
     prof = ds.ray([0.25+offset,0.25+offset,-2],[0.25+offset,0.25+offset,2],)
-    df = prof.to_dataframe([("gas","x"),("gas","y"),("gas","z"),"disp001","disp002","disp003","stress_xx","stress_yy","stress_zz"])
+    df = prof.to_dataframe([("gas","x"),("gas","y"),("gas","z"),"disp_x","disp_y","disp_z","stress_xx","stress_yy","stress_zz"])
 
     z,x,y,u1,u2,u3,sig11,sig22,sig33 = [numpy.array(_x) for _x in zip(*sorted(zip(
-        df["z"],df["x"],df["y"],df["disp001"],df["disp002"],df["disp003"],df["stress_xx"],df["stress_yy"],df["stress_zz"])))]
+        df["z"],df["x"],df["y"],df["disp_x"],df["disp_y"],df["disp_z"],df["stress_xx"],df["stress_yy"],df["stress_zz"])))]
 
 
 

--- a/tests/TrigTest/test
+++ b/tests/TrigTest/test
@@ -12,9 +12,9 @@ ds = yt.load(path)
 dim = int(ds.domain_dimensions[0] > 1) + int(ds.domain_dimensions[1] > 1) + int(ds.domain_dimensions[2] > 1)
 
 prof = ds.ray([0,0,0],[1,1,1],)
-df = prof.to_dataframe([("gas","x"),("gas","y"),("gas","z"),"disp001"])
+df = prof.to_dataframe([("gas","x"),("gas","y"),("gas","z"),"disp_x"])
 
-x,y,z,u1 = [numpy.array(_x) for _x in zip(*sorted(zip(df["x"],df["y"],df["z"],df["disp001"])))]
+x,y,z,u1 = [numpy.array(_x) for _x in zip(*sorted(zip(df["x"],df["y"],df["z"],df["disp_x"])))]
 
 if dim==2: u1_exact  =  - numpy.sin(numpy.pi*x) * numpy.sin(numpy.pi*y) / numpy.pi / numpy.pi / 2.0
 if dim==3: u1_exact  =  - numpy.sin(numpy.pi*x) * numpy.sin(numpy.pi*y) * numpy.sin(numpy.pi*z) / numpy.pi / numpy.pi / 3.0

--- a/tests/UniaxialTension/test
+++ b/tests/UniaxialTension/test
@@ -12,10 +12,10 @@ ds = yt.load(path)
 dim = int(ds.domain_dimensions[0] > 1) + int(ds.domain_dimensions[1] > 1) + int(ds.domain_dimensions[2] > 1)
 
 prof = ds.ray([-8,0,0],[8,0,0],)
-df = prof.to_dataframe([("gas","x"),"disp001","stress_xx"])
+df = prof.to_dataframe([("gas","x"),"disp_x","stress_xx"])
 
 x    = numpy.array(df["x"])
-u1   = numpy.array(df["disp001"])
+u1   = numpy.array(df["disp_x"])
 #u2   = numpy.array(df["disp002"])
 #u3   = numpy.array(df["disp003"])
 sig1 = numpy.array(df["stress_xx"])


### PR DESCRIPTION
This updates the `Solver::Nonlocal::Newton` solver to accept templated fields (specifically, `Set::Field<Set::Vector>`) for the body force field (input) and the displacement (output). A number of updates were made to the Newton solver, the BC object, and some IC objects as well. Most of the code was straight duplicated by necessity. Eventually we will probably get rid of the non-templated field options to clean up the code. See the `Mechanics` integrator as an example of how the templated newton solver works.