### PR TITLE
Wip dyn

### DIFF
--- a/src/Integrator/BaseField.H
+++ b/src/Integrator/BaseField.H
@@ -158,9 +158,10 @@ public:
         }
         else
         {
-            amrex::FabArray<amrex::BaseFab<T>> new_state(cgrids, dm, m_ncomp, m_nghost);
-            this->FillPatch(lev, time, m_field, new_state, 0);
-            std::swap(new_state, *m_field[lev]);
+            Util::Abort(INFO,"Not implemented yet");
+            //amrex::FabArray<amrex::BaseFab<T>> new_state(cgrids, dm, m_ncomp, m_nghost);
+            //this->FillPatch(lev, time, m_field, new_state, 0);
+            //std::swap(new_state, *m_field[lev]);
         }
     }
 
@@ -193,6 +194,7 @@ public:
             amrex::BoxArray ngrids = cgrids;
             ngrids.convert(amrex::IntVect::TheNodeVector());
             m_field[lev].reset(new amrex::FabArray<amrex::BaseFab<T>>(ngrids,dm,m_ncomp,m_nghost));
+            m_field[lev]->setVal(T::Zero());
         }
 //      else
 //      {

--- a/src/Integrator/BaseField.H
+++ b/src/Integrator/BaseField.H
@@ -27,6 +27,8 @@ public:
                                         const amrex::DistributionMapping& dm) = 0;
     virtual void SetFinestLevel(const int a_finestlevel) = 0;
     virtual void FillPatch(const int lev, const Set::Scalar time)=0;
+    virtual void FillBoundary(const int lev, Set::Scalar time)=0;
+    virtual void AverageDownNodal(const int lev, amrex::IntVect refRatio) = 0;
 
     virtual int NComp() = 0;
     virtual void Copy(int /*a_lev*/, amrex::MultiFab &/*a_dst*/, int /*a_dstcomp*/, int /*a_nghost*/) = 0;
@@ -201,6 +203,16 @@ public:
     virtual void SetFinestLevel(const int a_finestlevel)
     {
         m_field.finest_level = a_finestlevel;
+    }
+
+    virtual void FillBoundary(const int lev, Set::Scalar /*time*/) override
+    {
+        Util::RealFillBoundary(*m_field[lev],m_geom[lev]);
+    }
+    
+    virtual void AverageDownNodal(const int lev, amrex::IntVect refRatio) override
+    {
+        amrex::average_down_nodal(*m_field[lev+1],*m_field[lev],refRatio);
     }
     
 private:

--- a/src/Integrator/Integrator.cpp
+++ b/src/Integrator/Integrator.cpp
@@ -694,6 +694,11 @@ Integrator::MakeNewLevelFromScratch (int lev, amrex::Real t, const amrex::BoxArr
         node.physbc_array[n]->define(geom[lev]);
         node.physbc_array[n]->FillBoundary(*(*node.fab_array[n])[lev],0,0,t,0);
     }
+
+    for (unsigned int n = 0; n < m_basefields.size(); n++)
+    {
+        m_basefields[n]->FillBoundary(lev,t);
+    }
 }
 
 std::vector<std::string>
@@ -1057,7 +1062,7 @@ Integrator::TimeStep (int lev, amrex::Real time, int /*iteration*/)
             }
         }
     }
-SetFinestLevel(finest_level);
+    SetFinestLevel(finest_level);
 
     if (Verbose() && amrex::ParallelDescriptor::IOProcessor()) {
         std::cout << "[Level " << lev 
@@ -1103,6 +1108,11 @@ SetFinestLevel(finest_level);
             amrex::average_down(*(*node.fab_array[n])[lev+1], *(*node.fab_array[n])[lev],
                                 0, (*node.fab_array[n])[lev]->nComp(), refRatio(lev));
         }
+        for (unsigned int n = 0; n < m_basefields.size(); n++)
+        {
+            m_basefields[n]->AverageDownNodal(lev,refRatio(lev));
+        }
+    
     }
 }
 }

--- a/src/Integrator/Mechanics.H
+++ b/src/Integrator/Mechanics.H
@@ -53,9 +53,23 @@ public:
         {
             std::string type_str;
             pp.query("type",type_str);
-            if (type_str == "static")       value.m_type = Type::Static;
-            else if (type_str == "dynamic") value.m_type = Type::Static;
+            if (type_str == "static")
+            {
+                value.m_type = Type::Static;
+                // Read parameters for :ref:`Solver::Nonlocal::Newton` solver
+                pp.queryclass("elastic.solver",value.elastic.solver);
+            }
+            else if (type_str == "dynamic") 
+            {
+                value.m_type = Type::Dynamic;
+                value.RegisterGeneralFab(value.vel_mf,1,2,"vel");
+                value.RegisterGeneralFab(value.disp_old_mf,1,2,"dispold");
+                value.RegisterGeneralFab(value.vel_old_mf,1,2,"velold");
+                pp.query("viscous.mu",value.mu);
+                //value.RegisterGeneralFab(value.ddw_mf,1,2);
+            }
             else Util::Abort(INFO,"Invalid type ", type_str, " specified");
+
         }
 
         int nmodels = 1;
@@ -128,9 +142,6 @@ public:
         value.RegisterIntegratedVariable(&(value.trac_lo[0].data()[0]),"trac_lo_xx");
 #endif
 
-        // Read parameters for :ref:`Solver::Nonlocal::Newton` solver
-        pp.queryclass("elastic.solver",value.elastic.solver);
-
     }
 
 protected:
@@ -163,7 +174,7 @@ protected:
 
             eta_mf[lev]->FillBoundary();
 
-            disp_mf[lev]->setVal(Set::Vector::Zero());
+            //disp_mf[lev]->setVal(Set::Vector::Zero());
 
             Set::Vector DX(geom[lev].CellSize());
 
@@ -191,6 +202,8 @@ protected:
         if (m_interval && a_step%m_interval) return;
 
         UpdateModel();        
+
+        if (!m_type == Type::Static) return;
 
         elastic.bc->SetTime(a_time);
         elastic.bc->Init(rhs_mf,geom);
@@ -246,9 +259,53 @@ protected:
         }
     }
 
-    void Advance(int /*lev*/, Set::Scalar /*time*/, Set::Scalar /*dt*/) override
+    void Advance(int lev, Set::Scalar /*time*/, Set::Scalar dt) override
     {
+        if (!m_type == Type::Dynamic) return;
 
+        std::swap(*disp_mf[lev], *disp_old_mf[lev]);
+        std::swap(*vel_mf[lev], *vel_old_mf[lev]);
+
+        amrex::Box domain = geom[lev].Domain();
+        domain.convert(amrex::IntVect::TheNodeVector());
+        domain.grow(-1);
+        
+        const amrex::Real *DX = geom[lev].CellSize();
+
+        for (amrex::MFIter mfi(*disp_mf[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            amrex::Array4<Set::Vector>         const &unew = (*disp_mf[lev]).array(mfi);
+            amrex::Array4<Set::Vector>         const &vnew = (*vel_mf [lev]).array(mfi);
+
+            amrex::Array4<const Set::Vector>   const &u    = (*disp_old_mf[lev]).array(mfi);
+            amrex::Array4<const Set::Vector>   const &v    = (*vel_old_mf[lev]).array(mfi);
+            amrex::Array4<Set::Matrix>         const &eps  = (*strain_mf[lev]).array(mfi);
+            amrex::Array4<Set::Matrix>         const &sig  = (*stress_mf[lev]).array(mfi);
+            amrex::Array4<const Set::Vector>   const &b    = (*rhs_mf[lev]).array(mfi);
+        
+            amrex::Array4<MODEL>               const &model= (*model_mf[lev]).array(mfi);
+        
+            // Right now, we are forcing Dirichlet conditions on all boundaries
+            amrex::Box bx = mfi.nodaltilebox().grow(1) & domain;
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
+            {
+                //auto sten = Numeric::GetStencil(i,j,k,bx);
+                eps(i,j,k) = Numeric::Gradient(u,i,j,k,DX);
+                sig(i,j,k) = model(i,j,k).DW(eps(i,j,k));
+            });
+
+            bx = mfi.nodaltilebox().grow(0) & domain;
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
+            {
+                //auto sten = Numeric::GetStencil(i,j,k,bx);
+                Set::Vector udotdot = Numeric::Divergence(sig,i,j,k,DX) + b(i,j,k) - mu * v(i,j,k);
+                udotdot /= rho;
+                vnew(i,j,k) = v(i,j,k) + dt*udotdot;
+                unew(i,j,k) = u(i,j,k) + dt*vnew(i,j,k);
+            });
+
+        }
+        
     }
 
     void Integrate(int amrlev, Set::Scalar /*time*/, int /*step*/,
@@ -328,6 +385,14 @@ private:
     Set::Field<Set::Scalar> res_mf;
     Set::Field<Set::Matrix> stress_mf;
     Set::Field<Set::Matrix> strain_mf;
+    
+    // Only use these if using the "dynamics" option
+    Set::Field<Set::Vector> disp_old_mf;
+    Set::Field<Set::Vector> vel_mf;
+    Set::Field<Set::Vector> vel_old_mf;
+    //Set::Field<Set::Matrix4<AMREX_SPACEDIM,MODEL::sym>> ddw_mf;
+    Set::Scalar rho = 1.0;
+    Set::Scalar mu = 0.0;
 
     Set::Vector trac_lo[AMREX_SPACEDIM];
     Set::Vector trac_hi[AMREX_SPACEDIM];

--- a/src/Model/Solid/Affine/Cubic.H
+++ b/src/Model/Solid/Affine/Cubic.H
@@ -54,6 +54,12 @@ public:
     Set::Matrix F0 = Set::Matrix::Zero();
     static const KinematicVariable kinvar = KinematicVariable::gradu;
 
+    static Cubic Zero()
+    {
+        Cubic ret = Linear::Cubic::Zero();
+        ret.F0 = Set::Matrix::Zero();
+        return ret;
+    }
     static Cubic Random()
     {
         return Random(Util::Random(), Util::Random(), Util::Random());

--- a/src/Model/Solid/Linear/Cubic.H
+++ b/src/Model/Solid/Linear/Cubic.H
@@ -91,6 +91,13 @@ public:
         return ret;
     }
 
+    static Cubic Zero()
+    {
+        Cubic ret;
+        ret.Define(0.0,0.0,0.0,0.0,0.0,0.0);
+        return ret;
+        
+    }
     static Cubic Random()
     {
         return Random(Util::Random(), Util::Random(), Util::Random());

--- a/src/Model/Solid/Linear/IsotropicDegradable.H
+++ b/src/Model/Solid/Linear/IsotropicDegradable.H
@@ -82,6 +82,12 @@ public:
         //Util::Message(INFO, "lambda = ", lambda, ", mu = ", mu);
         value.Define(mu,mu,lambda,lambda);
     }
+    static IsotropicDegradable Zero()
+    {
+        Util::Abort(INFO,"Not properly implmeneted yet");
+        IsotropicDegradable ret;
+        return ret;
+    }
     virtual void Print(std::ostream &out) const override 
     {
         out << "ddw     = " << ddw << std::endl;

--- a/src/Numeric/Stencil.H
+++ b/src/Numeric/Stencil.H
@@ -670,23 +670,23 @@ Hessian(const amrex::Array4<const Set::Vector> &f,
     ret[1](0,0) = f_11(1);
     Set::Vector f_12 = Numeric::Stencil<Set::Vector,1,1,0>::D(f,i,j,k,0,dx);
     ret[0](1,0) = ret[0](0,1) = f_12(0);
-    ret[1](1,0) = ret[1](0,1) = f_12(0);
+    ret[1](1,0) = ret[1](0,1) = f_12(1);
     Set::Vector f_22 = Numeric::Stencil<Set::Vector,0,2,0>::D(f,i,j,k,0,dx);
     ret[0](1,1) = f_22(0);
     ret[1](1,1) = f_22(1);
     #endif
     #if AMREX_SPACEDIM>2
     ret[2](0,0) = f_11(2);
-    ret[2](1,0) = ret[2](0,1) = f_12(0);
+    ret[2](1,0) = ret[2](0,1) = f_12(2);
     Set::Vector f_13 = Numeric::Stencil<Set::Vector,1,0,1>::D(f,i,j,k,0,dx);
     ret[0](2,0) = ret[0](0,2) = f_13(0);
-    ret[1](2,0) = ret[1](0,2) = f_13(0);
-    ret[2](2,0) = ret[2](0,2) = f_13(0);
+    ret[1](2,0) = ret[1](0,2) = f_13(1);
+    ret[2](2,0) = ret[2](0,2) = f_13(2);
     ret[2](1,1) = f_22(2);
     Set::Vector f_23 = Numeric::Stencil<Set::Vector,0,1,1>::D(f,i,j,k,0,dx);
     ret[0](1,2) = ret[0](2,1) = f_23(0);
-    ret[1](1,2) = ret[1](2,1) = f_23(0);
-    ret[2](1,2) = ret[2](2,1) = f_23(0);
+    ret[1](1,2) = ret[1](2,1) = f_23(1);
+    ret[2](1,2) = ret[2](2,1) = f_23(2);
     Set::Vector f_33 = Numeric::Stencil<Set::Vector,0,0,2>::D(f,i,j,k,0,dx);
     ret[0](2,2) = f_33(0);
     ret[1](2,2) = f_33(1);
@@ -804,6 +804,49 @@ VectorToField(const amrex::Array4<Set::Scalar> &f,
 #endif
 #endif
 }
+
+template<int index,int SYM>
+Set::Matrix3
+Divergence(const amrex::Array4<const Set::Matrix4<AMREX_SPACEDIM,SYM>> &,
+            const int , const int , const int , const Set::Scalar[AMREX_SPACEDIM],
+            std::array<StencilType,AMREX_SPACEDIM> stencil = DefaultType)
+            {Util::Abort(INFO,"Not implemented yet"); return Set::Matrix3::Zero();}
+
+template<>
+AMREX_FORCE_INLINE
+Set::Matrix3 Divergence<2,Set::Sym::Isotropic>(const amrex::Array4<const Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic>> &C,
+            const int i, const int j, const int k, const Set::Scalar dx[AMREX_SPACEDIM],
+            std::array<StencilType,AMREX_SPACEDIM> stencil)
+{
+    Set::Matrix3 ret;
+    
+    Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic> gradCx =
+        Numeric::Stencil<Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic>,1,0,0>::D(C,i,j,k,0,dx,stencil);
+    #if AMREX_SPACEDIM>1
+    Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic> gradCy =
+        Numeric::Stencil<Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic>,0,1,0>::D(C,i,j,k,0,dx,stencil);
+    #endif
+    #if AMREX_SPACEDIM>2
+    Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic> gradCz =
+        Numeric::Stencil<Set::Matrix4<AMREX_SPACEDIM,Set::Sym::Isotropic>,0,0,1>::D(C,i,j,k,0,dx,stencil);
+    #endif
+
+    for (int i = 0; i < AMREX_SPACEDIM; i++)
+        for (int k = 0; k < AMREX_SPACEDIM; k++)
+            for (int l = 0; l < AMREX_SPACEDIM; l++)
+                {
+                    ret(i,k,l) = 0.0;
+                    ret(i,k,l) = gradCx(i,0,k,l);
+                    #if AMREX_SPACEDIM>1
+                    ret(i,k,l) = gradCy(i,1,k,l);
+                    #endif
+                    #if AMREX_SPACEDIM>2
+                    ret(i,k,l) = gradCz(i,2,k,l);
+                    #endif
+                }
+    return ret;
+}
+
 
 
 

--- a/tests/Dynamics/input
+++ b/tests/Dynamics/input
@@ -10,7 +10,7 @@ stop_time		      = 0.05
 
 # amr parameters
 amr.plot_int		      = 10
-amr.max_level		      = 1
+amr.max_level		      = 2
 amr.n_cell		      = 32 32 32
 amr.blocking_factor	      = 4
 amr.regrid_int		      = 1

--- a/tests/EshelbyDynamics/input
+++ b/tests/EshelbyDynamics/input
@@ -1,0 +1,57 @@
+alamo.program = mechanics
+alamo.program.mechanics.model = affine.isotropic
+
+plot_file		    = tests/EshelbyDynamics/output
+
+type=dynamic
+
+# this is not a time integration, so do
+# exactly one timestep and then quit
+timestep		    = 0.0001
+stop_time		    = 10.0
+
+# amr parameters
+amr.plot_int		    = 100
+amr.max_level		    = 3
+amr.n_cell		    = 32 32 32
+amr.blocking_factor	    = 8
+amr.regrid_int		    = 100
+amr.grid_eff		    = 1.0
+amr.cell.all                = 1
+
+# use an explicit mesh (i.e. no adaptive meshing)
+explicitmesh.on               = 0
+explicitmesh.lo1              = 16 16 16
+explicitmesh.hi1              = 47 47 47
+explicitmesh.lo2              = 48 48 48
+explicitmesh.hi2              = 79 79 79
+explicitmesh.lo3              = 112 112 112
+explicitmesh.hi3              = 145 145 145
+
+# geometry
+geometry.prob_lo	    = -8 -8 -8 
+geometry.prob_hi	    = 8 8 8
+geometry.is_periodic	    = 0 0 0
+
+# ellipse configuration
+ic.type        = ellipse
+ic.ellipse.a   = 1.0 0.75 0.5  # ellipse radii
+ic.ellipse.x0  = 0 0 0 # location of ellipse center
+ic.ellipse.eps = 0.1 # diffuse boundary
+
+# elastic moduli
+elastic.nmodels = 2
+elastic.model1.E = 210 
+elastic.model1.nu = 0.3
+elastic.model1.F0  = 0.001 0 0 0 0.001 0 0 0 0.001 # eigenstrain
+elastic.model2.E = 210 
+elastic.model2.nu = 0.3
+elastic.model2.F0  = 0 0 0 0 0 0 0 0 0 # eigenstrain
+
+elastic.solver.verbose = 3
+elastic.solver.nriters = 1
+elastic.solver.max_iter = 20
+
+elastic.ref_threshold = 1000000000
+
+viscous.mu = 25

--- a/tests/EshelbyDynamics/input
+++ b/tests/EshelbyDynamics/input
@@ -12,7 +12,7 @@ stop_time		    = 10.0
 
 # amr parameters
 amr.plot_int		    = 100
-amr.max_level		    = 3
+amr.max_level		    = 5
 amr.n_cell		    = 32 32 32
 amr.blocking_factor	    = 8
 amr.regrid_int		    = 100


### PR DESCRIPTION
This PR updates the mechanics integrator to be able to choose between "static" mode - i.e. an MLMG solve - or "dynamic" mode. Dynamics includes velocity dependent viscosity to enforce stability. Also, we should keep in mind that the dyanmic integrator is crude and can result in slight checkerboarding, even in the final solution, due to the chosen stencil.

One important update for templated fields is the setting of the field to zero on remake. This fixes a bug that was showing up in parallel. Importantly, a static `T::Zero` function is now required for all class template types, in addition to arithmetic operators.