### PR TITLE
Updates to queryarr_default

### DIFF
--- a/src/BC/Constant.H
+++ b/src/BC/Constant.H
@@ -63,12 +63,12 @@ public:
     Constant(int a_ncomp, Unit a_unit = Unit::Less()) : m_ncomp(a_ncomp), unit(a_unit) {};
     Constant(int a_ncomp, IO::ParmParse& pp, std::string name) : m_ncomp(a_ncomp)
     {
-        pp_queryclass(name, *this);
+        pp.queryclass(name, *this);
     };
     Constant(int a_ncomp, Unit a_unit, IO::ParmParse& pp, std::string name) : 
         m_ncomp(a_ncomp), unit(a_unit)
     {
-        pp_queryclass(name, *this);
+        pp.queryclass(name, *this);
     };
     Constant(int ncomp, amrex::Vector<std::string> bc_hi_str,
         amrex::Vector<std::string> bc_lo_str,
@@ -199,34 +199,34 @@ public:
         // TYPES
 
         std::vector<std::string> str;
-        pp_queryarr_default("type.xlo", str,"dirichlet");  // BC type on the lower x edge (2d) face (3d)
+        pp.queryarr_default("type.xlo", str,{"dirichlet"});  // BC type on the lower x edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Exception(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::XLO].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::XLO].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.xhi", str,"dirichlet");  // BC type on the upper x edge (2d) face (3d)
+        pp.queryarr_default("type.xhi", str,{"dirichlet"});  // BC type on the upper x edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Exception(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::XHI].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::XHI].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.ylo", str,"dirichlet");  // BC type on the lower y edge (2d) face (3d)
+        pp.queryarr_default("type.ylo", str,{"dirichlet"});  // BC type on the lower y edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Exception(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::YLO].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::YLO].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.yhi", str,"dirichlet");  // BC type on the upper y edge (2d) face (3d)
+        pp.queryarr_default("type.yhi", str,{"dirichlet"});  // BC type on the upper y edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Exception(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::YHI].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::YHI].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.zlo", str,"dirichlet");  // BC type on the lower z face (processed but ignored in 2d to prevent unused input errors)
+        pp.queryarr_default("type.zlo", str,{"dirichlet"});  // BC type on the lower z face (processed but ignored in 2d to prevent unused input errors)
 #if AMREX_SPACEDIM==3
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Exception(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::ZLO].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::ZLO].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
 #endif
-        pp_queryarr_default("type.zhi", str,"dirichlet");  // BC type on the upper z face (processed but ignored in 2d to prevent unused input errors)
+        pp.queryarr_default("type.zhi", str,{"dirichlet"});  // BC type on the upper z face (processed but ignored in 2d to prevent unused input errors)
 #if AMREX_SPACEDIM==3
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Exception(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::ZHI].push_back(bcmap[str[i]]);
@@ -237,7 +237,7 @@ public:
         // VALS
         std::vector<std::string> val;
         value.m_bc_val[Face::XLO].clear();
-        pp_queryarr_default("val.xlo", val,"0.0");  // BC value on the lower x edge (2d) face (3d)
+        pp.queryarr_default("val.xlo", val,{"0.0"});  // BC value on the lower x edge (2d) face (3d)
         if (val.size() == value.m_ncomp) 
             for (unsigned int i = 0; i < value.m_ncomp; i++) 
                 value.m_bc_val[Face::XLO].push_back(Numeric::Interpolator::Linear<Set::Scalar>(val[i],Unit::Time(),value.unit));
@@ -247,24 +247,24 @@ public:
             value.m_bc_val[Face::XLO].resize(value.m_ncomp, 0.0);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC value args: expected ", value.m_ncomp, " or 0 or 1 but got ", val.size());
         value.m_bc_val[Face::XHI].clear();
-        pp_queryarr_default("val.xhi", val,"0.0"); // BC value on the upper x edge (2d) face (3d)
+        pp.queryarr_default("val.xhi", val,{"0.0"}); // BC value on the upper x edge (2d) face (3d)
         if (val.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_val[Face::XHI].push_back(Numeric::Interpolator::Linear<Set::Scalar>(val[i],Unit::Time(),value.unit));
         else if (val.size() == 1) value.m_bc_val[Face::XHI].resize(value.m_ncomp, Numeric::Interpolator::Linear<Set::Scalar>(val[0]));
         else if (val.size() == 0) value.m_bc_val[Face::XHI].resize(value.m_ncomp, 0.0);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC value args: expected ", value.m_ncomp, " or 0 or 1 but got ", val.size());
         value.m_bc_val[Face::YLO].clear();
-        pp_queryarr_default("val.ylo", val,"0.0");  // BC value on the lower y edge (2d) face (3d)
+        pp.queryarr_default("val.ylo", val,{"0.0"});  // BC value on the lower y edge (2d) face (3d)
         if (val.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_val[Face::YLO].push_back(Numeric::Interpolator::Linear<Set::Scalar>(val[i],Unit::Time(),value.unit));
         else if (val.size() == 1) value.m_bc_val[Face::YLO].resize(value.m_ncomp, Numeric::Interpolator::Linear<Set::Scalar>(val[0]));
         else if (val.size() == 0) value.m_bc_val[Face::YLO].resize(value.m_ncomp, 0.0);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC value args: expected ", value.m_ncomp, " or 0 or 1 but got ", val.size());
         value.m_bc_val[Face::YHI].clear();
-        pp_queryarr_default("val.yhi", val,"0.0"); // BC value on the upper y edge (2d) face (3d)
+        pp.queryarr_default("val.yhi", val,{"0.0"}); // BC value on the upper y edge (2d) face (3d)
         if (val.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_val[Face::YHI].push_back(Numeric::Interpolator::Linear<Set::Scalar>(val[i],Unit::Time(),value.unit));
         else if (val.size() == 1) value.m_bc_val[Face::YHI].resize(value.m_ncomp, Numeric::Interpolator::Linear<Set::Scalar>(val[0]));
         else if (val.size() == 0) value.m_bc_val[Face::YHI].resize(value.m_ncomp, 0.0);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC value args: expected ", value.m_ncomp, " or 0 or 1 but got ", val.size());
-        pp_queryarr_default("val.zlo", val,"0.0");  // BC value on the lower z face (processed but ignored in 2d to prevent unused input errors)
+        pp.queryarr_default("val.zlo", val,{"0.0"});  // BC value on the lower z face (processed but ignored in 2d to prevent unused input errors)
 #if AMREX_SPACEDIM==3
         value.m_bc_val[Face::ZLO].clear();
         if (val.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_val[Face::ZLO].push_back(Numeric::Interpolator::Linear<Set::Scalar>(val[i],Unit::Time(),value.unit));
@@ -272,7 +272,7 @@ public:
         else if (val.size() == 0) value.m_bc_val[Face::ZLO].resize(value.m_ncomp, 0.0);
         else Util::Exception(INFO, "Incorrect number of ", pp.prefix(), " BC value args: expected ", value.m_ncomp, " or 0 or 1 but got ", val.size());
 #endif
-        pp_queryarr_default("val.zhi", val,"0.0"); // BC value on the upper z face (processed but ignored in 2d to prevent unused input errors)
+        pp.queryarr_default("val.zhi", val,{"0.0"}); // BC value on the upper z face (processed but ignored in 2d to prevent unused input errors)
 #if AMREX_SPACEDIM==3
         value.m_bc_val[Face::ZHI].clear();
         if (val.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_val[Face::ZHI].push_back(Numeric::Interpolator::Linear<Set::Scalar>(val[i],Unit::Time(),value.unit));

--- a/src/BC/Expression.H
+++ b/src/BC/Expression.H
@@ -135,34 +135,34 @@ public:
         // TYPES
 
         std::vector<std::string> str;
-        pp_queryarr_default("type.xlo", str,"dirichlet");  // BC type on the lower x edge (2d) face (3d)
+        pp.queryarr_default("type.xlo", str,{"dirichlet"});  // BC type on the lower x edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Abort(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::XLO].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::XLO].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Abort(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.xhi", str,"dirichlet");  // BC type on the upper x edge (2d) face (3d)
+        pp.queryarr_default("type.xhi", str,{"dirichlet"});  // BC type on the upper x edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Abort(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::XHI].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::XHI].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Abort(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.ylo", str,"dirichlet");  // BC type on the lower y edge (2d) face (3d)
+        pp.queryarr_default("type.ylo", str,{"dirichlet"});  // BC type on the lower y edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Abort(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::YLO].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::YLO].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Abort(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.yhi", str,"dirichlet");  // BC type on the upper y edge (2d) face (3d)
+        pp.queryarr_default("type.yhi", str,{"dirichlet"});  // BC type on the upper y edge (2d) face (3d)
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Abort(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::YHI].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::YHI].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Abort(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
-        pp_queryarr_default("type.zlo", str,"dirichlet");  // BC type on the lower z face (processed but ignored in 2d to prevent unused input errors)
+        pp.queryarr_default("type.zlo", str,{"dirichlet"});  // BC type on the lower z face (processed but ignored in 2d to prevent unused input errors)
 #if AMREX_SPACEDIM==3
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Abort(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::ZLO].push_back(bcmap[str[i]]);
         else if (str.size() == 1) value.m_bc_type[Face::ZLO].resize(value.m_ncomp, bcmap[str[0]]);
         else Util::Abort(INFO, "Incorrect number of ", pp.prefix(), " BC type args: expected ", value.m_ncomp, " or 1 but got ", str.size());
 #endif
-        pp_queryarr_default("type.zhi", str,"dirichlet");  // BC type on the upper z face (processed but ignored in 2d to prevent unused input errors)
+        pp.queryarr_default("type.zhi", str,{"dirichlet"});  // BC type on the upper z face (processed but ignored in 2d to prevent unused input errors)
 #if AMREX_SPACEDIM==3
         for (unsigned int i = 0; i < str.size(); i++) if (!bcmap.count(str[i])) Util::Abort(INFO, "Invalid BC: ", str[i]);
         if (str.size() == value.m_ncomp) for (unsigned int i = 0; i < value.m_ncomp; i++) value.m_bc_type[Face::ZHI].push_back(bcmap[str[i]]);

--- a/src/BC/Operator/Elastic/Expression.H
+++ b/src/BC/Operator/Elastic/Expression.H
@@ -431,112 +431,112 @@ public:
             }
         };
 
-        pp_queryarr_default("type.xlo",type, "disp"); // 3D Face / 2D Edge type
-        pp_queryarr_default("val.xlo", val , "0.0"); // 3D Face / 2D Edge value
+        pp.queryarr_default("type.xlo",type, {"disp"}); // 3D Face / 2D Edge type
+        pp.queryarr_default("val.xlo", val , {"0.0"}); // 3D Face / 2D Edge value
         set(type,val,Face::XLO); 
 
-        pp_queryarr_default("type.xhi",type, "disp"); // 3D Face / 2D Edge  type
-        pp_queryarr_default("val.xhi" ,val , "0.0"); // 3D Face / 2D Edge value
+        pp.queryarr_default("type.xhi",type, {"disp"}); // 3D Face / 2D Edge  type
+        pp.queryarr_default("val.xhi" ,val , {"0.0"}); // 3D Face / 2D Edge value
         set(type,val,Face::XHI); 
 
-        pp_queryarr_default("type.ylo",type, "disp"); // 3D Face / 2D Edge type
-        pp_queryarr_default("val.ylo" ,val , "0.0"); // 3D Face / 2D Edge value
+        pp.queryarr_default("type.ylo",type, {"disp"}); // 3D Face / 2D Edge type
+        pp.queryarr_default("val.ylo" ,val , {"0.0"}); // 3D Face / 2D Edge value
         set(type,val,Face::YLO); 
 
-        pp_queryarr_default("type.yhi",type, "disp"); // 3D Face / 2D Edge type
-        pp_queryarr_default("val.yhi", val , "0.0"); // 3D Face / 2D Edge value
+        pp.queryarr_default("type.yhi",type, {"disp"}); // 3D Face / 2D Edge type
+        pp.queryarr_default("val.yhi", val , {"0.0"}); // 3D Face / 2D Edge value
         set(type,val,Face::YHI); 
 
 #if AMREX_SPACEDIM==3
-        pp_queryarr_default("type.zlo",type, "disp"); // 3D Face type
-        pp_queryarr_default("val.zlo", val , "0.0"); // 3D Face value
+        pp.queryarr_default("type.zlo",type, {"disp"}); // 3D Face type
+        pp.queryarr_default("val.zlo", val , {"0.0"}); // 3D Face value
         set(type,val,Face::ZLO); 
 
-        pp_queryarr_default("type.zhi",type, "disp"); // 3D Face type
-        pp_queryarr_default("val.zhi", val , "0.0"); // 3D Face value
+        pp.queryarr_default("type.zhi",type, {"disp"}); // 3D Face type
+        pp.queryarr_default("val.zhi", val , {"0.0"}); // 3D Face value
         set(type,val,Face::ZHI); 
 #endif
 
 
-        pp.queryarr_default("type.xloylo",type, "disp"); // 3D Edge / 2D Corner type
-        pp.queryarr_default("val.xloylo", val , "0.0"); // 3D Edge / 2D Corner value
+        pp.queryarr_default("type.xloylo",type, {"disp"}); // 3D Edge / 2D Corner type
+        pp.queryarr_default("val.xloylo", val , {"0.0"}); // 3D Edge / 2D Corner value
         set(type,val,Face::XLO_YLO); 
 
-        pp_queryarr_default("type.xloyhi",type, "disp"); // 3D Edge / 2D Corner type
-        pp_queryarr_default("val.xloyhi", val , "0.0"); // 3D Edge / 2D Corner value
+        pp.queryarr_default("type.xloyhi",type, {"disp"}); // 3D Edge / 2D Corner type
+        pp.queryarr_default("val.xloyhi", val , {"0.0"}); // 3D Edge / 2D Corner value
         set(type,val,Face::XLO_YHI); 
 
-        pp_queryarr_default("type.xhiylo",type, "disp"); // 3D Edge / 2D Corner type
-        pp_queryarr_default("val.xhiylo", val , "0.0"); // 3D Edge / 2D Corner value
+        pp.queryarr_default("type.xhiylo",type, {"disp"}); // 3D Edge / 2D Corner type
+        pp.queryarr_default("val.xhiylo", val , {"0.0"}); // 3D Edge / 2D Corner value
         set(type,val,Face::XHI_YLO); 
 
-        pp_queryarr_default("type.xhiyhi",type, "disp"); // 3D Edge / 2D Corner type
-        pp_queryarr_default("val.xhiyhi", val , "0.0"); // 3D Edge / 2D Corner value
+        pp.queryarr_default("type.xhiyhi",type, {"disp"}); // 3D Edge / 2D Corner type
+        pp.queryarr_default("val.xhiyhi", val , {"0.0"}); // 3D Edge / 2D Corner value
         set(type,val,Face::XHI_YHI); 
 
 #if AMREX_SPACEDIM==3
-        pp_queryarr_default("type.xloylozlo",type,"disp"); // 3D Corner type
-        pp_queryarr_default("val.xloylozlo",val,"0.0"); // 3D Corner value
+        pp.queryarr_default("type.xloylozlo",type,{"disp"}); // 3D Corner type
+        pp.queryarr_default("val.xloylozlo",val,{"0.0"}); // 3D Corner value
         set(type,val,Face::XLO_YLO_ZLO);
 
-        pp_queryarr_default("type.xloylozhi",type, "disp");  // 3D Corner type
-        pp_queryarr_default("val.xloylozhi", val , "0.0");  // 3D Corner value
+        pp.queryarr_default("type.xloylozhi",type, {"disp"});  // 3D Corner type
+        pp.queryarr_default("val.xloylozhi", val , {"0.0"});  // 3D Corner value
         set(type,val,Face::XLO_YLO_ZHI); 
 
-        pp_queryarr_default("type.xloyhizlo",type, "disp"); // 3D Corner type
-        pp_queryarr_default("val.xloyhizlo", val , "0.0"); // 3D Corner value
+        pp.queryarr_default("type.xloyhizlo",type, {"disp"}); // 3D Corner type
+        pp.queryarr_default("val.xloyhizlo", val , {"0.0"}); // 3D Corner value
         set(type,val,Face::XLO_YHI_ZLO); 
 
-        pp_queryarr_default("type.xloyhizhi",type, "disp"); // 3D Corner type
-        pp_queryarr_default("val.xloyhizhi", val , "0.0"); // 3D Corner value
+        pp.queryarr_default("type.xloyhizhi",type, {"disp"}); // 3D Corner type
+        pp.queryarr_default("val.xloyhizhi", val , {"0.0"}); // 3D Corner value
         set(type,val,Face::XLO_YHI_ZHI); 
 
-        pp_queryarr_default("type.xhiylozlo",type, "disp"); // 3D Corner type
-        pp_queryarr_default("val.xhiylozlo", val , "0.0"); // 3D Corner value
+        pp.queryarr_default("type.xhiylozlo",type, {"disp"}); // 3D Corner type
+        pp.queryarr_default("val.xhiylozlo", val , {"0.0"}); // 3D Corner value
         set(type,val,Face::XHI_YLO_ZLO); 
 
-        pp_queryarr_default("type.xhiylozhi",type, "disp"); // 3D Corner type
-        pp_queryarr_default("val.xhiylozhi", val , "0.0"); // 3D Corner value
+        pp.queryarr_default("type.xhiylozhi",type, {"disp"}); // 3D Corner type
+        pp.queryarr_default("val.xhiylozhi", val , {"0.0"}); // 3D Corner value
         set(type,val,Face::XHI_YLO_ZHI); 
 
-        pp_queryarr_default("type.xhiyhizlo",type, "disp"); // 3D Corner type
-        pp_queryarr_default("val.xhiyhizlo", val , "0.0"); // 3D Corner value
+        pp.queryarr_default("type.xhiyhizlo",type, {"disp"}); // 3D Corner type
+        pp.queryarr_default("val.xhiyhizlo", val , {"0.0"}); // 3D Corner value
         set(type,val,Face::XHI_YHI_ZLO); 
 
-        pp_queryarr_default("type.xhiyhizhi",type, "disp"); // 3D Corner type
-        pp_queryarr_default("val.xhiyhizhi", val , "0.0"); // 3D Corner value
+        pp.queryarr_default("type.xhiyhizhi",type, {"disp"}); // 3D Corner type
+        pp.queryarr_default("val.xhiyhizhi", val , {"0.0"}); // 3D Corner value
         set(type,val,Face::XHI_YHI_ZHI); 
 
-        pp_queryarr_default("type.ylozlo",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.ylozlo", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.ylozlo",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.ylozlo", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::YLO_ZLO); 
 
-        pp_queryarr_default("type.ylozhi",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.ylozhi", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.ylozhi",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.ylozhi", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::YLO_ZHI); 
 
-        pp_queryarr_default("type.yhizlo",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.yhizlo", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.yhizlo",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.yhizlo", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::YHI_ZLO); 
 
-        pp_queryarr_default("type.yhizhi",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.yhizhi", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.yhizhi",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.yhizhi", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::YHI_ZHI); 
 
-        pp_queryarr_default("type.zloxlo",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.zloxlo", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.zloxlo",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.zloxlo", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::ZLO_XLO); 
 
-        pp_queryarr_default("type.zloxhi",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.zloxhi", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.zloxhi",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.zloxhi", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::ZLO_XHI); 
 
-        pp_queryarr_default("type.zhixlo",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.zhixlo", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.zhixlo",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.zhixlo", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::ZHI_XLO); 
 
-        pp_queryarr_default("type.zhixhi",type, "disp"); // 3D Edge type
-        pp_queryarr_default("val.zhixhi", val , "0.0"); // 3D Edge value
+        pp.queryarr_default("type.zhixhi",type, {"disp"}); // 3D Edge type
+        pp.queryarr_default("val.zhixhi", val , {"0.0"}); // 3D Edge value
         set(type,val,Face::ZHI_XHI); 
 #endif
 
@@ -565,7 +565,7 @@ public:
 
     }
     Expression(IO::ParmParse &pp, std::string name): Expression()
-    {pp_queryclass(name,*this);}
+    {pp.queryclass(name,*this);}
 };
 }
 }

--- a/src/IO/ParmParse.H
+++ b/src/IO/ParmParse.H
@@ -698,6 +698,40 @@ public:
         return -1;
     }
 
+    int queryarr_default(   std::string name, std::vector<double> & value, std::vector<double> defaultvalue)
+    {
+        try
+        {
+            if (!contains(name.c_str()))
+            {
+                addarr(name.c_str(),defaultvalue);
+            }
+            return queryarr(name.c_str(),value);
+        }
+        catch (...)
+        {
+            Util::ParmParseException(INFO,full(name));
+        }
+        return -1;
+    }
+
+    int queryarr_default(   std::string name, std::vector<double> & value, std::vector<std::string> defaultvalue, Unit unit)
+    {
+        try
+        {
+            if (!contains(name.c_str()))
+            {
+                addarr(name.c_str(),defaultvalue);
+            }
+            return queryarr(name,value, unit);
+        }
+        catch (...)
+        {
+            Util::ParmParseException(INFO,full(name));
+        }
+        return -1;
+    }
+
 
     template <typename T>
     int

--- a/src/IO/ParmParse.H
+++ b/src/IO/ParmParse.H
@@ -651,11 +651,11 @@ public:
         }        
         return queryarr(name,value,unit);
     }
-    int queryarr_default(   std::string name, std::vector<std::string> & value, std::string defaultvalue)
+    int queryarr_default(   std::string name, std::vector<std::string> & value, std::vector<std::string> defaultvalue)
     {
         if (!contains(name.c_str()))
         {
-            add(name.c_str(),defaultvalue);
+            addarr(name.c_str(),defaultvalue);
         }
         return amrex::ParmParse::queryarr(name.c_str(),value);
     }

--- a/src/Util/String.H
+++ b/src/Util/String.H
@@ -99,6 +99,14 @@ std::string Join(const std::vector<std::string> & vec, char separator)
 }
 
 AMREX_FORCE_INLINE
+std::string Join(const std::vector<double> & vec, std::string separator = " ")
+{
+    std::vector<std::string> strvec;
+    for (auto v : vec) strvec.push_back(std::to_string(v));
+    return Join(strvec,separator);
+}
+
+AMREX_FORCE_INLINE
 std::string Join(const Set::Vector & vec, char separator = ' ')
 {
     std::ostringstream oss;


### PR DESCRIPTION
### Addressing https://github.com/solidsgroup/alamo/issues/179

Adding the following functions

    int queryarr_default(   std::string name, std::vector<double> & value, std::vector<double> defaultvalue);
    int queryarr_default(   std::string name, std::vector<double> & value, std::vector<std::string> defaultvalue, Unit unit);

Example use case

    IO::ParmParse pp;
    std::vector<double> input;
    pp.queryarr_default("myinput",input,{1.0, 2.0, 3.0});
    pp.queryarr_default("myinput_unit",input,{"1.0_mph/s", "2.0_mph/s", "3.0_mph/s"}, Unit::Acceleration());


### Addressing https://github.com/solidsgroup/alamo/issues/178

Fixed `query_default` with string option. This required revising the interface slightly: the following is no longer permissible

    pp.queryarr_default("type.xlo", str,"dirichlet");    // ❌  [Now Incorrect] default value not an array

and has been replaced with

    pp.queryarr_default("type.xlo", str,{"dirichlet"});  // ✅ [Correct] single element array 

