### PR TITLE
Fixed memory check issues

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -23,14 +23,10 @@ jobs:
       continue-on-error: true
       run: ./configure --dim=2 --debug
     - name: make (2d)
-      continue-on-error: true
       run: make
     - name: unit tests (2d)
-      continue-on-error: true
-      run: --valgrind --error-exitcode=1 --leak-check=full ./bin/test-2d-debug-g++
+      run: valgrind --error-exitcode=1 --leak-check=full ./bin/test-2d-debug-g++
     - name: flame (2d)
-      continue-on-error: true
       run: valgrind --error-exitcode=1 --leak-check=full ./bin/alamo-2d-debug-g++ tests/SCPSandwich/input stop_time=0.0002
     - name: microstructure (2d)
-      continue-on-error: true
       run: valgrind --error-exitcode=1 --leak-check=full ./bin/alamo-2d-debug-g++ tests/PerturbedInterface/input stop_time=0.03

--- a/docs/source/scraper.py
+++ b/docs/source/scraper.py
@@ -59,7 +59,7 @@ def extract(basefilename):
         for i, line in enumerate(lines):
             
             # Catch standard pp.query and pp.queryarr inputs
-            match = re.findall('^\s*pp.(query[arr]*[_required]*[_file]*)\s*\("([^"]+)"\s*,\s*[a-z,A-Z,0-9,_,.]*\s*,*\s*[INFO]*\s*\)\s*;\s*(?:\/\/\s*(.*))?$',lines[i])
+            match = re.findall(r'^\s*pp.(query[arr]*[_required]*[_file]*)\s*\("([^"]+)"\s*,\s*[a-z,A-Z,0-9,_,.]*\s*,*\s*[INFO]*\s*\)\s*;\s*(?:\/\/\s*(.*))?$',lines[i])
             if match:
                 #print(match)
                 query = dict()
@@ -79,7 +79,7 @@ def extract(basefilename):
                 continue
 
             # Catch standard pp.query_default and pp.queryarr_default inputs
-            match = re.findall('^\s*pp.(query[arr]*_default*)\s*\("([^"]+)"\s*,\s*[a-z,A-Z,0-9,_,.]*\s*,\s*"*([^"^,]+)"*\s*,*\s*[INFO]*\s*\)\s*;\s*(?:\/\/\s*(.*))?$',lines[i])
+            match = re.findall(r'^\s*pp.(query[arr]*_default*)\s*\("([^"]+)"\s*,\s*[a-z,A-Z,0-9,_,.]*\s*,\s*"*([^"^,]+)"*\s*,*\s*[INFO]*\s*\)\s*;\s*(?:\/\/\s*(.*))?$',lines[i])
             if match:
                 #print(match)
                 query = dict()
@@ -100,7 +100,7 @@ def extract(basefilename):
                 continue
 
             # Catch standard pp.query_default and pp.queryarr_default inputs
-            match = re.findall('^\s*pp.(query_validate)\s*\("([^"]+)"\s*,\s*[a-z,A-Z,0-9,_,.]*\s*,\s*\{(.*)\}\s*,*\s*[INFO]*\s*\)\s*;\s*(?:\/\/\s*(.*))?$',lines[i])
+            match = re.findall(r'^\s*pp.(query_validate)\s*\("([^"]+)"\s*,\s*[a-z,A-Z,0-9,_,.]*\s*,\s*\{(.*)\}\s*,*\s*[INFO]*\s*\)\s*;\s*(?:\/\/\s*(.*))?$',lines[i])
             if match:
                 #print(match)
                 query = dict()
@@ -122,7 +122,7 @@ def extract(basefilename):
                 continue
 
             # Catch pp.queryclass inputs
-            match = re.findall('^\s*pp.queryclass(?:<(.*)>)?\s*\(\s*"([^"]*)"(?:.*static_cast\s*<\s*(.*)\s*>.*)?[^)]*,*\s*[INFO]*\s*\);\s*(?:\/\/\s*(.*)$)?',line)
+            match = re.findall(r'^\s*pp.queryclass(?:<(.*)>)?\s*\(\s*"([^"]*)"(?:.*static_cast\s*<\s*(.*)\s*>.*)?[^)]*,*\s*[INFO]*\s*\);\s*(?:\/\/\s*(.*)$)?',line)
             if match:
                 queryclass = dict()
                 queryclass["type"] = "queryclass"
@@ -144,7 +144,7 @@ def extract(basefilename):
 
             # Catch ParmParse groups. This is old-fashioned but still supported.
             # All subsequent inputs will be nested under a group
-            match = re.findall('^\s*(?:IO|amrex)::ParmParse\s*pp\s*(?:\(\s*"([^"]*)"\s*\))?\s*;\s*(?:\/\/\s*(.*))?',line)
+            match = re.findall(r'^\s*(?:IO|amrex)::ParmParse\s*pp\s*(?:\(\s*"([^"]*)"\s*\))?\s*;\s*(?:\/\/\s*(.*))?',line)
             if match:
                 reset()
                 group = dict()
@@ -159,7 +159,7 @@ def extract(basefilename):
                 group["inputs"] = list()
 
             # Catch definition of a Parser function.
-            if re.match('^\s*(?!\/\/).*Parse\(.*(?:IO|amrex)::ParmParse\s*&\s*(pp)\)(?!\s*;)',line):
+            if re.match(r'^\s*(?!\/\/).*Parse\(.*(?:IO|amrex)::ParmParse\s*&\s*(pp)\)(?!\s*;)',line):
                 if parsefn: raise Exception(filename,i,"Multiple Parse functions cannot be declared in a single file")
                 parsefn = True
 
@@ -178,7 +178,7 @@ def extract(basefilename):
                 # Check if previous lines have simple comments. Ignores "///" comments and
                 # any comment beginning with [
                 for j in reversed(range(0,i)):
-                    docmatch = re.findall('^\s*\/\/(?!\/)(?!\s*\[)\s*(.*)',lines[j])
+                    docmatch = re.findall(r'^\s*\/\/(?!\/)(?!\s*\[)\s*(.*)',lines[j])
                     if docmatch:
                         input["doc"] = docmatch[0] + " " + input["doc"]
                     else: break
@@ -196,7 +196,7 @@ def extract(basefilename):
                 # Check if previous lines have simple comments. Ignores "///" comments and
                 # any comment beginning with [
                 for j in reversed(range(0,i)):
-                    docmatch = re.findall('^\s*\/\/(?!\/)(?!\s*\[)\s*(.*)',lines[j])
+                    docmatch = re.findall(r'^\s*\/\/(?!\/)(?!\s*\[)\s*(.*)',lines[j])
                     if docmatch:
                         input["doc"] = docmatch[0] + " " + input["doc"]
                     else: break
@@ -215,7 +215,7 @@ def extract(basefilename):
                 # Check if previous lines have simple comments. Ignores "///" comments and
                 # any comment beginning with [
                 for j in reversed(range(0,i)):
-                    docmatch = re.findall('^\s*\/\/(?!\/)(?!\s*\[)\s*(.*)',lines[j])
+                    docmatch = re.findall(r'^\s*\/\/(?!\/)(?!\s*\[)\s*(.*)',lines[j])
                     if docmatch:
                         input["doc"] = docmatch[0] + " " + input["doc"]
                     else: break
@@ -224,7 +224,7 @@ def extract(basefilename):
 
 
             # Catch definition of a switch group
-            match =re.findall('^\s*\/\/\s*\[\s*switch\s*(\S*)\s*]\s*(.*)',line)
+            match =re.findall(r'^\s*\/\/\s*\[\s*switch\s*(\S*)\s*]\s*(.*)',line)
             if match:
                 reset()
                 switch = dict()
@@ -237,7 +237,7 @@ def extract(basefilename):
             if switch:
                 # If we are inside a switch block, look for matches like
                 #    else if (ic_type == "KEY") value.ic = new CLASS(args,"PREFIX")
-                match = re.findall('^\s*(?:else)*\s*if\s*\(\S*\s*==\s*"([^"]*)"\s*\).*new\s*([A-Z,:,a-z,0-9,_]*)[^"]*"(.*)"',line)
+                match = re.findall(r'^\s*(?:else)*\s*if\s*\(\S*\s*==\s*"([^"]*)"\s*\).*new\s*([A-Z,:,a-z,0-9,_]*)[^"]*"(.*)"',line)
                 if match:
                     input=dict()
                     input["type"]="switchitem"
@@ -247,7 +247,7 @@ def extract(basefilename):
                     switch["inputs"].append(input)
 
             # Close a switch group
-            if re.match('^\s*\/\/\s*\[\s*end\s*(?:switch)?\s*]',line):
+            if re.match(r'^\s*\/\/\s*\[\s*end\s*(?:switch)?\s*]',line):
                 reset()
             
         reset()

--- a/src/Integrator/Flame.cpp
+++ b/src/Integrator/Flame.cpp
@@ -219,6 +219,8 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
     }
 
     bool allow_unused;
+    // Set this to true to allow unused inputs without error.
+    // (Not recommended.)
     pp.query_default("allow_unused",allow_unused,false);
     if (!allow_unused && pp.AnyUnusedInputs())
     {

--- a/src/Integrator/Flame.cpp
+++ b/src/Integrator/Flame.cpp
@@ -49,10 +49,8 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
         value.RegisterNewFab(value.eta_old_mf, value.bc_eta, 1, value.ghost_count, "eta_old", false);
 
         // phase field initial condition
-        pp.select<IC::Constant,IC::Expression>("pf.eta.ic",value.ic_eta,value.geom); // after comment
-
-        // phase field initial condition
-        pp.select<IC::Laminate,IC::Constant,IC::Expression,IC::BMP,IC::PNG>("eta.ic",value.ic_eta,value.geom); 
+        pp.select<IC::Laminate,IC::Constant,IC::Expression,IC::BMP,IC::PNG>("pf.eta.ic",value.ic_eta,value.geom); 
+        pp.forbid("eta.ic","--> you must use pf.eta.ic instead"); // delete this eventually once all tests are updated
     }
 
     {
@@ -219,12 +217,21 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
         value.RegisterNewFab(value.psi_mf, value.bc_psi, 1, value.ghost_count, "psi", value.plot_psi);
         value.psi_on = true;
     }
+
+    bool allow_unused;
+    pp.query_default("allow_unused",allow_unused,false);
+    if (!allow_unused && pp.AnyUnusedInputs())
+    {
+        Util::Warning(INFO,"The following inputs were specified but not used:");
+        pp.AllUnusedInputs();
+        Util::Exception(INFO,"Aborting. Specify 'allow_unused=True` to ignore this error.");
+    }
+        
 }
 
 void Flame::Initialize(int lev)
 {
     BL_PROFILE("Integrator::Flame::Initialize");
-    Util::Message(INFO, m_type);
     Base::Mechanics<model_type>::Initialize(lev);
 
     ic_eta->Initialize(lev, eta_mf);

--- a/src/Numeric/Interpolator/Linear.H
+++ b/src/Numeric/Interpolator/Linear.H
@@ -133,7 +133,7 @@ public:
         }
 
         // Do this if point is within interpolation range
-        for (unsigned int i = start; i<interval_points.size(); i++)
+        for (unsigned int i = start; i<interval_points.size()-1; i++)
         {
             if (interval_points[i] <= point && point <= interval_points[i+1])
             {

--- a/tests/SCPSandwich/input
+++ b/tests/SCPSandwich/input
@@ -58,8 +58,8 @@ pressure.n_comb = 0.0 # [ 1 ]
 pressure.P = 0.2
 
 # Phase field IC
-eta.ic.type = constant
-eta.ic.constant.value = 1
+pf.eta.ic.type = constant
+pf.eta.ic.constant.value = 1
 
 # Species field params
 phi.ic.type = laminate

--- a/tests/SCPSpheresElastic/input
+++ b/tests/SCPSpheresElastic/input
@@ -3,16 +3,12 @@
 #@ dim=2
 #@ nprocs=1
 #@ args = stop_time=0.001
-#@ args = temp.ic.type="constant"
-#@ args = temp.ic.constant.value=500
 #@ check-file = reference/2d-serial-short.dat
 #@
 #@ [2d-parallel-long]
 #@ dim=2
 #@ nprocs=8
 #@ args = stop_time=0.02
-#@ args = temp.ic.type="constant"
-#@ args = temp.ic.constant.value=500
 #@ check-file = reference/2d-parallel-long.dat
 #@
 
@@ -39,8 +35,8 @@ stop_time = 0.11
 
 pf.eps = 0.000001 
 pf.lambda = 0.001
-eta.ic.type = constant
-eta.ic.constant.value=1.0
+pf.eta.ic.type = constant
+pf.eta.ic.constant.value=1.0
 phi.ic.type = psread
 phi.ic.psread.filename = tests/SCPSpheresElastic/2d.xyzr
 phi.ic.psread.eps = 1.13e-5 
@@ -64,9 +60,6 @@ pf.eta.bc.constant.val.ylo = 0.0
 pf.eta.bc.constant.val.yhi = 0.0
 pf.eta.bc.constant.val.zlo = 0.0
 pf.eta.bc.constant.val.zhi = 0.0
-
-pf.eta.ic.type = constant
-pf.eta.ic.constant.value = 1.0
 
 thermal.on = 1
 thermal.bound = 300.0
@@ -100,6 +93,9 @@ thermal.hc = 1.0e7
 thermal.mlocal_ap = 1000.0
 thermal.mlocal_htpb = 5000.0
 thermal.mlocal_comb = 0.0
+
+temp.ic.type="constant"
+temp.ic.constant.value=500
 
 pressure.P = 4.0
 pressure.mob_ap = 1

--- a/tests/SCPThermalSandwich/input
+++ b/tests/SCPThermalSandwich/input
@@ -49,8 +49,8 @@ pf.eps = 0.000001 #0.0005 # [m]
 pf.lambda = 0.001
 
 ## ETA IC ################################################################ ETA IC
-eta.ic.type = constant #laminate 
-eta.ic.constant.value = 1.0 #laminate 
+pf.eta.ic.type = constant #laminate 
+pf.eta.ic.constant.value = 1.0 #laminate 
 
 ### Constant IC ############################################################ IC
 phi.ic.type = laminate


### PR DESCRIPTION
This updates the memory leak check. It also fixes some of the leaks that were present. 
@meierms1 @Abiswal1234 Note that the use of `eta.ic` is now forbidden, use `pf.eta.ic` instead. This was already happening most places but both had been incorrectly used interchangeably. You will now get an error if you use `eta.ic`.