### PR TITLE
Support openmpi and move default ubuntu 24.04 configuration to openmpi

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -16,6 +16,6 @@ make
 ls ./bin/
 
 #
-# Run the unit test suite using the regression test script
+# Run the unit test suite in serial using the regression test script
 #
-scripts/runtests.py --dim=3 tests/Unit
+scripts/runtests.py --dim=3 --serial tests/Unit

--- a/.github/workflows/dependencies-ubuntu-24.04.sh
+++ b/.github/workflows/dependencies-ubuntu-24.04.sh
@@ -10,14 +10,14 @@ sudo apt install build-essential g++ gfortran
 # Use apt (or apt-get) to install these packages
 # [ you should only need to do this once ]
 #
-sudo apt install libmpich-dev libmpich12 mpich
+sudo apt install libopenmpi-dev 
 sudo apt install libeigen3-dev
 sudo apt install libpng-dev
 
 #
 # Install these packages if compiling with clang
 #
-sudo apt install clang libgfortran-14-dev
+sudo apt install clang libgfortran-14-dev libstdc++-14-dev
 
 #
 # These are needed for regression test scripts and other code infrastructure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,9 +50,9 @@ jobs:
     - name: regression tests
       run: scripts/runtests.py --serial --no-coverage --dim=2 --benchmark=github  --timeout=200 --no-backspace
     - name: parallelism check
-      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --no-backspace --mpirun-flags="--oversubscribe"
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --no-backspace
   test-2d-24-04:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: installing preliminaries

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,8 +37,22 @@ jobs:
       run: bash .github/workflows/dependencies-ubuntu-24.04.sh
     - name: make
       run: bash .github/workflows/build-docs.sh
+  test-2d-22-04:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: installing preliminaries
+      run: bash .github/workflows/dependencies-ubuntu-22.04.sh
+    - name: configure (2d)
+      run: ./configure --dim=2 
+    - name: make
+      run: make
+    - name: regression tests
+      run: scripts/runtests.py --serial --no-coverage --dim=2 --benchmark=github  --timeout=200 --no-backspace
+    - name: parallelism check
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --no-backspace --mpirun-flags="--oversubscribe"
   test-2d-24-04:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: installing preliminaries
@@ -50,7 +64,7 @@ jobs:
     - name: regression tests
       run: scripts/runtests.py --serial --no-coverage --dim=2 --benchmark=github  --timeout=200 --no-backspace
     - name: parallelism check
-      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --no-backspace
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --no-backspace --mpirun-flags="--oversubscribe"
   test-3d-24-04:
     runs-on: ubuntu-24.04
     steps:
@@ -64,7 +78,7 @@ jobs:
     - name: regression tests
       run: scripts/runtests.py --serial --no-coverage --dim=3 --benchmark=github  --timeout=200 --no-backspace
     - name: parallelism check
-      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=3 --no-backspace
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=3 --no-backspace --mpirun-flags="--oversubscribe"
   test-2d-24-04-clang:
     runs-on: ubuntu-24.04
     steps:
@@ -80,4 +94,4 @@ jobs:
     - name: regression tests
       run: scripts/runtests.py --serial --no-coverage --dim=2 --benchmark=github --comp=clang++  --timeout=200 --no-backspace
     - name: parallelism check
-      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --comp=clang++ --no-backspace
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --comp=clang++ --no-backspace --mpirun-flags="--oversubscribe"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,6 +49,8 @@ jobs:
       run: make
     - name: regression tests
       run: scripts/runtests.py --serial --no-coverage --dim=2 --benchmark=github  --timeout=200 --no-backspace
+    - name: parallelism check
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --no-backspace
   test-3d-24-04:
     runs-on: ubuntu-24.04
     steps:
@@ -61,6 +63,8 @@ jobs:
       run: make
     - name: regression tests
       run: scripts/runtests.py --serial --no-coverage --dim=3 --benchmark=github  --timeout=200 --no-backspace
+    - name: parallelism check
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=3 --no-backspace
   test-2d-24-04-clang:
     runs-on: ubuntu-24.04
     steps:
@@ -75,3 +79,5 @@ jobs:
       run: make
     - name: regression tests
       run: scripts/runtests.py --serial --no-coverage --dim=2 --benchmark=github --comp=clang++  --timeout=200 --no-backspace
+    - name: parallelism check
+      run: scripts/runtests.py tests/Unit/ --check-mpi --dim=2 --comp=clang++ --no-backspace

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -11,11 +11,11 @@ permissions:
 
 jobs:
   memcheck-2d-asan-gcc:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: installing preliminaries
-      run: bash .github/workflows/dependencies-ubuntu-24.04.sh
+      run: bash .github/workflows/dependencies-ubuntu-22.04.sh
     - name: configure (2d)
       continue-on-error: true
       run: ./configure --dim=2 --debug --memcheck --memcheck-tool=asan 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -11,13 +11,18 @@ permissions:
 
 jobs:
   memcheck-2d-asan-gcc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: installing preliminaries
-      run: bash .github/workflows/dependencies-ubuntu-22.04.sh
+      run: bash .github/workflows/dependencies-ubuntu-24.04.sh 
+    - name: installing mpich (needed for asan)
+      run: sudo apt install -y libmpich-dev libmpich12 mpich
+    - name: switch mpi compiler to mpich
+      run: sudo update-alternatives --set mpi /usr/bin/mpicc.mpich
+    - name: switch mpirun to mpich
+      run: sudo update-alternatives --set mpirun /usr/bin/mpirun.mpich
     - name: configure (2d)
-      continue-on-error: true
       run: ./configure --dim=2 --debug --memcheck --memcheck-tool=asan 
     - name: make (2d)
       run: make

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ FG_MAGENTA         = \033[35m
 
 
 
+QUIET ?= @
+
+
 METADATA_GITHASH  = $(shell git describe --always --dirty)
 METADATA_USER     = $(shell whoami)
 METADATA_PLATFORM = $(shell hostname)
@@ -74,12 +77,6 @@ CTR_EXE = 0
 default: $(DEP) $(EXE) $(DEP_EXTRA)
 	@printf "$(B_ON)$(FG_GREEN)DONE $(RESET)\n" 
 
-
-python: $(OBJ)
-	@printf "$(B_ON)$(FG_MAGENTA)PYTHON  $(RESET)    Compiling library\n" 
-	@$(CC) -x c++ -c py/alamo.cpy -fPIC -o py/alamo.cpy.o ${ALAMO_INCLUDE} ${PYTHON_INCLUDE} ${CXX_COMPILE_FLAGS} 
-	@$(CC) -shared -Wl,-soname,alamo.so -o alamo.so py/alamo.cpy.o ${OBJ} ${LIB} ${MPI_LIB} $(PYTHON_LIB) 
-
 tidy:
 	@printf "$(B_ON)$(FG_RED)TIDYING  $(RESET)\n" 
 	find src -name "*.orig" -exec rm -rf {} \;
@@ -109,7 +106,7 @@ realclean: clean
 
 info:
 	@printf "$(B_ON)$(FG_BLUE)Compiler version information$(RESET)\n"
-	@$(CC) --version
+	$(CC) --version
 
 -include .make/Makefile.post.conf
 
@@ -121,7 +118,7 @@ bin/%-$(POSTFIX): ${OBJ_F} ${OBJ} obj/obj-$(POSTFIX)/%.cc.o
 	@printf '%9s' "($(CTR_EXE)/$(NUM_EXE)) " 
 	@printf "$(RESET)$@\n"
 	@mkdir -p bin/
-	@$(CC) -o $@ $^ ${LIB}  ${MPI_LIB}  ${LINKER_FLAGS}
+	$(QUIET)$(CC) -o $@ $^ ${LIB}  ${MPI_LIB}  ${LINKER_FLAGS}
 
 obj/obj-$(POSTFIX)/test.cc.o: src/test.cc ${AMREX_TARGET}
 	$(eval CTR=$(shell echo $$(($(CTR)+1))))
@@ -129,7 +126,7 @@ obj/obj-$(POSTFIX)/test.cc.o: src/test.cc ${AMREX_TARGET}
 	@printf '%9s' "($(CTR)/$(NUM)) " 
 	@printf "$(RESET)$<\n"
 	@mkdir -p $(dir $@)
-	@$(CC) -c $< -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
+	$(QUIET)$(CC) -c $< -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
 
 obj/obj-$(POSTFIX)/%.cc.o: src/%.cc ${AMREX_TARGET} 
 	$(eval CTR=$(shell echo $$(($(CTR)+1))))
@@ -137,7 +134,7 @@ obj/obj-$(POSTFIX)/%.cc.o: src/%.cc ${AMREX_TARGET}
 	@printf '%9s' "($(CTR)/$(NUM)) " 
 	@printf "$(RESET)$<\n"
 	@mkdir -p $(dir $@)
-	@$(CC) -c $< -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
+	$(QUIET)$(CC) -c $< -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
 
 obj/obj-$(POSTFIX)/%.cpp.o: 
 	$(eval CTR=$(shell echo $$(($(CTR)+1))))
@@ -145,7 +142,7 @@ obj/obj-$(POSTFIX)/%.cpp.o:
 	@printf '%9s' "($(CTR)/$(NUM)) " 
 	@printf "$(RESET)$<\n"
 	@mkdir -p $(dir $@)
-	@$(CC) -c $< -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
+	$(QUIET)$(CC) -c $< -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
 
 obj/obj-$(POSTFIX)/%.cpp.d: src/%.cpp  ${AMREX_TARGET}
 	$(eval CTR_DEP=$(shell echo $$(($(CTR_DEP)+1))))
@@ -153,7 +150,7 @@ obj/obj-$(POSTFIX)/%.cpp.d: src/%.cpp  ${AMREX_TARGET}
 	@printf '%9s' "($(CTR_DEP)/$(NUM)) " 
 	@printf "$(RESET)$<\n"
 	@mkdir -p $(dir $@)
-	@$(CC) -I./src/ $< ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} -MM -MT $(@:.cpp.d=.cpp.o) -MF $@
+	$(QUIET)$(CC) -Wno-unused-command-line-argument -I./src/ $< ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS}-MM -MT $(@:.cpp.d=.cpp.o) -MF $@
 
 obj/obj-$(POSTFIX)/%.cc.d: src/%.cc ${AMREX_TARGET}
 	$(eval CTR_DEP=$(shell echo $$(($(CTR_DEP)+1))))
@@ -161,7 +158,7 @@ obj/obj-$(POSTFIX)/%.cc.d: src/%.cc ${AMREX_TARGET}
 	@printf '%9s' "($(CTR_DEP)/$(NUM)) " 
 	@printf "$(RESET)$<\n"
 	@mkdir -p $(dir $@)
-	@$(CC) -I./src/ $< ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} -MM -MT $(@:.cc.d=.cc.o) -MF $@
+	$(QUIET)$(CC) -Wno-unused-command-line-argument -I./src/ $< ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} -MM -MT $(@:.cc.d=.cc.o) -MF $@
 
 obj/obj-$(POSTFIX)/IO/WriteMetaData.cpp.o: .FORCE ${AMREX_TARGET}
 	$(eval CTR=$(shell echo $$(($(CTR)+1))))
@@ -169,7 +166,7 @@ obj/obj-$(POSTFIX)/IO/WriteMetaData.cpp.o: .FORCE ${AMREX_TARGET}
 	@printf '%9s' "($(CTR)/$(NUM)) " 
 	@printf "$(RESET)${subst obj/obj-$(POSTFIX)/,src/,${@:.cpp.o=.cpp}} \n"
 	@mkdir -p $(dir $@)
-	@$(CC) -c ${subst obj/obj-$(POSTFIX)/,src/,${@:.cpp.o=.cpp}} -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
+	$(QUIET)$(CC) -c ${subst obj/obj-$(POSTFIX)/,src/,${@:.cpp.o=.cpp}} -o $@ ${ALAMO_INCLUDE} ${CXX_COMPILE_FLAGS} 
 
 .PHONY: .FORCE
 
@@ -199,10 +196,10 @@ test: .FORCE
 	@make docs
 	@./scripts/runtests.py
 
-GCDA = $(shell find obj/ -name "*.gcda" )
-GCNO = $(shell find obj/ -name "*.gcno" )
+GCDA = $(shell mkdir -p obj && find obj/ -name "*.gcda")
+GCNO = $(shell mkdir -p obj && find obj/ -name "*.gcno")
 
-GCDA_DIRS  = $(shell find obj/ -maxdepth 1 -name "*coverage*" )
+GCDA_DIRS  = $(shell mkdir -p obj && find obj/ -maxdepth 1 -name "*coverage*" )
 GCDA_DIMS  = $(subst obj-,,$(subst -coverage-g++,,$(notdir $(GCDA_DIRS))))
 GCDA_INFOS = $(subst obj-,cov/coverage_,$(subst -coverage-g++,.info,$(notdir $(GCDA_DIRS))))
 GCDA_LCOVS = $(subst obj-,--add-tracefile cov/coverage_,$(subst -coverage-g++,.info,$(notdir $(GCDA_DIRS))))

--- a/README.rst
+++ b/README.rst
@@ -53,14 +53,13 @@ If you are using a non-debian based system such as RedHat, you can install the c
 Windows and Mac OS are not supported.
 To configure and run Alamo on a high-performance computing (HPC) cluster, please see :ref:`install_hpc`.
 
-Setting MPICH as default MPI
-============================
+Setting the default MPI
+=======================
 
-Alamo and AMReX require either mpich or mvapich. 
-OpenMPI is not supported, but is often set as the default on Ubuntu systems.
-This can often happen after the installation of other packages, such as Paraview, and is not usually caught by the configure script.
-
-On Ubuntu, you can check to see whether openmpi is being used by the :code:`update-alternatives` command.
+Alamo can be compiled with either MPICH or OpenMPI.
+(mvapich2 is semi-supported but not regularly tested.)
+**MPICH currently does not work on Ubuntu 24.04**, so OpenMPI is now recommended.
+On Ubuntu, you can check to see which version of mpi is being used by the :code:`update-alternatives` command.
 
 .. code-block::
 
@@ -70,14 +69,14 @@ On Ubuntu, you can check to see whether openmpi is being used by the :code:`upda
     
       Selection    Path                    Priority   Status
     ------------------------------------------------------------
-    * 0            /usr/bin/mpicc.openmpi   50        auto mode
-      1            /usr/bin/mpicc.mpich     40        manual mode
+      0            /usr/bin/mpicc.openmpi   50        auto mode
+    * 1            /usr/bin/mpicc.mpich     40        manual mode
       2            /usr/bin/mpicc.openmpi   50        manual mode
     
     Press <enter> to keep the current choice[*], or type selection number:     
 
-In this case, mpich is installed along with openmpi, but openmpi has been set to the default.
-Here, you can just type 1 to set the selection to mpich.
+In this case, mpich is installed along with openmpi, but mpich is currently the default.
+You can press 0 to switch to openmpi.
 Do the same thing for :code:`mpirun`:
 
 .. code-block::
@@ -86,7 +85,7 @@ Do the same thing for :code:`mpirun`:
     
 Now your system should be properly configured.
 
-If you are using an HPC, it is easier to switch to mpich or mvapich using the :code:`module` command.
+If you are using an HPC, it is easier to switch between versions using the :code:`module` command.
 See the documentation for your specific platform to see how to load mpich or mvapich.    
 
 Configuring

--- a/configure
+++ b/configure
@@ -67,7 +67,7 @@ def message(title,message="",wrap_message=True):
     print(color.boldgreen + title.ljust(width) + color.reset,end="")
     if wrap_message: wrap(message)
     else: print(message)
-def shellmessage(title,cmd,env=None,message=None,hidecmd=False,cwd=None):
+def shellmessage(title,cmd,env=None,message=None,hidecmd=False,cwd=None,shell=False):
     print(color.boldgreen + title.ljust(width) + color.reset, end="")
     if message and hidecmd:
         print(message)
@@ -77,7 +77,9 @@ def shellmessage(title,cmd,env=None,message=None,hidecmd=False,cwd=None):
     elif not message and not hidecmd:
         print(code(cmd))
     
-    p = subprocess.run(cmd.split(' '),capture_output=True,cwd=cwd)
+    if not shell: cmd = cmd.split()
+    p = subprocess.run(cmd,shell=shell,capture_output=True,cwd=cwd)
+
     wrap(p.stdout.decode('ascii').replace('\n',' '),hanging=hidecmd,strcolor=color.lightblue)
     wrap(p.stderr.decode('ascii').replace('\n',' '),hanging=hidecmd,strcolor=color.blue)
     try:
@@ -108,8 +110,6 @@ parser.add_argument('--debug', dest='debug', action='store_true', help='Compile 
 parser.add_argument('--no-debug', dest='debug', action='store_false', help='[Compile in production mode]')
 parser.add_argument('--offline', dest='offline', action='store_true',default=False, help='[Compile in production mode]')
 parser.add_argument('--omp', dest='omp', action='store_true',default=False, help='Compile with OpenMP')
-parser.add_argument('--alternate-mpi', dest='alternate_mpi', action='store_true',default=False, help='Compile with an unsupported MPI library (only MPICH and MVAPICH are supported)')
-parser.add_argument('--python',dest='python',nargs='?',const=python_version,help='Compile python interface library')
 parser.add_argument('--docs',dest='docs',action='store_true',help='Check installation of packages for building documentation')
 parser.add_argument('--diff',dest='diff',default=False,action='store_true',help='Use diff2html to generate git diff reports')
 parser.add_argument('--macos',dest='macos',default=False,action='store_true',help='Compile without libpng (currently needed for macos)')
@@ -121,6 +121,7 @@ parser.add_argument('--create-gfortran-link',dest='gfortranln',action='store_tru
                     help="Create a link to the gfortran library. (Unless you are CircleCI, you should probably not do this!)")
 parser.add_argument('--link',default=None, nargs='+', help='Additional link paths')
 parser.add_argument('--no-comp-cmds',dest='compile_commands',default=False,action='store_true', help='Suppress generation of compile_commands.json for language servers like clangd')
+parser.add_argument('--verbose',default=False,action='store_true',help="Show full make commands - useful if encountering compile/link errors")
 parser.set_defaults(debug=False)
 
 #
@@ -152,11 +153,15 @@ if args.memcheck and args.memcheck_tool == "asan":
     print(mpich_minimum_version)
 
 
-fpic = args.python 
-
 subprocess.run(['mkdir','-p','.make'])
 f = open(".make/Makefile.pre.conf","w")
 f2 = open(".make/Makefile.post.conf","w")
+
+#
+# Specify verbosity of Makefile
+#
+if args.verbose:
+    f.write("QUIET = \n")
 
 #
 # Specify Postfix
@@ -167,7 +172,6 @@ if args.debug: postfix += "-debug"
 if args.memcheck:
     if args.memcheck_tool == "asan": postfix += "-asan"
     if args.memcheck_tool == "msan": postfix += "-msan"
-if fpic: postfix += "-fpic"
 if args.profile: postfix += "-profile"
 if args.coverage: postfix += "-coverage"
 postfix += "-" + args.comp
@@ -270,7 +274,6 @@ if args.buildamrex and not args.amrex:
     elif args.comp == "clang++": amrex_configure += ' --comp=llvm --allow-different-compiler=yes '
     elif args.comp == "icc":     amrex_configure += ' --comp=intel'
     if args.debug: amrex_configure += ' --debug=yes'
-    if fpic: amrex_configure += ' --enable-pic=yes'
     if args.profile: amrex_configure += ' --enable-tiny-profile=yes'
     
     message("AMReX-Configure",amrex_configure,False)
@@ -368,44 +371,14 @@ if args.link:
         f.write("LIB += -L" + l + "\n")
     
 #
-# Compiler and MPI library
+# CHECK COMPILER AND SET OPTIONS
 #
 if   (args.comp == "g++"):     f.write("COMP = GCC\n")
 elif (args.comp == "clang++"): f.write("COMP = CLANG\n")
 elif (args.comp == "icc"):     f.write("COMP = INTEL\n")
 else: raise Exception(color.red + "ERROR" + color.reset + ": Compiler must be g++, clang++, or icc")
-
-if not args.alternate_mpi:
-    if not shutil.which("mpichversion"):
-        raise Exception(color.red + "ERROR" + color.reset +
-            ": An MPICH or MVAPICH installation was not found, to compile with another MPI library please use " +
-            code("--alternate-mpi"))
-    message("Comp-Type", str(args.comp))
-    shellmessage("Comp-Version",args.comp+" --version")
-    compmpicmd = shellmessage("Comp-MPI","mpicxx -cxx="+args.comp+" -show")
-    mpichversionresult = shellmessage("MPICH:","mpichversion")
-    if args.memcheck_tool=="asan":
-        version_match_str = re.search(r"MPICH Version:\s*([\d.]+)", mpichversionresult.stdout.decode('ascii')).group(1)
-        version = [int(a) for a in version_match_str.split('.')]
-        minimum_version = [int(a) for a in mpich_minimum_version.split('.')]
-        if version<minimum_version:
-            raise Exception(error("MPICH version {} is less than required version {}".format(version_match_str, mpich_minimum_version)))
-        
-    shellmessage("MPICH mpicxx:","mpicxx -v")
-    f.write("CC = mpicxx -cxx="+args.comp+"\n")
-    f.write("MPI_LIB = -lmpich\n")
-else:
-    warning("Only mpich/mvapich mpi are supported. Use alternatives at your own risk.")
-    shellmessage("Compiler (" + args.comp + ")", args.comp + " -v")
-    shellmessage("MPI Library","mpiexec --version")
-
-    env = os.environ.copy()
-    env.update({'MPICH_CXX': args.comp, 'OMPI_CXX': args.comp, 'I_MPI_CXX': args.comp})
-    shellmessage("MPI Compiling Line", "mpicxx -show", env)
-
-    backend_comp = " MPICH_CXX=" + args.comp + " OMPI_CXX=" + args.comp + " I_MPI_CXX=" + args.comp + " "
-    f.write("CC =" + backend_comp + "mpicxx\n")
-
+message("Comp-Type", str(args.comp))
+shellmessage("Comp-Version",args.comp+" --version")
 if args.comp == 'g++':
     f.write("MPI_LIB += -lgfortran\n")
     f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
@@ -432,46 +405,80 @@ if args.comp == 'clang++':
 if args.comp == 'icc':
     f.write("MPI_LIB += -lifcore\n")
     if args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
-    else:          f.write("CXX_COMPILE_FLAGS += -Ofast -ipo\n") # -inline-forceinline
+    else:          f.write("CXX_COMPILE_FLAGS += -Ofast -ipo\n") # 
+
 
 #
-# LibGFortran? -- not needed anymore
+# CHECK MPI DISTRIBUTION AND SET OPTIONS
 #
-#if args.gfortranln:
-#    shellmessage("Gfort Link","ln -s /usr/lib/x86_64-linux-gnu/libgfortran.so.4 /usr/lib/libgfortran.so")
-#run = subprocess.run(['ld','-lgfortran'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-#if run.returncode:
-#    warning("Could not find -lgfortran, which will probably cause linking errors. You can try running " 
-#            + code("ln -s /usr/lib/x86_64-linux-gnu/libgfortran.so.4 /usr/lib/libgfortran.so"))
-#subprocess.run(['rm','a.out','-rf'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
 
-#
-# Python information
-#
-if args.python:
-    if os.path.isdir("/usr/include/python"+str(args.python)+"/"):
-        python_include_dir = "/usr/include/python"+str(args.python)+"/"
-    elif os.path.isdir("/usr/include/python"+str(args.python)+"m/"):
-        python_include_dir = "/usr/include/python"+str(args.python)+"m/"
-    else:
-        message("Py incl. dirs",' '.join(glob.glob(("/usr/include/python*"))))
-        raise Exception(error("Python include directory does not exist. Version may be incorrect, or you may need to install using either" 
-                        + code("sudo apt install python3-dev") + " or " + code("sudo apt install python-dev")))
+p = shellmessage("MPI","mpicxx -show")
+mpidiststr = p.stdout.decode('utf-8').replace('\n','')
 
-    #if ctypes.util.find_library("boost_python-py"+args.python.replace(".","")):
-    #    python_boost_lib = "-lboost_python-py"+str(args.python).replace(".","")
-    #elif ctypes.util.find_library("boost_python3-py"+args.python.replace(".","")):
-    #    python_boost_lib = "-lboost_python3-py"+str(args.python).replace(".","")
-    #else:
-    #    raise Exception(error("Cannot find python boost lib. Install using " + code("sudo apt install libboost-python-dev")))
-    
-    f.write("PYTHON_INCLUDE = -I" + python_include_dir + '\n')
-    f.write("PYTHON_LIB = " + python_boost_lib + '\n')
-    f.write("CXX_COMPILE_FLAGS += -fPIC \n")
-    message("Python","True")
-    message("Pythin include dir:",python_include_dir)
-    message("Pythin boost lib:",python_boost_lib)
-    note("Be sure to add " + code("USE_COMPILE_PIC=True") + " to the AMReX GNUMakefile")
+mpidist = None
+if "mpich" in mpidiststr.lower():
+    mpidist = "mpich"
+elif "mvapich2" in mpidiststr.lower():
+    mpidist = "mvapich2"
+elif "mvapich" in mpidiststr.lower():
+    mpidist = "mvapich"
+elif "openmpi" in mpidiststr.lower():
+    mpidist = "openmpi"
+message("mpi implementation", mpidist)
+
+if mpidist == "openmpi":
+    compmpicmd = shellmessage("openmpi comp flags", "mpicxx --showme:compiler").stdout.decode('utf-8').replace('\n','')
+    compmpicmd = args.comp + " " + compmpicmd
+    shellmessage("openmpi c++ link"   , "mpicxx --showme:link".format(args.comp))
+    shellmessage("openmpi fort link"   , "mpifort --showme:link".format(args.comp))
+    shellmessage("openmpi version", "mpicxx --showme:version")
+    env = os.environ.copy()
+    env.update({'OMPI_CXX': args.comp})
+
+    mpicomp = shellmessage("openmpi cxx default", "mpicxx --showme:command").stdout.decode('utf-8').replace('\n','')
+    ompicc = f"export OMPI_CXX={args.comp} && mpicxx"
+    shellmessage("openmpi cxx used",f"{ompicc} --version",shell=True)
+    f.write(f"CC = {ompicc} \n")
+
+    p = shellmessage("openmpi mpiexec", "mpiexec --version")
+    pexecversion = p.stdout.decode('utf-8').replace('\n','').lower()
+
+    if ("openmpi" not in pexecversion and
+        "open mpi" not in pexecversion and
+        "openrte" not in pexecversion and
+        "open-mpi" not in pexecversion):
+        warning("Your mpiexec seems inconsistent with your mpicxx!!!")
+    if ("mpich" in pexecversion):
+        error("In fact, it seems as though your mpiexec is part of mpich "+
+              "instead of openmpi. Please fix before attempting to run.")
+
+elif mpidist == "mpich":
+    if not shutil.which("mpichversion"):
+        raise Exception(color.red + "ERROR" + color.reset +
+            ": An MPICH or MVAPICH installation was not found, to compile "+
+            "with another MPI library please use " +
+            code("--alternate-mpi"))
+    compmpicmd = shellmessage("mpich comp","mpicxx -cxx="+args.comp+" -show").stdout.decode('utf-8').replace('\n','')
+    mpichversionresult = shellmessage("MPICH:","mpichversion")
+    if args.memcheck_tool=="asan":
+        version_match_str = re.search(r"MPICH Version:\s*([\d.]+)", mpichversionresult.stdout.decode('ascii')).group(1)
+        version = [int(a) for a in version_match_str.split('.')]
+        minimum_version = [int(a) for a in mpich_minimum_version.split('.')]
+        if version<minimum_version:
+            raise Exception(error("MPICH version {} is less than required version {}".format(version_match_str, mpich_minimum_version)))
+        
+    shellmessage("mpich mpicxx:","mpicxx -v")
+    f.write("CC = mpicxx -cxx="+args.comp+"\n")
+    f.write("MPI_LIB = -lmpich\n")
+
+    p = shellmessage("mpich mpiexec", "mpiexec --version")
+    if "mpich" not in p.stdout.decode('utf-8').replace('\n',''):
+        warning("Your mpiexec seems inconsistent with your mpicxx!!!")
+else:
+    f.write("CC = mpicxx -cxx="+args.comp+"\n")
+    f.write("MPI_LIB = -lmpich\n")
+    warning("We haven't tested "+mpidist+" yet. Attempting to add the proper compile " +
+            "flags but no guarantees.")
 
 #
 # DIFF
@@ -493,20 +500,6 @@ f2.write("\t-@mkdir -p .diff\n".format(postfix))
 f2.write("\t-@rm -rf .diff/{}.diff.patch\n".format(postfix))
 f2.write("\t-@git diff > .diff/{}.diff.patch\n".format(postfix))
 
-#
-# JIT expression evaluation with Libmesh's FParser
-#
-# TODO: This part here is not done yet. Still need to generalize for
-#       arbitrary user libmesh install path.
-# https://mooseframework.inl.gov/modules/phase_field/FunctionMaterials/JITCompilation.html
-#
-#if args.libmesh:
-#    if not os.path.isfile(args.libmesh+'/lib/libmesh_opt.so'):
-#        raise Exception(error("{}/lib/libmesh_opt.so not found. libmesh path must contain lib/libmesh_opt.so".format(args.libmesh)))
-#    f.write('ALAMO_INCLUDE += -I{}/include/\n'.format(args.libmesh))
-#    f.write('LIB     +=   {}/lib/libmesh_opt.so -Wl,-rpath,{}/lib/ \n'.format(args.libmesh,args.libmesh))
-#if args.jit:
-#    f.write('CXX_COMPILE_FLAGS += -DALAMO_JIT\n')
 
 #
 # Documentation check
@@ -543,7 +536,7 @@ if not args.compile_commands:
 
     projectdir = os.getcwd()
 
-    cc = compmpicmd.stdout.decode('utf-8').replace('\n','')
+    cc = compmpicmd
     command_objects = []
     command_objects = [{
         "directory": projectdir,

--- a/configure
+++ b/configure
@@ -379,33 +379,6 @@ elif (args.comp == "icc"):     f.write("COMP = INTEL\n")
 else: raise Exception(color.red + "ERROR" + color.reset + ": Compiler must be g++, clang++, or icc")
 message("Comp-Type", str(args.comp))
 shellmessage("Comp-Version",args.comp+" --version")
-if args.comp == 'g++':
-    f.write("MPI_LIB += -lgfortran\n")
-    f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
-    if args.coverage: f.write("LINKER_FLAGS += -fprofile-arcs\n")
-
-    if args.memcheck:
-        if args.memcheck_tool=="asan":
-            f.write("CXX_COMPILE_FLAGS += -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope\n")
-            f.write("LINKER_FLAGS += -fsanitize=address -static-libasan\n")
-        elif args.memcheck_tool=="msan":
-            f.write("CXX_COMPILE_FLAGS += -fsanitize=memory -fno-omit-frame-pointer\n")
-            f.write("LINKER_FLAGS += -fsanitize=memory\n")
-        else:
-            error("Invalid memory check tool ", args.memcheck_tool)
-    if args.coverage and args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3 -fprofile-arcs -ftest-coverage\n")
-    elif args.debug:                 f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
-    elif args.coverage:              f.write("CXX_COMPILE_FLAGS += -fprofile-arcs -ftest-coverage\n")
-    else:                            f.write("CXX_COMPILE_FLAGS += -O3 -flto\n")
-if args.comp == 'clang++':
-    f.write("MPI_LIB += -lgfortran\n")
-    f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
-    if args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
-    else:          f.write("CXX_COMPILE_FLAGS += -O3\n")
-if args.comp == 'icc':
-    f.write("MPI_LIB += -lifcore\n")
-    if args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
-    else:          f.write("CXX_COMPILE_FLAGS += -Ofast -ipo\n") # 
 
 
 #
@@ -479,6 +452,41 @@ else:
     f.write("MPI_LIB = -lmpich\n")
     warning("We haven't tested "+mpidist+" yet. Attempting to add the proper compile " +
             "flags but no guarantees.")
+
+
+#
+# ADD NECESSARY COMPILER-SPECIFIC MPI FLAGS
+#   note: this must come after the MPI section, otherwise the order of
+#         flags may cause linker to fail!
+#
+if args.comp == 'g++':
+    f.write("MPI_LIB += -lgfortran\n")
+    f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
+    if args.coverage: f.write("LINKER_FLAGS += -fprofile-arcs\n")
+    if args.memcheck:
+        if args.memcheck_tool=="asan":
+            f.write("CXX_COMPILE_FLAGS += -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope\n")
+            f.write("LINKER_FLAGS += -fsanitize=address -static-libasan\n")
+        elif args.memcheck_tool=="msan":
+            f.write("CXX_COMPILE_FLAGS += -fsanitize=memory -fno-omit-frame-pointer\n")
+            f.write("LINKER_FLAGS += -fsanitize=memory\n")
+        else:
+            error("Invalid memory check tool ", args.memcheck_tool)
+    if args.coverage and args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3 -fprofile-arcs -ftest-coverage\n")
+    elif args.debug:                 f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
+    elif args.coverage:              f.write("CXX_COMPILE_FLAGS += -fprofile-arcs -ftest-coverage\n")
+    else:                            f.write("CXX_COMPILE_FLAGS += -O3 -flto\n")
+if args.comp == 'clang++':
+    f.write("MPI_LIB += -lgfortran\n")
+    f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
+    if args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
+    else:          f.write("CXX_COMPILE_FLAGS += -O3\n")
+if args.comp == 'icc':
+    f.write("MPI_LIB += -lifcore\n")
+    if args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
+    else:          f.write("CXX_COMPILE_FLAGS += -Ofast -ipo\n") # 
+
+
 
 #
 # DIFF

--- a/docs/source/Install/Ubuntu.rst
+++ b/docs/source/Install/Ubuntu.rst
@@ -20,13 +20,17 @@ Install dependencies
 
 .. tab-set::
 
-    .. tab-item:: 24.04
+    .. tab-item:: :fab:`ubuntu;fa-b` 24.04 LTS
+
+       MPICH does not currently work on 24.04, so OpenMPI is used instead.
+       If you already have multiple versions of MPI installed, 
+       see :ref:`Setting the default MPI` to set the correct one.
 
         .. literalinclude:: ../../../.github/workflows/dependencies-ubuntu-24.04.sh
            :language: bash
            :lines: 2-
 
-    .. tab-item:: 22.04
+    .. tab-item:: :fab:`ubuntu;fa-b` 22.04 LTS
 
         .. literalinclude:: ../../../.github/workflows/dependencies-ubuntu-22.04.sh
            :language: bash

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -102,6 +102,7 @@ parser.add_argument('--permissive', dest='permissive', default=False, action='st
 parser.add_argument('--permit-timeout', dest='permit_timeout', default=False, action='store_true', help='Permit timeouts without failing')
 parser.add_argument('--no-backspace',default=False,dest="no_backspace",action='store_true',help="Avoid using backspace (For GH actions)")
 parser.add_argument('--check-mpi',default=False,dest="check_mpi",action='store_true',help="Check if MPI is running correctly")
+parser.add_argument('--mpirun-flags',dest="mpirun_flags",default="",help="Extra arguments to pass to mpirun (like --oversubscribe). All arguments must be in a string.")
 args=parser.parse_args()
 
 if args.coverage and args.no_coverage:
@@ -262,7 +263,7 @@ def test(testdir):
             if nprocs > 1 and args.serial: 
                 continue
             # If not running in serial, specify mpirun command
-            if nprocs > 1: command += "mpirun -np {} ".format(nprocs)
+            if nprocs > 1: command += f"mpirun {args.mpirun_flags} -np {nprocs} "
             # Specify alamo command.
             
             exestr = "./bin/{}-{}d".format(exe,dim)

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -101,6 +101,7 @@ parser.add_argument('--no-clean', dest='clean', default=False, action='store_fal
 parser.add_argument('--permissive', dest='permissive', default=False, action='store_true', help='Option to run without erroring out (if at all possible)')
 parser.add_argument('--permit-timeout', dest='permit_timeout', default=False, action='store_true', help='Permit timeouts without failing')
 parser.add_argument('--no-backspace',default=False,dest="no_backspace",action='store_true',help="Avoid using backspace (For GH actions)")
+parser.add_argument('--check-mpi',default=False,dest="check_mpi",action='store_true',help="Check if MPI is running correctly")
 args=parser.parse_args()
 
 if args.coverage and args.no_coverage:
@@ -357,6 +358,18 @@ def test(testdir):
             stdout, stderr = proc.communicate(timeout=timeout)
             retcode = proc.returncode
             if retcode: raise subprocess.CalledProcessError(retcode, proc.args, output=stdout, stderr=stderr)
+
+            if args.check_mpi:
+                pattern = r"MPI initialized with (\d+) MPI processes"
+                match = re.search(pattern, stdout.decode('utf-8'))
+                if match:
+                    actual_nprocs = int(match.group(1))
+                    if nprocs != actual_nprocs:
+                        raise subprocess.CalledProcessError(retcode, proc.args, output=stdout,
+                                                            stderr=f"MPI is not working: should run with {nprocs} procs but is running with {actual_nprocs}!".encode('utf-8'))
+                else:
+                    raise subprocess.CalledProcessError(retcode, proc.args, output=stdout,
+                                                        stderr=f"Could not tell if MPI is working!".encode('utf-8'))
 
             executionTime = time.time() - timeStarted
             record['executionTime'] = str(executionTime)

--- a/tests/Unit/input
+++ b/tests/Unit/input
@@ -3,8 +3,19 @@
 #@ dim=2
 #@ check=false
 #@
+#@ [2d-parallel]
+#@ exe=test
+#@ dim=2
+#@ check=false
+#@ nprocs=4
+#@
 #@ [3d]
 #@ exe=test
 #@ dim=3
 #@ check=false
 #@
+#@ [3d-parallel]
+#@ exe=test
+#@ dim=3
+#@ check=false
+#@ nprocs=4


### PR DESCRIPTION
This PR improves support for openmpi to address https://github.com/solidsgroup/alamo/issues/127: 
- updated configure script to set proper options for openmpi as well as mpich

Additional relevant changes in this PR:
- add a "check-mpi" option to the regression test script to see whether MPI was started properly 
- add a "check parallelism" check in CI to fail if MPI is not started correctly
- updated documentation

Some other changes in this PR:
- added `--verbose` option to configure script causing make to show full compilation command for debugging
- fixed the "cannot find ./obj" warning
- removed the deprecated `--python` option from the configure script
- removed old commented-out code from the configure script
