### PR TITLE
update .gitignore to exclude files created by clangd and pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ ext/
 *_BASE_*
 *_LOCAL_*
 *_REMOTE_*
+.cache/
+.python-version


### PR DESCRIPTION
By default, clangd—a C/C++ language server—creates a `.cache/` directory in the [same directory as the `compile_commands.json` file](https://github.com/clangd/clangd/issues/184). Additionally, pyenv—a Python version and environment manager—creates a `.python-version` file in a directory [to tell the user's shell which Python environment to use](https://github.com/pyenv/pyenv?tab=readme-ov-file#understanding-python-version-selection). This pull request excludes both these files.