### PR TITLE
add --comp-cmds flag to `configure` to generate `compile_commands.json`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+Language: Cpp
+BasedOnStyle: GNU
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+NamespaceIndentation: None
+AllowAllArgumentsOnNextLine: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  BeforeNonEmptyParentheses: false
+ColumnLimit: 0
+AlwaysBreakAfterDefinitionReturnType: false
+

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ ext/
 *_BASE_*
 *_LOCAL_*
 *_REMOTE_*
+
+compile_commands.json

--- a/configure
+++ b/configure
@@ -118,6 +118,7 @@ parser.add_argument('--memcheck-tool',dest='memcheck_tool',default="msan",help="
 parser.add_argument('--create-gfortran-link',dest='gfortranln',action='store_true',default=False,
                     help="Create a link to the gfortran library. (Unless you are CircleCI, you should probably not do this!)")
 parser.add_argument('--link',default=None, nargs='+', help='Additional link paths')
+parser.add_argument('--clangd',dest='clangd',default=False,action='store_true', help='Generate compile_commands.json for clangd')
 parser.set_defaults(debug=False)
 
 #
@@ -379,7 +380,7 @@ if not args.alternate_mpi:
             code("--alternate-mpi"))
     message("Comp-Type", str(args.comp))
     shellmessage("Comp-Version",args.comp+" --version")
-    shellmessage("Comp-MPI","mpicxx -cxx="+args.comp+" -show")
+    compmpicmd = shellmessage("Comp-MPI","mpicxx -cxx="+args.comp+" -show")
     mpichversionresult = shellmessage("MPICH:","mpichversion")
     if args.memcheck_tool=="asan":
         version_match_str = re.search(r"MPICH Version:\s*([\d.]+)", mpichversionresult.stdout.decode('ascii')).group(1)
@@ -527,4 +528,29 @@ if (args.docs):
     #M2R
     try: import m2r; message("M2R", str(m2r.__version__) + " (python 3)")
     except: message("M2R",color.red + "M2R not installed - install using " + code("pip install m2r"))
+
+
+if args.clangd:
+    srcfiles = set()
+    for dirname, subdirlist, filelist in sorted(os.walk("src/")):
+        for f in filelist:
+            if f.endswith(".cc"): srcfiles.add(dirname+"/"+f)
+            if f.endswith(".cpp"): srcfiles.add(dirname+"/"+f)
+            if f.endswith(".H"): srcfiles.add(dirname+"/"+f)
+    srcfiles = list(srcfiles)
+
+    projectdir = os.getcwd()
+
+    cc = compmpicmd.stdout.decode('utf-8').replace('\n','')
+
+    f = open("compile_commands.json","w")
+    f.write(    """[                                                                \n""")
+    for srcfile in srcfiles:
+        f.write("""  {                                                              \n""")
+        f.write("""     "directory": "{}",                                          \n""".format(projectdir))
+        f.write("""     "command":   "{} -I./src/ {} -I./ext/amrex/{}/include",\n""".format(cc, srcfile,postfix_amrex))
+        f.write("""     "file":      "{}",                                          \n""".format(srcfile))
+        f.write("""  },                                                             \n""")
+    f.write(    """]                                                                \n""")
+
 

--- a/configure
+++ b/configure
@@ -544,13 +544,13 @@ if args.clangd:
     cc = compmpicmd.stdout.decode('utf-8').replace('\n','')
 
     f = open("compile_commands.json","w")
-    f.write(    """[                                                                \n""")
+    f.write(    """[                                                                      \n""")
     for srcfile in srcfiles:
-        f.write("""  {                                                              \n""")
-        f.write("""     "directory": "{}",                                          \n""".format(projectdir))
-        f.write("""     "command":   "{} -I./src/ {} -I./ext/amrex/{}/include",\n""".format(cc, srcfile,postfix_amrex))
-        f.write("""     "file":      "{}",                                          \n""".format(srcfile))
-        f.write("""  },                                                             \n""")
-    f.write(    """]                                                                \n""")
+        f.write("""  {                                                                    \n""")
+        f.write("""     "directory": "{}",                                                \n""".format(projectdir))
+        f.write("""     "command":   "{} -std=c++17 -I./src/ {} -I./ext/amrex/{}/include",\n""".format(cc, srcfile,postfix_amrex))
+        f.write("""     "file":      "{}",                                                \n""".format(srcfile))
+        f.write("""  },                                                                   \n""")
+    f.write(    """]                                                                      \n""")
 
 

--- a/configure
+++ b/configure
@@ -120,7 +120,7 @@ parser.add_argument('--memcheck-tool',dest='memcheck_tool',default="msan",help="
 parser.add_argument('--create-gfortran-link',dest='gfortranln',action='store_true',default=False,
                     help="Create a link to the gfortran library. (Unless you are CircleCI, you should probably not do this!)")
 parser.add_argument('--link',default=None, nargs='+', help='Additional link paths')
-parser.add_argument('--clangd',dest='clangd',default=False,action='store_true', help='Generate compile_commands.json for clangd')
+parser.add_argument('--comp-cmds',dest='compile_commands',default=False,action='store_true', help='Generate compile_commands.json for language servers like clangd')
 parser.set_defaults(debug=False)
 
 #
@@ -532,7 +532,7 @@ if (args.docs):
     except: message("M2R",color.red + "M2R not installed - install using " + code("pip install m2r"))
 
 
-if args.clangd:
+if args.compile_commands:
     srcfiles = set()
     for dirname, _, filelist in sorted(os.walk("src/")):
         for f in filelist:

--- a/configure
+++ b/configure
@@ -558,5 +558,5 @@ if args.compile_commands:
     } for srcfile in srcfiles]
 
     with open(Path("compile_commands.json"), "w") as f:
-        json.dump(command_objects, f, indent="\t")
+        json.dump(command_objects, f, indent=4)
 

--- a/configure
+++ b/configure
@@ -8,6 +8,8 @@ import sys
 import shutil
 #import ctypes.util
 import glob
+import json
+from pathlib import Path
 
 #
 # Configuration parameters, mainly to specify default values:
@@ -532,7 +534,7 @@ if (args.docs):
 
 if args.clangd:
     srcfiles = set()
-    for dirname, subdirlist, filelist in sorted(os.walk("src/")):
+    for dirname, _, filelist in sorted(os.walk("src/")):
         for f in filelist:
             if f.endswith(".cc"): srcfiles.add(dirname+"/"+f)
             if f.endswith(".cpp"): srcfiles.add(dirname+"/"+f)
@@ -542,15 +544,19 @@ if args.clangd:
     projectdir = os.getcwd()
 
     cc = compmpicmd.stdout.decode('utf-8').replace('\n','')
+    command_objects = []
+    command_objects = [{
+        "directory": projectdir,
+        "file": srcfile,
+        "arguments": [
+            *cc.split(" "),
+            "-std=c++17",
+            "-I./src/",
+            srcfile,
+            f"-I./ext/amrex/{postfix_amrex}/include",
+        ],
+    } for srcfile in srcfiles]
 
-    f = open("compile_commands.json","w")
-    f.write(    """[                                                                      \n""")
-    for srcfile in srcfiles:
-        f.write("""  {                                                                    \n""")
-        f.write("""     "directory": "{}",                                                \n""".format(projectdir))
-        f.write("""     "command":   "{} -std=c++17 -I./src/ {} -I./ext/amrex/{}/include",\n""".format(cc, srcfile,postfix_amrex))
-        f.write("""     "file":      "{}",                                                \n""".format(srcfile))
-        f.write("""  },                                                                   \n""")
-    f.write(    """]                                                                      \n""")
-
+    with open(Path("compile_commands.json"), "w") as f:
+        json.dump(command_objects, f, indent="\t")
 

--- a/configure
+++ b/configure
@@ -120,7 +120,7 @@ parser.add_argument('--memcheck-tool',dest='memcheck_tool',default="msan",help="
 parser.add_argument('--create-gfortran-link',dest='gfortranln',action='store_true',default=False,
                     help="Create a link to the gfortran library. (Unless you are CircleCI, you should probably not do this!)")
 parser.add_argument('--link',default=None, nargs='+', help='Additional link paths')
-parser.add_argument('--comp-cmds',dest='compile_commands',default=False,action='store_true', help='Generate compile_commands.json for language servers like clangd')
+parser.add_argument('--no-comp-cmds',dest='compile_commands',default=False,action='store_true', help='Suppress generation of compile_commands.json for language servers like clangd')
 parser.set_defaults(debug=False)
 
 #
@@ -532,7 +532,7 @@ if (args.docs):
     except: message("M2R",color.red + "M2R not installed - install using " + code("pip install m2r"))
 
 
-if args.compile_commands:
+if not args.compile_commands:
     srcfiles = set()
     for dirname, _, filelist in sorted(os.walk("src/")):
         for f in filelist:


### PR DESCRIPTION
This PR adds the capability for the `configure` script to generate a `compile_commands.json` file. To do so, run `configure` with the `--comp-cmds` flag.

Language servers add features like "auto complete, go to definition, or documentation on hover" to text-based editors (Vim, Neovim, Emacs, VS Code, etc.). The most popular [language server protocol](https://microsoft.github.io/language-server-protocol/) (LSP) language servers for C/C++ are [ccls](https://github.com/MaskRay/ccls) and [clangd](https://clangd.llvm.org), both of which require a JSON file called [`compile_commands.json`](https://clang.llvm.org/docs/JSONCompilationDatabase.html) to be somewhere in the project structure.