### PR TITLE
Add .pyright-override.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ ext/
 compile_commands.json
 .cache/
 .python-version
+.pyright-override.toml
 .clangd
 .DS_Store


### PR DESCRIPTION
* I use pyright as an LSP and I have to specify the path to my Python virtualenv in `.pyright-override.toml`—which should not be included in any scenario in the git repository as it specifies user specific settings for Pyright.