### PR TITLE
Performance improvement for Hydro and Flame

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -20,7 +20,7 @@ jobs:
       run: ./configure --dim=2
     - name: make 2d
       continue-on-error: true
-      run: make
+      run: make -j8
     - name: unit tests 2d
       continue-on-error: true
       run: ./bin/test-2d-g++
@@ -29,7 +29,7 @@ jobs:
       run: ./configure --dim=3
     - name: make 3d
       continue-on-error: true
-      run: make
+      run: make -j8
     - name: unit tests 3d
       continue-on-error: true
       run: ./bin/test-3d-g++

--- a/src/Integrator/Flame.H
+++ b/src/Integrator/Flame.H
@@ -60,11 +60,9 @@ private:
     Set::Field<Set::Scalar> temp_mf;
     Set::Field<Set::Scalar> temp_old_mf;
     Set::Field<Set::Scalar> temps_mf;
-    Set::Field<Set::Scalar> temps_old_mf;
 
     Set::Field<Set::Scalar> eta_mf;
     Set::Field<Set::Scalar> eta_old_mf;
-    Set::Field<Set::Scalar> mob_mf;
     Set::Field<Set::Scalar> mdot_mf;
 
     Set::Field<Set::Scalar> phi_mf;

--- a/src/Integrator/Flame.H
+++ b/src/Integrator/Flame.H
@@ -123,7 +123,6 @@ private:
         Set::Scalar pressure = NAN;
     } chamber;
 
-    BC::BC<Set::Scalar>* bc_psi = nullptr;
 
     // Propellant model
     Model::Propellant::Propellant<

--- a/src/Integrator/Flame.cpp
+++ b/src/Integrator/Flame.cpp
@@ -188,7 +188,7 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
     pp.select_default<IC::PSRead,IC::Laminate,IC::Expression,IC::Constant,IC::BMP,IC::PNG>
         ("phi.ic",value.ic_phi,value.geom);
 
-    value.RegisterNodalFab(value.phi_mf, 1, 3, "phi", true);
+    value.RegisterNodalFab(value.phi_mf, 1, 2, "phi", true);
 
     // Whether to use Neo-hookean Elastic model
     pp_query_default("elastic.on", value.elastic.on, 0); 

--- a/src/Integrator/Flame.cpp
+++ b/src/Integrator/Flame.cpp
@@ -144,14 +144,12 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
             
         value.RegisterNewFab(value.temp_mf, value.bc_temp, 1, 3, "temp", true);
         value.RegisterNewFab(value.temp_old_mf, value.bc_temp, 1, 3, "temp_old", false);
-        value.RegisterNewFab(value.temps_mf, value.bc_temp, 1, 3, "temps", false);
-        value.RegisterNewFab(value.temps_old_mf, value.bc_temp, 1, 3, "temps_old", false);
+        value.RegisterNewFab(value.temps_mf, value.bc_temp, 1, 0, "temps", false);
 
-        value.RegisterNewFab(value.mdot_mf, value.bc_temp, 1, 3, "mdot", value.plot_field);
-        value.RegisterNewFab(value.mob_mf, value.bc_temp, 1, 3, "mob", value.plot_field);
-        value.RegisterNewFab(value.alpha_mf, value.bc_temp, 1, 3, "alpha", value.plot_field);
-        value.RegisterNewFab(value.heatflux_mf, value.bc_temp, 1, 3, "heatflux", value.plot_field);
-        value.RegisterNewFab(value.laser_mf, value.bc_temp, 1, 3, "laser", value.plot_field);
+        value.RegisterNewFab(value.mdot_mf, value.bc_temp, 1, 0, "mdot", value.plot_field);
+        value.RegisterNewFab(value.alpha_mf, value.bc_temp, 1, 0, "alpha", value.plot_field);
+        value.RegisterNewFab(value.heatflux_mf, value.bc_temp, 1, 0, "heatflux", value.plot_field);
+        value.RegisterNewFab(value.laser_mf, value.bc_temp, 1, 0, "laser", value.plot_field);
 
         value.RegisterIntegratedVariable(&value.chamber.volume, "volume");
         value.RegisterIntegratedVariable(&value.chamber.area, "area");
@@ -250,17 +248,14 @@ void Flame::Initialize(int lev)
             thermal.ic_temp->Initialize(lev,temp_mf);
             thermal.ic_temp->Initialize(lev,temp_old_mf);
             thermal.ic_temp->Initialize(lev,temps_mf);
-            thermal.ic_temp->Initialize(lev,temps_old_mf);
         }
         else
         {
             temp_mf[lev]->setVal(thermal.Tref);
             temp_old_mf[lev]->setVal(thermal.Tref);
             temps_mf[lev]->setVal(thermal.Tref);
-            temps_old_mf[lev]->setVal(thermal.Tref);
         }
         alpha_mf[lev]->setVal(0.0);
-        mob_mf[lev]->setVal(0.0);
         mdot_mf[lev]->setVal(0.0);
         heatflux_mf[lev]->setVal(0.0);
         thermal.w1 = 0.2 * chamber.pressure + 0.9;
@@ -472,17 +467,18 @@ void Flame::Advance(int lev, Set::Scalar time, Set::Scalar dt)
     if (thermal.on)
     {
         std::swap(temp_old_mf[lev], temp_mf[lev]);
-        std::swap(temps_old_mf[lev], temps_mf[lev]);
 
         for (amrex::MFIter mfi(*eta_mf[lev], true); mfi.isValid(); ++mfi)
         {
             const amrex::Box& bx = mfi.tilebox();
 
             Set::Patch<Set::Scalar>       tempnew = temp_mf.Patch(lev,mfi);
-            Set::Patch<Set::Scalar>       tempsnew = temps_mf.Patch(lev,mfi);
             Set::Patch<const Set::Scalar> temp = temp_old_mf.Patch(lev,mfi);
             Set::Patch<const Set::Scalar> alpha = alpha_mf.Patch(lev,mfi);
-            Set::Patch<const Set::Scalar> temps = temps_old_mf.Patch(lev,mfi);
+
+            Set::Patch<Set::Scalar>       temps = temps_mf.Patch(lev,mfi);
+
+
             // Phase field
             Set::Patch<Set::Scalar>       etanew = (*eta_mf[lev]).array(mfi);
             Set::Patch<const Set::Scalar> eta = (*eta_old_mf[lev]).array(mfi);
@@ -504,9 +500,8 @@ void Flame::Advance(int lev, Set::Scalar time, Set::Scalar dt)
                 dTdt += alpha(i, j, k) * heatflux(i, j, k) * grad_eta_mag;
 
                 Set::Scalar Tsolid = dTdt + temps(i, j, k) * (etanew(i, j, k) - eta(i, j, k)) / dt;
-                tempsnew(i, j, k) = temps(i, j, k) + dt * Tsolid;
-                tempnew(i, j, k) = etanew(i, j, k) * tempsnew(i, j, k) + (1.0 - etanew(i, j, k)) * thermal.Tfluid;
-
+                temps(i, j, k) = temps(i, j, k) + dt * Tsolid;
+                tempnew(i, j, k) = etanew(i, j, k) * temps(i, j, k) + (1.0 - etanew(i, j, k)) * thermal.Tfluid;
             });
         }
     }

--- a/src/Integrator/Flame.cpp
+++ b/src/Integrator/Flame.cpp
@@ -211,9 +211,9 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
         // elastic model of HTPB
         pp.queryclass<Model::Solid::Finite::NeoHookeanPredeformed>("model_htpb", value.elastic.model_htpb);
 
-        value.bc_psi = new BC::Nothing();
-        value.RegisterNewFab(value.psi_mf, value.bc_psi, 1, 2, "psi", value.plot_psi);
-        value.psi_on = true;
+        // Use our current eta field as the psi field for the solver
+        value.psi_on = false;
+        value.solver.setPsi(value.eta_mf);
     }
 
     bool allow_unused;
@@ -239,7 +239,6 @@ void Flame::Initialize(int lev)
     //ic_phicell->Initialize(lev, phicell_mf);
 
     if (elastic.on) {
-        psi_mf[lev]->setVal(1.0);
         rhs_mf[lev]->setVal(Set::Vector::Zero());
     }
     if (thermal.on) {
@@ -327,8 +326,6 @@ void Flame::UpdateModel(int /*a_step*/, Set::Scalar /*a_time*/)
         }
         Util::RealFillBoundary(*model_mf[lev], geom[lev]);
 
-        psi_mf[lev]->setVal(1.0);
-        amrex::MultiFab::Copy(*psi_mf[lev], *eta_mf[lev], 0, 0, 1, psi_mf[lev]->nGrow());
     }
 }
 

--- a/src/Solver/Local/Riemann/Roe.H
+++ b/src/Solver/Local/Riemann/Roe.H
@@ -91,6 +91,8 @@ public:
         Set::Scalar h_RL    = (std::sqrt(rho_L) * h_TL + std::sqrt(rho_R) * h_TR) / (std::sqrt(rho_L) + std::sqrt(rho_R) + small);
         Set::Scalar a_RL_sq = std::max(0.0,(gamma - 1.0) * (h_RL - 0.5 * u_RL * u_RL));
 
+
+#ifdef AMREX_DEBUG
         if (verbose && ((a_RL_sq<0) || (a_RL_sq!=a_RL_sq)))
         {   
             Util::Message(INFO, "sound speed ", a_RL_sq);
@@ -112,6 +114,7 @@ public:
         }
         Util::AssertException(INFO,TEST(a_RL_sq==a_RL_sq)," a_RL_sq is nan/inf; (a_RL_sq=", a_RL_sq,")");
         Util::AssertException(INFO,TEST(a_RL_sq>=0),      " a_RL_sq is negative; (a_RL_sq=(",a_RL_sq,")");
+#endif
 
         Set::Scalar a_RL = std::sqrt(a_RL_sq) + small;
 


### PR DESCRIPTION
Performance enhancements for `Hydro` and `Flame`:

For `Hydro`:
- eliminate excess `Assert` statements in `Roe` solver

For `Flame`:
- eliminate unneeded fields like `mob` 
- reduce the number of ghost nodes/cells
- eliminate the `psi` field, point to `eta` instead.

Other:
- updating the `performance` test to use multiple cores when compiling. 