### PR TITLE
Implement templated IC objects

### DIFF
--- a/src/IC/BMP.H
+++ b/src/IC/BMP.H
@@ -17,7 +17,7 @@
 
 namespace IC
 {
-class BMP : public IC
+class BMP : public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "bmp";

--- a/src/IC/Constant.H
+++ b/src/IC/Constant.H
@@ -6,31 +6,31 @@
 #ifndef IC_CONSTANT_H_
 #define IC_CONSTANT_H_
 
+#include "AMReX_Config.H"
 #include "IC/IC.H"
 #include "IO/ParmParse.H"
 #include "Util/Util.H"
 
-/// \class Constant
-/// \brief 
-///
 namespace IC
 {
-class Constant : public IC
+class Constant : public IC<Set::Scalar>, public IC<Set::Vector>
 {
 public:
     static constexpr const char* name = "constant";
 
-    Constant (amrex::Vector<amrex::Geometry> &_geom) :IC::IC(_geom) {}
-    Constant (amrex::Vector<amrex::Geometry> &_geom, IO::ParmParse &pp) : IC::IC(_geom) 
+    virtual ~Constant() = default;
+
+    Constant (amrex::Vector<amrex::Geometry> &_geom) :
+        IC<Set::Scalar>(_geom), IC<Set::Vector>(_geom) {}
+    Constant (amrex::Vector<amrex::Geometry> &_geom, IO::ParmParse &pp) : 
+        IC<Set::Scalar>(_geom), IC<Set::Vector>(_geom)
     {pp_queryclass(*this);}
-    Constant (amrex::Vector<amrex::Geometry> &_geom, IO::ParmParse &pp, std::string name) : IC::IC(_geom) 
+    Constant (amrex::Vector<amrex::Geometry> &_geom, IO::ParmParse &pp, std::string name) : 
+        IC<Set::Scalar>(_geom), IC<Set::Vector>(_geom)
     {pp_queryclass(name,*this);}
 
-    Constant(amrex::Vector<amrex::Geometry> &_geom, std::vector<amrex::Real> a_value)
-    : IC(_geom), m_value(a_value)
-    {}
-    ~Constant() { };
-    void Add(const int &lev, Set::Field<Set::Scalar> &a_field, Set::Scalar)
+
+    virtual void Add(const int &lev, Set::Field<Set::Scalar> &a_field, Set::Scalar /*time*/) override
     {
         Util::Assert(INFO,TEST((m_value.size() == 1 || (int)m_value.size() == (int)a_field[lev]->nComp())));
         for (amrex::MFIter mfi(*a_field[lev],amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -43,6 +43,21 @@ public:
             });  
         }
     }
+
+    virtual void Add(const int &lev, Set::Field<Set::Vector> &a_field, Set::Scalar /*time*/) override
+    {
+        Util::Assert(INFO,TEST((m_value.size() == 1 || (int)m_value.size() == AMREX_SPACEDIM)));
+        for (amrex::MFIter mfi(*a_field[lev],amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const amrex::Box& bx = mfi.growntilebox();
+            amrex::Array4<Set::Vector> const& field = a_field[lev]->array(mfi);
+            for (int m = 0; m < a_field[lev]->nComp(); m++)
+                amrex::ParallelFor (bx,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    field(i,j,k)(m) += m_value.size() == 1 ? m_value[0] : m_value[m];
+            });  
+        }
+    }
+
     static void Parse(Constant & value, IO::ParmParse & pp)
     {
         // Default: set equal to one everywhere

--- a/src/IC/Ellipse.H
+++ b/src/IC/Ellipse.H
@@ -12,7 +12,7 @@
 
 namespace IC
 {
-class Ellipse : public IC
+class Ellipse : public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "ellipse";

--- a/src/IC/Expression.H
+++ b/src/IC/Expression.H
@@ -41,7 +41,7 @@
 
 namespace IC
 {
-class Expression : public IC
+class Expression : public IC<Set::Scalar>, public IC<Set::Vector>
 {
 private:
     enum CoordSys { Cartesian, Polar, Spherical };
@@ -50,12 +50,14 @@ private:
     Expression::CoordSys coord = Expression::CoordSys::Cartesian;
 public:
     static constexpr const char* name = "expression";
-    Expression(amrex::Vector<amrex::Geometry>& _geom) : IC(_geom) {}
-    Expression(amrex::Vector<amrex::Geometry>& _geom, IO::ParmParse& pp, std::string name) : IC(_geom)
+    Expression(amrex::Vector<amrex::Geometry>& _geom) : 
+        IC<Set::Scalar>(_geom), IC<Set::Vector>(_geom) {}
+    Expression(amrex::Vector<amrex::Geometry>& _geom, IO::ParmParse& pp, std::string name) : 
+        IC<Set::Scalar>(_geom), IC<Set::Vector>(_geom)
     {
         pp_queryclass(name, *this);
     }
-    void Add(const int& lev, Set::Field<Set::Scalar>& a_field, Set::Scalar a_time = 0.0)
+    virtual void Add(const int& lev, Set::Field<Set::Scalar>& a_field, Set::Scalar a_time = 0.0) override
     {
         Util::Assert(INFO, TEST(a_field[lev]->nComp() == (int)f.size()));
         for (amrex::MFIter mfi(*a_field[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -72,7 +74,7 @@ public:
             {
                 amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
                 {
-                    Set::Vector x = Set::Position(i, j, k, geom[lev], type);
+                    Set::Vector x = Set::Position(i, j, k, IC<Set::Scalar>::geom[lev], type);
                     if (coord == Expression::CoordSys::Cartesian)
                     {
 #if AMREX_SPACEDIM == 1
@@ -95,7 +97,7 @@ public:
         a_field[lev]->FillBoundary();
     };
 
-    void Add(const int& lev, Set::Field<Set::Vector>& a_field, Set::Scalar a_time = 0.0)
+    virtual void Add(const int& lev, Set::Field<Set::Vector>& a_field, Set::Scalar a_time = 0.0) override
     {
         Util::Assert(INFO, TEST(a_field[lev]->nComp() == 1));
         Util::Assert(INFO, TEST(f.size() >= AMREX_SPACEDIM));
@@ -112,7 +114,7 @@ public:
             {
                 amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
                 {
-                    Set::Vector x = Set::Position(i, j, k, geom[lev], type);
+                    Set::Vector x = Set::Position(i, j, k, IC<Set::Vector>::geom[lev], type);
                     if (coord == Expression::CoordSys::Cartesian)
                     {
 #if AMREX_SPACEDIM == 1

--- a/src/IC/IC.H
+++ b/src/IC/IC.H
@@ -17,7 +17,8 @@
 
 namespace IC
 {
-/// \brief Pure abstract IC object from which all other IC objects inherit.
+/// Pure abstract IC object from which all other IC objects inherit.
+template<class T = Set::Scalar>
 class IC
 {
 public:
@@ -25,27 +26,33 @@ public:
         : geom(_geom) {} ;
     virtual ~IC() {}
 
-    virtual void Add(const int &lev, Set::Field<Set::Scalar> &field, Set::Scalar time) = 0;
-    virtual void Add(const int &lev, Set::Field<Set::Scalar> &field)
+    virtual void Add(const int &lev, Set::Field<T> &field, Set::Scalar time) = 0;
+    void Add(const int &lev, Set::Field<T> &field)
     {
         Add(lev,field,0.0);
     }
-    virtual void Add(const int &, Set::Field<Set::Vector> &, Set::Scalar) 
-    {Util::Abort(INFO,"Not yet implemented");};
+
+
+    // SFINAE solution: this is how we initialize if the type is arithmetic and has a  
+    // "0" value
+    template <typename U = T, typename std::enable_if_t<std::is_arithmetic_v<U>, int> = 0>
     void Initialize(const int &a_lev,
-                    Set::Field<Set::Scalar> &a_field,
+                    Set::Field<T> &a_field,
                     Set::Scalar a_time = 0.0)
     {
         Util::Assert(INFO,TEST(a_lev < a_field.size())," a_lev=",a_lev," size=",a_field.size());
         a_field[a_lev]->setVal(0.0);
         Add(a_lev,a_field,a_time);
     };
+
+    // SFINAE solution: we initialize using "Zero" if it is a class type.
+    template <typename U = T, typename std::enable_if_t<!std::is_arithmetic_v<U>, int> = 0>
     void Initialize(const int &a_lev,
-                    Set::Field<Set::Vector> &a_field,
+                    Set::Field<T> &a_field,
                     Set::Scalar a_time = 0.0)
     {
         Util::Assert(INFO,TEST(a_lev < a_field.size())," a_lev=",a_lev," size=",a_field.size());
-        a_field[a_lev]->setVal(Set::Vector::Zero());
+        a_field[a_lev]->setVal(T::Zero());
         Add(a_lev,a_field,a_time);
     };
 

--- a/src/IC/Laminate.H
+++ b/src/IC/Laminate.H
@@ -12,7 +12,7 @@
 namespace IC
 {
 /// Initialize Laminates in a matrix
-class Laminate: public IC
+class Laminate: public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "laminate";

--- a/src/IC/PNG.H
+++ b/src/IC/PNG.H
@@ -21,7 +21,7 @@
 
 namespace IC
 {
-class PNG : public IC
+class PNG : public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "png";

--- a/src/IC/PSRead.H
+++ b/src/IC/PSRead.H
@@ -18,7 +18,7 @@ using namespace std;
 
 namespace IC
 {
-class PSRead : public IC
+class PSRead : public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "psread";

--- a/src/IC/PerturbedInterface.H
+++ b/src/IC/PerturbedInterface.H
@@ -24,7 +24,7 @@
 
 namespace IC
 {
-class PerturbedInterface : public IC
+class PerturbedInterface : public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "perturbedinterface";

--- a/src/IC/Random.H
+++ b/src/IC/Random.H
@@ -11,8 +11,8 @@
 
 namespace IC
 {
-/// \brief Set each point to a random value.
-class Random : public IC
+/// Set each point to a random value.
+class Random : public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "random";

--- a/src/IC/Sphere.H
+++ b/src/IC/Sphere.H
@@ -3,6 +3,7 @@
 
 #include <cmath>
 
+#include "IO/ParmParse.H"
 #include "IC/IC.H"
 #include "Util/Util.H"
 
@@ -10,7 +11,7 @@
 /// \brief Initialize a spherical inclusion
 namespace IC
 {
-class Sphere: public IC
+class Sphere: public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "sphere";

--- a/src/IC/TabulatedInterface.H
+++ b/src/IC/TabulatedInterface.H
@@ -11,7 +11,7 @@
 ///
 namespace IC
 {
-class TabulatedInterface : public IC
+class TabulatedInterface : public IC<Set::Scalar>
 {
 public:
     enum Type {Partition, Values};
@@ -47,7 +47,7 @@ public:
         ys = a_ys;
     }
   
-    void Add(const int &lev, Set::Field<Set::Scalar> &a_field,Set::Scalar)
+    virtual void Add(const int &lev, Set::Field<Set::Scalar> &a_field,Set::Scalar) override
     {
         Numeric::Interpolator::Linear<Set::Scalar> f(ys,xs);
 

--- a/src/IC/Trig.H
+++ b/src/IC/Trig.H
@@ -12,13 +12,14 @@
 #include "IO/ParmParse.H"
 #include "AMReX_Vector.H"
 #include "IC/IC.H"
+#include "Set/Base.H"
 #include "Util/Util.H"
 #include "Set/Set.H"
 
 namespace IC
 {
 /// \brief Initialize using a trigonometric series
-class Trig : public IC
+class Trig : public IC<Set::Scalar>, public IC<Set::Vector>
 {
 public:
     static constexpr const char* name = "trig";
@@ -28,11 +29,12 @@ public:
                 std::complex<int> _n2 = 0,
                 std::complex<int> _n3 = 0),
         int _dim = AMREX_SPACEDIM) :
-        IC(_geom)
+        IC<Set::Scalar>(_geom), IC<Set::Vector>(_geom)
     {
         Define(_alpha,AMREX_D_DECL(_n1,_n2,_n3),_dim);
     }
-    Trig(amrex::Vector<amrex::Geometry> &_geom,IO::ParmParse &pp, std::string name) : IC(_geom)
+    Trig(amrex::Vector<amrex::Geometry> &_geom,IO::ParmParse &pp, std::string name) : 
+        IC<Set::Scalar>(_geom), IC<Set::Vector>(_geom)
     {pp_queryclass(name,*this);}
 
 
@@ -51,13 +53,13 @@ public:
     }
 
 
-    void Add(const int &lev, Set::Field<Set::Scalar> &a_field, Set::Scalar)
+    virtual void Add(const int &lev, Set::Field<Set::Scalar> &a_field, Set::Scalar) override
     {
         bool cellcentered = (a_field[0]->boxArray().ixType() == amrex::IndexType(amrex::IntVect::TheCellVector()));
 
-        const Set::Scalar AMREX_D_DECL(L1 = geom[lev].ProbHi()[0] - geom[lev].ProbLo()[0],
-                            L2 = geom[lev].ProbHi()[1] - geom[lev].ProbLo()[1],
-                            L3 = geom[lev].ProbHi()[2] - geom[lev].ProbLo()[2]);
+        const Set::Scalar AMREX_D_DECL(L1 = IC<Set::Scalar>::geom[lev].ProbHi()[0] - IC<Set::Scalar>::geom[lev].ProbLo()[0],
+                            L2 = IC<Set::Scalar>::geom[lev].ProbHi()[1] - IC<Set::Scalar>::geom[lev].ProbLo()[1],
+                            L3 = IC<Set::Scalar>::geom[lev].ProbHi()[2] - IC<Set::Scalar>::geom[lev].ProbLo()[2]);
 
 
         for (amrex::MFIter mfi(*a_field[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -72,15 +74,15 @@ public:
                 Set::Scalar AMREX_D_DECL(x1,x2,x3);
                 if (cellcentered)
                 {
-                    AMREX_D_TERM(x1 = geom[lev].ProbLo()[0] + ((amrex::Real)(i) + 0.5) * geom[lev].CellSize()[0];,
-                                x2 = geom[lev].ProbLo()[1] + ((amrex::Real)(j) + 0.5) * geom[lev].CellSize()[1];,
-                                x3 = geom[lev].ProbLo()[2] + ((amrex::Real)(k) + 0.5) * geom[lev].CellSize()[2];);
+                    AMREX_D_TERM(x1 = IC<Set::Scalar>::geom[lev].ProbLo()[0] + ((Set::Scalar)(i) + 0.5) * IC<Set::Scalar>::geom[lev].CellSize()[0];,
+                                x2 = IC<Set::Scalar>::geom[lev].ProbLo()[1] + ((Set::Scalar)(j) + 0.5) * IC<Set::Scalar>::geom[lev].CellSize()[1];,
+                                x3 = IC<Set::Scalar>::geom[lev].ProbLo()[2] + ((Set::Scalar)(k) + 0.5) * IC<Set::Scalar>::geom[lev].CellSize()[2];);
                 }
                 else
                 {
-                    AMREX_D_TERM(x1 = geom[lev].ProbLo()[0] + (amrex::Real)(i) * geom[lev].CellSize()[0];,
-                                x2 = geom[lev].ProbLo()[1] + (amrex::Real)(j) * geom[lev].CellSize()[1];,
-                                x3 = geom[lev].ProbLo()[2] + (amrex::Real)(k) * geom[lev].CellSize()[2];);
+                    AMREX_D_TERM(x1 = IC<Set::Scalar>::geom[lev].ProbLo()[0] + (Set::Scalar)(i) * IC<Set::Scalar>::geom[lev].CellSize()[0];,
+                                x2 = IC<Set::Scalar>::geom[lev].ProbLo()[1] + (Set::Scalar)(j) * IC<Set::Scalar>::geom[lev].CellSize()[1];,
+                                x3 = IC<Set::Scalar>::geom[lev].ProbLo()[2] + (Set::Scalar)(k) * IC<Set::Scalar>::geom[lev].CellSize()[2];);
                 }
                                    
                 Set::Scalar trigfn = 1.0;
@@ -100,18 +102,18 @@ public:
                             fabs(std::sin(phi3))*std::sin(n3.imag()*Set::Constant::Pi*x3 / L3));
                 #endif
                         
-                field(i,j,k,comp) += alpha * trigfn;
+                field(i,j,k,IC<Set::Scalar>::comp) += alpha * trigfn;
 
             });
         }
     }
-    void Add(const int &lev, Set::Field<Set::Vector> &a_field, Set::Scalar)
+    virtual void Add(const int &lev, Set::Field<Set::Vector> &a_field, Set::Scalar) override
     {
         bool cellcentered = (a_field[0]->boxArray().ixType() == amrex::IndexType(amrex::IntVect::TheCellVector()));
 
-        const Set::Scalar AMREX_D_DECL(L1 = geom[lev].ProbHi()[0] - geom[lev].ProbLo()[0],
-                            L2 = geom[lev].ProbHi()[1] - geom[lev].ProbLo()[1],
-                            L3 = geom[lev].ProbHi()[2] - geom[lev].ProbLo()[2]);
+        const Set::Scalar AMREX_D_DECL(L1 = IC<Set::Vector>::geom[lev].ProbHi()[0] - IC<Set::Vector>::geom[lev].ProbLo()[0],
+                            L2 = IC<Set::Vector>::geom[lev].ProbHi()[1] - IC<Set::Vector>::geom[lev].ProbLo()[1],
+                            L3 = IC<Set::Vector>::geom[lev].ProbHi()[2] - IC<Set::Vector>::geom[lev].ProbLo()[2]);
 
 
         for (amrex::MFIter mfi(*a_field[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -126,15 +128,15 @@ public:
                 Set::Scalar AMREX_D_DECL(x1,x2,x3);
                 if (cellcentered)
                 {
-                    AMREX_D_TERM(x1 = geom[lev].ProbLo()[0] + ((amrex::Real)(i) + 0.5) * geom[lev].CellSize()[0];,
-                                x2 = geom[lev].ProbLo()[1] + ((amrex::Real)(j) + 0.5) * geom[lev].CellSize()[1];,
-                                x3 = geom[lev].ProbLo()[2] + ((amrex::Real)(k) + 0.5) * geom[lev].CellSize()[2];);
+                    AMREX_D_TERM(x1 = IC<Set::Vector>::geom[lev].ProbLo()[0] + ((Set::Scalar)(i) + 0.5) * IC<Set::Vector>::geom[lev].CellSize()[0];,
+                                x2 = IC<Set::Vector>::geom[lev].ProbLo()[1] + ((Set::Scalar)(j) + 0.5) * IC<Set::Vector>::geom[lev].CellSize()[1];,
+                                x3 = IC<Set::Vector>::geom[lev].ProbLo()[2] + ((Set::Scalar)(k) + 0.5) * IC<Set::Vector>::geom[lev].CellSize()[2];);
                 }
                 else
                 {
-                    AMREX_D_TERM(x1 = geom[lev].ProbLo()[0] + (amrex::Real)(i) * geom[lev].CellSize()[0];,
-                                x2 = geom[lev].ProbLo()[1] + (amrex::Real)(j) * geom[lev].CellSize()[1];,
-                                x3 = geom[lev].ProbLo()[2] + (amrex::Real)(k) * geom[lev].CellSize()[2];);
+                    AMREX_D_TERM(x1 = IC<Set::Vector>::geom[lev].ProbLo()[0] + (Set::Scalar)(i) * IC<Set::Vector>::geom[lev].CellSize()[0];,
+                                x2 = IC<Set::Vector>::geom[lev].ProbLo()[1] + (Set::Scalar)(j) * IC<Set::Vector>::geom[lev].CellSize()[1];,
+                                x3 = IC<Set::Vector>::geom[lev].ProbLo()[2] + (Set::Scalar)(k) * IC<Set::Vector>::geom[lev].CellSize()[2];);
                 }
                                    
                 Set::Scalar trigfn = 1.0;
@@ -154,12 +156,11 @@ public:
                             fabs(std::sin(phi3))*std::sin(n3.imag()*Set::Constant::Pi*x3 / L3));
                 #endif
                         
-                field(i,j,k)(comp) += alpha * trigfn;
+                field(i,j,k)(IC<Set::Vector>::comp) += alpha * trigfn;
 
             });
         }
     }
-    using IC::Add;
 
 public:
     static void Parse(Trig & value, IO::ParmParse & pp)

--- a/src/IC/Trig2.H
+++ b/src/IC/Trig2.H
@@ -11,7 +11,7 @@
 namespace IC
 {
 /// \brief Initialize using a trigonometric series
-class Trig2 : public IC
+class Trig2 : public IC<Set::Scalar>
 {
 public:
     Trig2 (amrex::Vector<amrex::Geometry> &_geom,

--- a/src/IC/Voronoi.H
+++ b/src/IC/Voronoi.H
@@ -7,7 +7,7 @@
 
 namespace IC
 {
-class Voronoi : public IC
+class Voronoi : public IC<Set::Scalar>
 {
 public:
     static constexpr const char* name = "voronoi";

--- a/src/IC/Wedge.H
+++ b/src/IC/Wedge.H
@@ -6,12 +6,12 @@
 namespace IC
 {
 /// Initialize a coupon-shaped IC (for the Flame simulation)
-class Wedge : public IC
+class Wedge : public IC<Set::Scalar>
 {
 public:
     Wedge (amrex::Vector<amrex::Geometry> &_geom) : IC(_geom) {};
   
-    void Add(const int &lev, Set::Field<Set::Scalar> &field)
+    virtual void Add(const int &lev, Set::Field<Set::Scalar> &field, Set::Scalar /*time*/) override
     {
         amrex::Real sizex = geom[0].ProbHi()[0] - geom[0].ProbLo()[0];
         // AMREX_D_TERM(,

--- a/src/Integrator/AllenCahn.H
+++ b/src/Integrator/AllenCahn.H
@@ -172,9 +172,9 @@ protected:
     }
 
 protected:
-    Set::Field<Set::Scalar> alpha_mf;         // Temperature field variable (current timestep)
-    Set::Field<Set::Scalar> alpha_old_mf;     // Temperature field variable (previous timestep)
-    IC::IC* ic;                              // Object used to initialize temperature field
+    Set::Field<Set::Scalar> alpha_mf;         /// Temperature field variable (current timestep)
+    Set::Field<Set::Scalar> alpha_old_mf;     /// Temperature field variable (previous timestep)
+    IC::IC<Set::Scalar>* ic;                  /// Object used to initialize temperature field
 
     struct {
         Set::Scalar L = NAN;

--- a/src/Integrator/Base/Mechanics.H
+++ b/src/Integrator/Base/Mechanics.H
@@ -487,9 +487,9 @@ protected:
     Set::Vector disp_hi[AMREX_SPACEDIM];
 
 
-    IC::IC* ic_rhs = nullptr;
+    IC::IC<Set::Vector>* ic_rhs = nullptr;
 
-    IC::IC* velocity_ic = nullptr;
+    IC::IC<Set::Vector>* velocity_ic = nullptr;
 
     Solver::Nonlocal::Newton<MODEL> solver;//(elastic.op);
     BC::Operator::Elastic::Elastic* bc = nullptr;

--- a/src/Integrator/CahnHilliard.H
+++ b/src/Integrator/CahnHilliard.H
@@ -70,7 +70,7 @@ private:
     Set::Field<Set::Scalar> intermediate;  /// Intermediate field used for CH kinetics
 
     BC::BC<Set::Scalar> *bc; /// eta's bc object
-    IC::IC *ic;              /// eta's ic object
+    IC::IC<Set::Scalar> *ic; /// eta's ic object
     
     Set::Scalar gamma = NAN; 
     Set::Scalar L     = NAN; 

--- a/src/Integrator/Dendrite.H
+++ b/src/Integrator/Dendrite.H
@@ -206,7 +206,7 @@ private:
     Set::Scalar refinement_threshold_temp = NAN; // Criterion for cell refinement
     Set::Scalar refinement_threshold_phi = NAN; // Criterion for cell refinement
 
-    IC::IC* ic_temp, * ic_phi;
+    IC::IC<Set::Scalar>* ic_temp, * ic_phi;
     BC::BC<Set::Scalar>* bc_temp, * bc_phi;
 };
 } // namespace Integrator

--- a/src/Integrator/Flame.H
+++ b/src/Integrator/Flame.H
@@ -80,8 +80,8 @@ private:
 
     BC::BC<Set::Scalar>* bc_temp = nullptr;
     BC::BC<Set::Scalar>* bc_eta = nullptr;
-    IC::IC* ic_phi = nullptr;
-    IC::IC* ic_laser = nullptr;
+    IC::IC<Set::Scalar>* ic_phi = nullptr;
+    IC::IC<Set::Scalar>* ic_laser = nullptr;
 
     Set::Scalar phi_refinement_criterion = std::numeric_limits<Set::Scalar>::infinity();
     Set::Scalar m_refinement_criterion = NAN;
@@ -91,7 +91,7 @@ private:
     Set::Scalar zeta_0 =NAN;
     Set::Scalar small = NAN;
     Set::Scalar base_time = NAN;
-    IC::IC* ic_eta = nullptr;
+    IC::IC<Set::Scalar>* ic_eta = nullptr;
     int ghost_count = -1;
     int homogeneousSystem = -1;
     bool plot_field = true;
@@ -145,7 +145,7 @@ private:
         Set::Scalar disperssion1 = NAN;
         Set::Scalar disperssion2 = NAN;
         Set::Scalar disperssion3 = NAN;
-        IC::IC* ic_temp = nullptr;
+        IC::IC<Set::Scalar>* ic_temp = nullptr;
     } thermal;
 
     struct {

--- a/src/Integrator/Fracture.H
+++ b/src/Integrator/Fracture.H
@@ -568,7 +568,7 @@ private:
 
         Model::Interface::Crack::Constant cracktype;                      ///< type of crack. See Crack/Constant or Crack/Sin
         amrex::Vector<std::string> ic_type;                            ///< crack IC type. See IC/Notch and IC/Ellipsoid
-        amrex::Vector<IC::IC*> ic;                                     ///< crack IC. See IC/Notch and IC/Ellipsoid
+        amrex::Vector<IC::IC<Set::Scalar>*> ic;                                     ///< crack IC. See IC/Notch and IC/Ellipsoid
         bool is_ic = false;
 
         Set::Scalar scaleModulusMax = 0.02;         ///< material modulus ratio inside crack (default = 0.02).
@@ -586,7 +586,7 @@ private:
         std::string input_material = "isotropic";
         Set::Scalar refinement_threshold = 0.1;
         
-        IC::IC *ic;
+        IC::IC<Set::Scalar> *ic;
         std::string ic_type;
         bool is_ic = false;
     } material;

--- a/src/Integrator/HeatConduction.H
+++ b/src/Integrator/HeatConduction.H
@@ -191,7 +191,7 @@ private:
     // in the ~HeatConduction destructor.
     //
 
-    IC::IC* ic = nullptr;                    // Object used to initialize temperature field
+    IC::IC<Set::Scalar>* ic = nullptr;                    // Object used to initialize temperature field
     BC::BC<Set::Scalar>* bc = nullptr;       // Object used to update temp field boundary ghost cells
 };
 } // namespace Integrator

--- a/src/Integrator/Mechanics.H
+++ b/src/Integrator/Mechanics.H
@@ -352,9 +352,9 @@ protected:
     Set::Field<Set::Scalar> eta_mf;
     Set::Scalar m_eta_ref_threshold = NAN;
     std::vector<MODEL> models;
-    IC::IC* ic_eta = nullptr;
-    IC::IC* ic_psi = nullptr;
-    IC::IC* ic_trac_normal = nullptr;
+    IC::IC<Set::Scalar>* ic_eta = nullptr;
+    IC::IC<Set::Scalar>* ic_psi = nullptr;
+    IC::IC<Set::Scalar>* ic_trac_normal = nullptr;
     BC::BC<Set::Scalar>* bc_psi = nullptr;
     BC::BC<Set::Scalar>* bc_trac_normal = nullptr;
     bool psi_reset_on_regrid = false;

--- a/src/Integrator/PhaseFieldMicrostructure.H
+++ b/src/Integrator/PhaseFieldMicrostructure.H
@@ -331,7 +331,7 @@ private:
 
     Model::Interface::GB::GB *boundary = nullptr;
 
-    IC::IC *ic = nullptr;
+    IC::IC<Set::Scalar> *ic = nullptr;
 
     Set::Scalar volume = 5;
     Set::Scalar area = 0.0;

--- a/src/Integrator/TopOp.H
+++ b/src/Integrator/TopOp.H
@@ -218,7 +218,7 @@ public:
 
 protected:
     MODEL model;
-    IC::IC* ic_psi = nullptr;
+    IC::IC<Set::Scalar>* ic_psi = nullptr;
     BC::BC<Set::Scalar>* bc_psi = nullptr;
     Set::Scalar m_eta_ref_threshold = NAN;
     Set::Field<Set::Scalar> psi_old_mf;


### PR DESCRIPTION
This PR upgrades the `IC::IC` structures to use templates, similar to how `BC::BC` works. This makes the `IC` structure more general and versatile as we move towards more sophisticated fields.

**Changes may be required in your code**

**Change 1**: explicitly specify `Set::Scalar` in IC pointers, usually in an `Integrator` file. 

    IC::IC* my_initial_condition; // <<< this will no longer work
    IC::IC<Set::Scalar>* my_initial_condition; // <<< use this instead

**Change 2**: specify template type in derived ICs. You only need to do this if you have implemented a custom IC.

    class Random : public IC // <<< this will no longer work
    class Random : public IC<Set::Scalar> // <<< use this instead

If you are working with, or would like to work with more sophisticated IC object (like those that initialze vectors or other class types), see `IC::Expression` for an example of an IC that works with both scalar and vector objects.

