### PR TITLE
added 'make lib' option and added PIC to all debug compiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ compile_commands.json
 profile.prof*
 report*.html
 report.tar.gz
+alamo.egg-info
+alamo
+setup.py
+

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ FG_LIGHTBLUE       = \033[94m
 FG_CYAN            = \033[36m
 FG_MAGENTA         = \033[35m
 
+FG_ORANGE          = \033[38;5;208m
 
 
 
@@ -47,7 +48,7 @@ LINKER_FLAGS += -Bsymbolic-functions -lstdc++fs
 
 
 ALAMO_INCLUDE += $(if ${EIGEN}, -isystem ${EIGEN})  $(if ${AMREX}, -isystem ${AMREX}/include/) -I./src/ $(for pth in ${CPLUS_INCLUDE_PATH}; do echo -I"$pth"; done)
-LIB     += -L${AMREX}/lib/ -lamrex -lpthread
+LIB     += ${AMREX}/lib/libamrex.a -lpthread
 
 HDR_ALL = $(shell find src/ -name *.H)
 HDR_TEST = $(shell find src/ -name *Test.H)
@@ -104,6 +105,9 @@ realclean: clean
 	@printf "$(B_ON)$(FG_RED)CLEANING OLD CONFIGURATIONS $(RESET)\n" 
 	rm -rf Makefile.conf Makefile.amrex.conf .make
 
+lib: lib/libalamo-$(POSTFIX).so ${AMREX}/lib/libamrex.so
+	@printf $(POSTFIX)
+
 
 info:
 	@printf "$(B_ON)$(FG_BLUE)Compiler version information$(RESET)\n"
@@ -120,6 +124,7 @@ bin/%-$(POSTFIX): ${OBJ_F} ${OBJ} obj/obj-$(POSTFIX)/%.cc.o
 	@printf "$(RESET)$@\n"
 	@mkdir -p bin/
 	$(QUIET)$(CC) -o $@ $^ ${LIB}  ${MPI_LIB}  ${LINKER_FLAGS}
+
 
 obj/obj-$(POSTFIX)/test.cc.o: src/test.cc ${AMREX_TARGET}
 	$(eval CTR=$(shell echo $$(($(CTR)+1))))
@@ -223,6 +228,15 @@ cov/coverage_merged.info: $(GCDA_INFOS)
 cov/coverage_%.info: obj/obj-%-coverage-g++/ $(GCDA)
 	mkdir -p ./cov/
 	geninfo $< -b . -o $@ --exclude "/usr/*" --exclude "ext/*"
+
+lib/libalamo-$(POSTFIX).so: ${OBJ} 
+	@printf "$(B_ON)$(FG_ORANGE)LIBALAMO$(RESET)             $@\n" 	
+	$(QUIET)mkdir -p lib
+	$(QUIET)$(CC) -shared -fPIC -o $@ $^
+
+${AMREX}/lib/libamrex.so : ${AMREX}/lib/libamrex.a
+	@printf "$(B_ON)$(FG_ORANGE)LIBAMREX$(RESET)             $@\n" 	
+	$(QUIET)$(CC) -shared -fPIC -o $@ -Wl,--whole-archive $< -Wl,--no-whole-archive
 
 githubpages: docs cov-report
 	mkdir -p ./githubpages/

--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,11 @@ realclean: clean
 	@printf "$(B_ON)$(FG_RED)CLEANING OLD CONFIGURATIONS $(RESET)\n" 
 	rm -rf Makefile.conf Makefile.amrex.conf .make
 
+py: lib
+	python3 ./scripts/make_alamo_package.py
+
 lib: lib/libalamo-$(POSTFIX).so ${AMREX}/lib/libamrex.so
 	@printf $(POSTFIX)
-
 
 info:
 	@printf "$(B_ON)$(FG_BLUE)Compiler version information$(RESET)\n"

--- a/configure
+++ b/configure
@@ -276,7 +276,7 @@ if args.buildamrex and not args.amrex:
     if   args.comp == "g++":     amrex_configure += ' --comp=gnu'
     elif args.comp == "clang++": amrex_configure += ' --comp=llvm --allow-different-compiler=yes '
     elif args.comp == "icc":     amrex_configure += ' --comp=intel'
-    if args.debug: amrex_configure += ' --debug=yes'
+    if args.debug: amrex_configure += ' --debug=yes --enable-pic=yes'
     if args.profile: amrex_configure += ' --enable-tiny-profile=yes'
     
     if args.fft: amrex_configure += " --enable-fft=yes"
@@ -487,9 +487,9 @@ if args.comp == 'g++':
         else:
             error("Invalid memory check tool ", args.memcheck_tool)
     if args.coverage and args.debug:
-        f.write("CXX_COMPILE_FLAGS += -ggdb -g3 -fprofile-arcs -ftest-coverage\n")
+        f.write("CXX_COMPILE_FLAGS += -ggdb -g3 -fprofile-arcs -ftest-coverage -fPIC\n")
     elif args.debug:
-        f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
+        f.write("CXX_COMPILE_FLAGS += -ggdb -g3  -fPIC\n")
     elif args.coverage:
         f.write("CXX_COMPILE_FLAGS += -fprofile-arcs -ftest-coverage\n")
     else:
@@ -499,7 +499,7 @@ if args.comp == 'clang++':
     f.write("MPI_LIB += -lgfortran\n")
     f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
     if args.debug:
-        f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
+        f.write("CXX_COMPILE_FLAGS += -ggdb -g3 -fPIC\n")
     elif args.perf:
         f.write("CXX_COMPILE_FLAGS += -g -O2 -fno-omit-frame-pointer\n")
         f.write("LINKER_FLAGS += -g -fno-omit-frame-pointer -lprofiler\n")    

--- a/scripts/make_alamo_package.py
+++ b/scripts/make_alamo_package.py
@@ -43,7 +43,7 @@ class AlamoModule(types.ModuleType):
         return getattr(cppyy.gbl, name)
 
     def include(self, path):
-        cppyy.include("/home/brunnels/Research/alamo/src/" + path)
+        cppyy.include("{alamo_home}/src/" + path)
 
 # Replace current module with AlamoModule instance
 sys.modules[__name__].__class__ = AlamoModule

--- a/scripts/make_alamo_package.py
+++ b/scripts/make_alamo_package.py
@@ -1,0 +1,50 @@
+import os, subprocess
+
+alamo_home = os.getcwd()
+
+result = subprocess.run(['mpicxx', '--showme:compile'],capture_output=True,text=True).stdout.strip()
+openmpi_includes = [r.replace('-I','') for r in result.split()]
+
+f = open("setup.py",'w')
+f.write("""
+from setuptools import setup
+
+setup(
+    name='alamo',
+    py_modules=['alamo'],
+    install_requires=['cppyy'],
+)
+""")
+f.close()
+
+os.makedirs('alamo',exist_ok=True)
+
+f = open("alamo.py",'w')
+f.write(f"""
+import cppyy
+import types
+import sys
+
+""")
+
+for openmpi_include in openmpi_includes:
+    f.write(f"cppyy.add_include_path('{openmpi_include}')\n")
+    #cppyy.add_include_path('/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi')
+
+f.write(f"""
+cppyy.add_include_path('{alamo_home}/ext/amrex/2d-debug-g++-25.07/include/')
+cppyy.add_include_path('{alamo_home}/src/')
+cppyy.load_library("{alamo_home}/ext/amrex/2d-debug-g++-25.07/lib/libamrex.so")
+cppyy.load_library("{alamo_home}/lib/libalamo-2d-debug-g++.so")
+
+# Create proxy module
+class AlamoModule(types.ModuleType):
+    def __getattr__(self, name):
+        return getattr(cppyy.gbl, name)
+
+    def include(self, path):
+        cppyy.include("/home/brunnels/Research/alamo/src/" + path)
+
+# Replace current module with AlamoModule instance
+sys.modules[__name__].__class__ = AlamoModule
+""")


### PR DESCRIPTION
This PR enables the automatic building of
- a shared library version of alamo (libalamo....so)
- a shared library version of amrex (just a conversion from .a to .so for libamrex)

It also adds `-fPIC` flags to all debug builds for alamo and amrex. 

This enables the use of cling and cppyy libraries to test and prototype alamo functions driven by python.