### PR TITLE
add extra flags to mpirun command to fix test errors due to not enough cores

### DIFF
--- a/.github/workflows/dependencies-ubuntu-22.04.sh
+++ b/.github/workflows/dependencies-ubuntu-22.04.sh
@@ -17,7 +17,7 @@ sudo apt install libpng-dev
 #
 # Install these packages if compiling with clang
 #
-sudo apt install clang libgfortran-14-dev libstdc++-14-dev
+sudo apt install clang
 
 #
 # These are needed for regression test scripts and other code infrastructure

--- a/.github/workflows/dependencies-ubuntu-22.04.sh
+++ b/.github/workflows/dependencies-ubuntu-22.04.sh
@@ -10,14 +10,14 @@ sudo apt install build-essential g++ gfortran
 # Use apt (or apt-get) to install these packages
 # [ you should only need to do this once ]
 #
-sudo apt install libmpich-dev libmpich12 mpich
+sudo apt install libopenmpi-dev
 sudo apt install libeigen3-dev
 sudo apt install libpng-dev
 
 #
 # Install these packages if compiling with clang
 #
-sudo apt install clang
+sudo apt install clang libgfortran-14-dev libstdc++-14-dev
 
 #
 # These are needed for regression test scripts and other code infrastructure

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -288,7 +288,7 @@ def test(testdir):
                 env["CPUPROFILE"] = "profile.prof"
 
             # If not running in serial, specify mpirun command
-            if nprocs > 1: command += f"mpirun {args.mpirun_flags} -np {nprocs} "
+            if nprocs > 1: command += f"mpirun {args.mpirun_flags} --use-hwthread-cpus --oversubscribe -n {nprocs} "
             # Specify alamo command.
             
             exestr = "./bin/{}-{}d".format(exe,dim)

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -288,7 +288,7 @@ def test(testdir):
                 env["CPUPROFILE"] = "profile.prof"
 
             # If not running in serial, specify mpirun command
-            if nprocs > 1: command += f"mpirun {args.mpirun_flags} --use-hwthread-cpus --oversubscribe -n {nprocs} "
+            if nprocs > 1: command += f"mpirun {args.mpirun_flags} --oversubscribe -n {nprocs} "
             # Specify alamo command.
             
             exestr = "./bin/{}-{}d".format(exe,dim)


### PR DESCRIPTION
- fixes a bug where tests would fail if there weren't enough available cores on the host to run the parallel tests
- fixes #189