### PR TITLE
add pyproject.toml to Alamo to support Python LSPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ compile_commands.json
 .python-version
 .clangd
 .DS_Store
+.pyright-override.toml

--- a/configure
+++ b/configure
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 import argparse
+import json
 import os
 import re
-import subprocess
-import textwrap
-import sys
 import shutil
-#import ctypes.util
-import glob
-import json
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
+from typing import Tuple
 
 #
 # Configuration parameters, mainly to specify default values:
@@ -19,12 +18,6 @@ from pathlib import Path
 amrex_current_version = "25.03"
 # Required minimum mpich version - ignore unless using ASan
 mpich_minimum_version = "0.0.0"
-# Python versions
-python_minimum_major = 3
-python_minimum_minor = 5
-
-
-python_version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
 
 class color:
     reset = "\033[0m"
@@ -92,7 +85,51 @@ def shellmessage(title,cmd,env=None,message=None,hidecmd=False,cwd=None,shell=Fa
         raise e
     return p
 
-message("Python",python_version)
+def get_requires_python_version(pyproject_path: Path = Path("pyproject.toml")) -> Tuple[int, int]:
+    """Gets the required Python version from the pyproject.toml.
+
+    This uses a regex because TOML support wasn't added to the standard
+    library until Python 3.11 and we need to support Python >= 3.7. If
+    we increase the minimum Python version to >= 3.11, we can replace
+    this functionality using the much more Pythonic `toml` library.
+
+    Parameters
+    ----------
+    pyproject_path
+        Path to the `pyproject.toml`.
+
+    Returns
+    -------
+    Tuple[int, int]
+        The (<major version, <minor version>).
+
+    Raises
+    ------
+    ValueError
+        If `requires-python` cannot be parsed from `pyproject.toml`.
+    """
+    with open(pyproject_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    match = re.search(r'requires-python\s*=\s*["\']([^"\']+)["\']', content)
+    if not match:
+        raise ValueError("Could not find 'requires-python' in pyproject.toml.")
+
+    requires_python = match.group(1)
+    versions = re.findall(r'(\d+)\.(\d+)', requires_python)
+
+    if not versions:
+        raise ValueError(f"Invalid 'requires-python' format: {requires_python}")
+    
+    major, minor = map(int, versions[0])
+    assert isinstance(major, int) and isinstance(minor, int)
+
+    return major, minor
+
+python_minimum_major, python_minimum_minor = get_requires_python_version() 
+message("Requires Python", f">= {python_minimum_major}.{python_minimum_minor}")
+message("System Python", f"{sys.version_info.major}.{sys.version_info.minor}")
+
 if sys.version_info.major < python_minimum_major or sys.version_info.minor < python_minimum_minor:
     raise Exception(error("You need Python {}.{} or greater".format(python_minimum_major,python_minimum_minor)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,6 @@
+[project]
+requires-python = ">= 3.7"
+
 [tool.pyright]
-exclude = [
-    "LICENSE",
-    "Makefile",
-    "README.rst",
-    "bin",
-    "compile_commands.json",
-    "ext",
-    "pyproject.toml",
-    "src",
-]
 extends = ".pyright-override.toml"
 pythonVersion = "3.7"
-
-[tool.ruff]
-target-version = "py37"
-exclude = [
-    "LICENSE",
-    "Makefile",
-    "README.rst",
-    "bin",
-    "compile_commands.json",
-    "ext",
-    "pyproject.toml",
-    "src",
-]
-line-length = 79
-
-[tool.ruff.format]
-preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.pyright]
+exclude = [
+    "LICENSE",
+    "Makefile",
+    "README.rst",
+    "bin",
+    "compile_commands.json",
+    "ext",
+    "pyproject.toml",
+    "src",
+]
+extends = ".pyright-override.toml"
+pythonVersion = "3.7"
+
+[tool.ruff]
+target-version = "py37"
+exclude = [
+    "LICENSE",
+    "Makefile",
+    "README.rst",
+    "bin",
+    "compile_commands.json",
+    "ext",
+    "pyproject.toml",
+    "src",
+]
+line-length = 79
+
+[tool.ruff.format]
+preview = true


### PR DESCRIPTION
* Adds a minimal `pyproject.toml` that simply defines the minimum supported Python version and configures `pyright`, a Python LSP server
  * I recommend we use [`pyright`](https://github.com/microsoft/pyright) as the "supported" Python LSP server.
    * In addition to all the LSP things an LSP server does, `pyright` also supports basic and strict type checking out of the box—which can prevent many of the most frequent Python bugs
  * I recommend we use [`ruff`](https://github.com/astral-sh/ruff) as the "supported" Python linter and formatter.
    * `ruff` is an opinionated linter and formatter. It's incredibly customizable; we can disable or enable any of their [many, many rules](https://docs.astral.sh/ruff/rules/).
    * `ruff` does an even better job than `pyright` at statically linting code.
  * Both tools are incredibly mature, relatively easy to install. They both integrate well with Vim, Neovim, Emacs, and VS Code.
  * Importantly, both tools are completely optional and are **not** a required developer dependency.
    * In the future, we could trivially add `pyright` and `ruff` checks into CI, but this is optional.
* Refactors `configure` to pull the minimum supported Python version from `pyproject.toml`.
* **This PR increases the minimum supported Python version to Python 3.7**
  * The initial release of Ubuntu 20.04 came pre-installed with Python 3.8; so, this shouldn't break any user experience
  * Ruff only supports Python 3.7 and later.
* **These changes do not necessitate immediate sweeping overhauls of the Python code.**
  * For those using these tools, they will likely see many warnings and errors, but these can be temporarily disabled or fixed at a later date.

`ruff` and `pyright` ship with sensible defaults out of the box, but we can obviously tweak and modify the rulesets as necessary. @bsrunnels, I wanted to put this on your radar so you could experiment if you wanted and see if this was something you wanted to move forward with. I'll be using these tools regardless of whether we officially support them.