### PR TITLE
update coverage tests to run on PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,11 @@ name: Coverage
 
 on:
   push:
-    branches: ["development","candidate-coverage"]
+    branches:
+    - development
+  pull_request:
+    branches:
+    - development
 
 permissions:
   contents: read
@@ -38,6 +42,12 @@ jobs:
       run: make docs
     - name: combine githubpages
       run: make githubpages
+  publish-documentation:
+    name: Deploy documentation to GitHub Pages
+    needs: test-coverage
+    if: ${{ github.ref == 'refs/heads/development' }}
+    runs-on: ubuntu-24.04
+    steps:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -3,6 +3,9 @@ name: Install
 on:
   push:
     branches: ["development", "master","candidate","candidate-install"]
+  pull_request:
+    branches:
+    - development
 
 jobs:
   install-ubuntu-20-04:

--- a/tests/PlateHole/test
+++ b/tests/PlateHole/test
@@ -78,11 +78,11 @@ class new:
     sigyy = ret[4]
 
 pylab.clf()
-pylab.plot(new.x,new.sigxx,marker='o',color='C0',label="$\sigma_{xx}$",linestyle="",markerfacecolor='None')
+pylab.plot(new.x,new.sigxx,marker='o',color='C0',label=r"$\sigma_{xx}$",linestyle="",markerfacecolor='None')
 pylab.plot(ref.x,ref.sigxx,color='C0')
-pylab.plot(new.x,new.sigyy,marker='o',color='C1',label="$\sigma_{yy}$",linestyle="",markerfacecolor='None')
+pylab.plot(new.x,new.sigyy,marker='o',color='C1',label=r"$\sigma_{yy}$",linestyle="",markerfacecolor='None')
 pylab.plot(ref.x,ref.sigyy,color='C1')
-pylab.plot(new.x,new.sigxy,marker='o',color='C2',label="$\sigma_{xy}$",linestyle="",markerfacecolor='None')
+pylab.plot(new.x,new.sigxy,marker='o',color='C2',label=r"$\sigma_{xy}$",linestyle="",markerfacecolor='None')
 pylab.plot(ref.x,ref.sigxy,color='C2')
 pylab.legend()
 pylab.tight_layout()


### PR DESCRIPTION
- update GitHub Actions to run the regression tests on PRs
- split the deployment of the coverage tests/documentation into a separate job and restricted it to pushes to development