### PR TITLE
moving the roefix variable to be read and handled by the roe solver

### DIFF
--- a/src/Integrator/Hydro.H
+++ b/src/Integrator/Hydro.H
@@ -1,10 +1,6 @@
 #ifndef INTEGRATOR_HYDRO_H
 #define INTEGRATOR_HYDRO_H
 
-#include <string>
-#include <limits>
-#include <memory>
-
 #include "Integrator/Integrator.H"
 #include "IO/ParmParse.H"
 
@@ -12,11 +8,6 @@
 #include "BC/Constant.H"
 #include "BC/Nothing.H"
 #include "IC/IC.H"
-
-#include "IC/Sphere.H"
-#include "IC/Constant.H"
-#include "IC/Laminate.H"
-#include "IC/Expression.H"
 
 #include "Set/Base.H"
 #include "Solver/Local/Riemann/Roe.H"
@@ -135,7 +126,6 @@ private:
     Set::Scalar small=NAN;
     Set::Scalar cutoff=NAN;
     Set::Scalar lagrange=NAN;
-    int roefix = 0;
 
     Solver::Local::Riemann::Roe *roesolver = nullptr;
 

--- a/src/Integrator/Hydro.cpp
+++ b/src/Integrator/Hydro.cpp
@@ -2,12 +2,10 @@
 #include "Hydro.H"
 #include "IO/ParmParse.H"
 #include "BC/Constant.H"
-#include "BC/Nothing.H"
 #include "BC/Expression.H"
 #include "Numeric/Stencil.H"
-#include "Numeric/Function.H"
+#include "IC/Constant.H"
 #include "IC/Laminate.H"
-#include "IC/PSRead.H"
 #include "IC/Expression.H"
 #include "IC/BMP.H"
 #include "IC/PNG.H"
@@ -68,7 +66,8 @@ Hydro::Parse(Hydro& value, IO::ParmParse& pp)
         pp_query_default("small",value.small,1E-8); // small regularization value
         pp_query_default("cutoff",value.cutoff,-1E100); // cutoff value
         pp_query_default("lagrange",value.lagrange,0.0); // lagrange no-penetration factor
-        pp_query_default("roefix",value.roefix,0); // Roe solver entropy fix
+
+        pp_forbid("roefix","--> solver.roe.entropy_fix"); // Roe solver entropy fix
 
     }
     // Register FabFields:
@@ -427,12 +426,12 @@ void Hydro::Advance(int lev, Set::Scalar time, Set::Scalar dt)
             try
             {
                 //lo interface fluxes
-                flux_xlo = roesolver->Solve(state_xlo_fluid, state_x_fluid, gamma, pref, small, roefix) * eta(i,j,k);
-                flux_ylo = roesolver->Solve(state_ylo_fluid, state_y_fluid, gamma, pref, small, roefix) * eta(i,j,k);
+                flux_xlo = roesolver->Solve(state_xlo_fluid, state_x_fluid, gamma, pref, small) * eta(i,j,k);
+                flux_ylo = roesolver->Solve(state_ylo_fluid, state_y_fluid, gamma, pref, small) * eta(i,j,k);
 
                 //hi interface fluxes
-                flux_xhi = roesolver->Solve(state_x_fluid, state_xhi_fluid, gamma, pref, small, roefix) * eta(i,j,k);
-                flux_yhi = roesolver->Solve(state_y_fluid, state_yhi_fluid, gamma, pref, small, roefix) * eta(i,j,k);
+                flux_xhi = roesolver->Solve(state_x_fluid, state_xhi_fluid, gamma, pref, small) * eta(i,j,k);
+                flux_yhi = roesolver->Solve(state_y_fluid, state_yhi_fluid, gamma, pref, small) * eta(i,j,k);
             }
             catch(...)
             {

--- a/src/Solver/Local/Riemann/Roe.H
+++ b/src/Solver/Local/Riemann/Roe.H
@@ -1,14 +1,15 @@
-#ifndef SOLVER_LOCAL_RIEMANN_ROE_H
-#define SOLVER_LOCAL_RIEMANN_ROE_H
-
 //
 // This implements the Riemann Roe solver.
 //
 // Notation and algorithm follow the presentation in Section 5.3.3
 // of *Computational Gasdynamics* by Culbert B. Laney (page 88)
 //
+// This solver uses an optional entropy fix [documentation needed]
+//
 
-#include "Set/Set.H"
+#ifndef SOLVER_LOCAL_RIEMANN_ROE_H
+#define SOLVER_LOCAL_RIEMANN_ROE_H
+
 #include "IO/ParmParse.H"
 #include "Solver/Local/Riemann/Riemann.H"
 
@@ -40,14 +41,17 @@ public:
     }
 
     int verbose = 0;
+    bool entropy_fix = false;
 
     static void Parse(Roe & value, IO::ParmParse & pp)
     {
         // enable to dump diagnostic data if the roe solver fails
-        pp.query_default("verbose",value.verbose,1);
+        pp.query_default("verbose", value.verbose, 1);
+        // apply entropy fix if tru
+        pp.query_default("entropy_fix", value.entropy_fix, false);
     }
 
-    Flux Solve(State lo, State hi, Set::Scalar gamma, Set::Scalar p_ref, Set::Scalar small, int roefix)
+    Flux Solve(State lo, State hi, Set::Scalar gamma, Set::Scalar p_ref, Set::Scalar small)
     {
         Set::Scalar rho_L = lo.rho       ,  rho_R = hi.rho;
         Set::Scalar Mn_L  = lo.M_normal  ,  Mn_R  = hi.M_normal  ;
@@ -142,7 +146,7 @@ public:
         //
         // ROE ENTROPY FIX (not included in cited paper)
         //
-        if (roefix == 1) {
+        if (entropy_fix == 1) {
             Util::ParallelMessage(INFO,"Entropy fix is still experimental and needs to be investigated further");
             //  Eq. 4.3.67 in "Computational Fluid Dynamics for Engineers and Scientists" by Sreenivas Jayanti
             //Set::Scalar a_L = std::sqrt(gamma * p_L / (rho_L + small)); // sound speed
@@ -236,15 +240,14 @@ public:
         Set::Scalar gamma = 1.4;
         Set::Scalar pref = 10.0;
         Set::Scalar small = 1E-10;
-        int roefix = 0;
 
         // Test 1: Tangential Velocity Difference - No Normal Flux
         try {
             State left  (1.0, 1.0, 0.0, 1.0);
             State center(1.0, 1.0, 1.0, 1.0);
             State right (1.0, 1.0, 2.0, 1.0);
-            Flux fluxlo = solver.Solve(center, right, gamma, pref, small, roefix);
-            Flux fluxhi = solver.Solve(left, center,  gamma, pref, small, roefix);
+            Flux fluxlo = solver.Solve(center, right, gamma, pref, small);
+            Flux fluxhi = solver.Solve(left, center,  gamma, pref, small);
 
             if (fabs(fluxhi.mass - fluxlo.mass) > 1E-10
                 || fabs(fluxhi.momentum_normal - fluxlo.momentum_normal) > 1E-10
@@ -268,8 +271,8 @@ public:
             State left  (1.0, 0.0, 0.0, 1.0);
             State center(1.0, 0.0, 1.0, 1.0);
             State right (1.0, 0.0, 2.0, 1.0);
-            Flux fluxlo = solver.Solve(left, center,  gamma, pref, small, roefix);
-            Flux fluxhi = solver.Solve(center, right, gamma, pref, small, roefix);
+            Flux fluxlo = solver.Solve(left, center,  gamma, pref, small);
+            Flux fluxhi = solver.Solve(center, right, gamma, pref, small);
             if (fabs(fluxhi.mass - fluxlo.mass) > 1E-10
                 || fabs(fluxhi.momentum_normal - fluxlo.momentum_normal) > 1E-10
                 || fabs(fluxhi.energy - fluxlo.energy) > 1E-10) {
@@ -292,8 +295,8 @@ public:
             State left(1.0, 0.0, 0.0, 1.0);
             State center(1.0, 0.0, 0.0, 1.0);
             State right(1.0, 0.0, 0.0, 1.0);
-            Flux fluxhi = solver.Solve(center, right, gamma, pref, small, roefix);
-            Flux fluxlo = solver.Solve(left, center, gamma, pref, small, roefix);
+            Flux fluxhi = solver.Solve(center, right, gamma, pref, small);
+            Flux fluxlo = solver.Solve(left, center, gamma, pref, small);
             if (fabs(fluxhi.mass - fluxlo.mass) > 1E-10 // no change in mass flux
                 || fabs(fluxhi.momentum_normal - fluxlo.momentum_normal) > 1E-10 // no change in momentum flux
                 || fabs(fluxhi.momentum_tangent) > 1E-10 // zero tangent flux
@@ -318,8 +321,8 @@ public:
             State left (1.0, 1.0, 0.5, 1.0);
             State center(1.0, 1.0, 0.5, 1.0);
             State right (1.0, 1.0, 0.5, 1.0);
-            Flux fluxhi = solver.Solve(center, right, gamma, pref, small, roefix);
-            Flux fluxlo = solver.Solve(left, center, gamma, pref, small, roefix);
+            Flux fluxhi = solver.Solve(center, right, gamma, pref, small);
+            Flux fluxlo = solver.Solve(left, center, gamma, pref, small);
             if (fabs(fluxhi.mass - fluxlo.mass) > 1E-10 ||
                 fabs(fluxhi.momentum_normal - fluxlo.momentum_normal) > 1E-10 ||
                 fabs(fluxhi.energy - fluxlo.energy) > 1E-10) {

--- a/src/Solver/Local/Riemann/Roe.H
+++ b/src/Solver/Local/Riemann/Roe.H
@@ -49,6 +49,9 @@ public:
         pp.query_default("verbose", value.verbose, 1);
         // apply entropy fix if tru
         pp.query_default("entropy_fix", value.entropy_fix, false);
+
+        if (value.entropy_fix)
+            Util::Warning(INFO,"The entropy fix is experimental and should be used with caution");
     }
 
     Flux Solve(State lo, State hi, Set::Scalar gamma, Set::Scalar p_ref, Set::Scalar small)
@@ -147,21 +150,6 @@ public:
         // ROE ENTROPY FIX (not included in cited paper)
         //
         if (entropy_fix == 1) {
-            Util::ParallelMessage(INFO,"Entropy fix is still experimental and needs to be investigated further");
-            //  Eq. 4.3.67 in "Computational Fluid Dynamics for Engineers and Scientists" by Sreenivas Jayanti
-            //Set::Scalar a_L = std::sqrt(gamma * p_L / (rho_L + small)); // sound speed
-            //Set::Scalar a_R = std::sqrt(gamma * p_R / (rho_R + small));
-            //Set::Scalar lambda1_L = u_L;         Set::Scalar lambda1_R = u_R; // eigenvalues
-            //Set::Scalar lambda2_L = u_L + a_L;   Set::Scalar lambda2_R = u_R + a_R;
-            //Set::Scalar lambda3_L = u_L - a_L;   Set::Scalar lambda3_R = u_R - a_R;
-            //Set::Scalar fix1 = std::max(0.0, std::max(lambda1 - lambda1_L, lambda1_R - lambda1));
-            //Set::Scalar fix2 = std::max(0.0, std::max(lambda2 - lambda2_L, lambda2_R - lambda2));
-            //Set::Scalar fix3 = std::max(0.0, std::max(lambda3 - lambda3_L, lambda3_R - lambda3));
-            //if ( lambda1 < fix1 ) lambda1 = fix1;
-            //if ( lambda2 < fix2 ) lambda2 = fix2;
-            //if ( lambda3 < fix3 ) lambda3 = fix3;
-
-            // chimeracfd method https://chimeracfd.com/programming/gryphon/fluxroe.html
             lambda1 = fabs(lambda1);
             lambda2 = fabs(lambda2);
             lambda3 = fabs(lambda3);

--- a/src/Solver/Local/Riemann/Roe.H
+++ b/src/Solver/Local/Riemann/Roe.H
@@ -4,7 +4,9 @@
 // Notation and algorithm follow the presentation in Section 5.3.3
 // of *Computational Gasdynamics* by Culbert B. Laney (page 88)
 //
-// This solver uses an optional entropy fix [documentation needed]
+// This solver uses an optional entropy fix
+//   Option 1: chimeracfd method https://chimeracfd.com/programming/gryphon/fluxroe.html
+//   Option 2: Eq. 4.3.67 in *Computational Fluid Dynamics for Engineers and Scientists* by Sreenivas Jayanti
 //
 
 #ifndef SOLVER_LOCAL_RIEMANN_ROE_H
@@ -41,7 +43,7 @@ public:
     }
 
     int verbose = 0;
-    bool entropy_fix = false;
+    int entropy_fix = 0;
 
     static void Parse(Roe & value, IO::ParmParse & pp)
     {
@@ -50,8 +52,10 @@ public:
         // apply entropy fix if tru
         pp.query_default("entropy_fix", value.entropy_fix, false);
 
-        if (value.entropy_fix)
+        if (value.entropy_fix == 1)
             Util::Warning(INFO,"The entropy fix is experimental and should be used with caution");
+        else if (value.entropy_fix == 2)
+            Util::Warning(INFO,"The entropy fix is experimental and should be used with caution. Has previously caused errors with FlowDrivenCavity regression test");
     }
 
     Flux Solve(State lo, State hi, Set::Scalar gamma, Set::Scalar p_ref, Set::Scalar small)
@@ -147,15 +151,28 @@ public:
         //
 
         //
-        // ROE ENTROPY FIX (not included in cited paper)
+        // ROE ENTROPY FIX (Source cited in header comments)
         //
-        if (entropy_fix == 1) {
+        if (entropy_fix == 1) { // chimeracfd
             lambda1 = fabs(lambda1);
             lambda2 = fabs(lambda2);
             lambda3 = fabs(lambda3);
             if ( lambda1 < deltau ) lambda1 = 0.5*(lambda1*lambda1 + deltau*deltau)/deltau;
             if ( lambda2 < deltau ) lambda2 = 0.5*(lambda2*lambda2 + deltau*deltau)/deltau;
             if ( lambda3 < deltau ) lambda3 = 0.5*(lambda3*lambda3 + deltau*deltau)/deltau;
+        }
+        else if (entropy_fix == 2) { // Jayanti
+            Set::Scalar a_L = std::sqrt(gamma * p_L / (rho_L + small)); // sound speed
+            Set::Scalar a_R = std::sqrt(gamma * p_R / (rho_R + small));
+            Set::Scalar lambda1_L = u_L;         Set::Scalar lambda1_R = u_R; // eigenvalues
+            Set::Scalar lambda2_L = u_L + a_L;   Set::Scalar lambda2_R = u_R + a_R;
+            Set::Scalar lambda3_L = u_L - a_L;   Set::Scalar lambda3_R = u_R - a_R;
+            Set::Scalar fix1 = std::max(0.0, std::max(lambda1 - lambda1_L, lambda1_R - lambda1));
+            Set::Scalar fix2 = std::max(0.0, std::max(lambda2 - lambda2_L, lambda2_R - lambda2));
+            Set::Scalar fix3 = std::max(0.0, std::max(lambda3 - lambda3_L, lambda3_R - lambda3));
+            if ( lambda1 < fix1 ) lambda1 = fix1;
+            if ( lambda2 < fix2 ) lambda2 = fix2;
+            if ( lambda3 < fix3 ) lambda3 = fix3;
         }
 
         //
@@ -181,8 +198,6 @@ public:
                 Util::ParallelMessage(INFO,"u_R ", u_R);
                 Util::ParallelMessage(INFO,"u_L ", u_L);
                 Util::ParallelMessage(INFO,"u_RL ", u_RL); 
-                //Util::ParallelMessage(INFO,"a_R ", a_R);
-                //Util::ParallelMessage(INFO,"a_L ", a_L);
                 Util::ParallelMessage(INFO,"a_RL ", a_RL);
                 Util::ParallelMessage(INFO,"lambda1 ", lambda1); 
                 Util::ParallelMessage(INFO,"lambda2 ", lambda2); 

--- a/tests/FlowRiemannShockTube/input
+++ b/tests/FlowRiemannShockTube/input
@@ -5,7 +5,7 @@
 #@ [roe-fix]
 #@ exe=hydro
 #@ dim=2
-#@ roefix=1
+#@ args= solver.roe.entropy_fix=1
 
 alamo.program = hydro
 

--- a/tests/FlowRiemannShockTube/input
+++ b/tests/FlowRiemannShockTube/input
@@ -2,10 +2,15 @@
 #@ exe=hydro
 #@ dim=2
 
-#@ [roe-fix]
+#@ [roe-fix1]
 #@ exe=hydro
 #@ dim=2
 #@ args= solver.roe.entropy_fix=1
+
+#@ [roe-fix2]
+#@ exe=hydro
+#@ dim=2
+#@ args= solver.roe.entropy_fix=2
 
 alamo.program = hydro
 


### PR DESCRIPTION
The `roefix` toggle should be set inside the Roe solver since it is specific to the Roe solver and not an input that is directly relevant to Hydro.
`[prefix].roefix` is now `[prefix].solver.roe.entropy_fix`
A `pp_forbid` has been set to provide guidance on the new input.  

(some extraneous includes have also been removed)