### PR TITLE
adding clock stop functionality to integrator

### DIFF
--- a/src/Integrator/Integrator.H
+++ b/src/Integrator/Integrator.H
@@ -187,6 +187,16 @@ protected:
     {}
 
 
+    inline void StopClock()
+    {
+        clock_running = false;
+    }
+    inline void RestartClock()
+    {
+        clock_running = true;
+    }
+
+
     /// Add a new cell-based scalar field.
     void RegisterNewFab(Set::Field<Set::Scalar>& new_fab, BC::BC<Set::Scalar>* new_bc, int ncomp, int nghost, std::string name, bool writeout,bool evolving = true,std::vector<std::string> suffix = {});
     /// Add a new cell-based scalar field (with additional arguments).
@@ -391,6 +401,8 @@ private:
 protected:
     bool integrate_variables_before_advance = true;
     bool integrate_variables_after_advance = false;
+
+    bool clock_running = true;
 
 protected:
     struct {

--- a/src/Integrator/Integrator.cpp
+++ b/src/Integrator/Integrator.cpp
@@ -1031,7 +1031,8 @@ Integrator::Evolve()
         TimeStep(lev, cur_time, iteration);
         if (integrate_variables_after_advance) IntegrateVariables(cur_time, step);
         TimeStepComplete(cur_time, step);
-        cur_time += dt[0];
+        if (clock_running)
+            cur_time += dt[0];
 
         if (amrex::ParallelDescriptor::IOProcessor()) {
             std::cout << "STEP " << step + 1 << " ends."
@@ -1198,7 +1199,10 @@ Integrator::TimeStep(int lev, amrex::Real time, int /*iteration*/)
     if (lev < finest_level)
     {
         for (int i = 1; i <= nsubsteps[lev + 1]; ++i)
-            TimeStep(lev + 1, time + (i - 1) * dt[lev + 1], i);
+        {
+            Set::Scalar substep_time = clock_running ? time + (i - 1) * dt[lev + 1] : time;
+            TimeStep(lev + 1, substep_time, i);
+        }
 
         for (int n = 0; n < cell.number_of_fabs; n++)
         {


### PR DESCRIPTION
Added a `StopClock` and `RestartClock` to integrator, so we (theoretically) should be able to pause the clock while evolving the crack field, then start it again. Please take a look and approve if this looks good.