### PR TITLE
Shoring up the python support

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -29,6 +29,8 @@ jobs:
       run: bash .github/workflows/build-and-test.sh
     - name: documentation
       run: bash .github/workflows/build-docs.sh
+    - name: python
+      run: bash .github/workflows/python.sh
   install-macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -31,6 +31,14 @@ jobs:
       run: bash .github/workflows/build-docs.sh
     - name: python
       run: bash .github/workflows/python.sh
+  install-python:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: running the install script
+      run: bash .github/workflows/dependencies-ubuntu-24.04.sh
+    - name: python
+      run: bash .github/workflows/python.sh
   install-macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/python.sh
+++ b/.github/workflows/python.sh
@@ -1,10 +1,15 @@
 set -eu -o pipefail 
 
+# Must use debug mode using g++ for python
+./configure --comp=g++ --debug
+
+# Build python package
+make py
+
 # Set up a virtual environment and activate
 mkdir alamovenv 
 python -m venv alamovenv
 source alamovenv/bin/activate
-
 
 # Install alamo using pip (-e for editable mode is optional)
 pip install -e .

--- a/.github/workflows/python.sh
+++ b/.github/workflows/python.sh
@@ -1,0 +1,13 @@
+set -eu -o pipefail 
+
+# Set up a virtual environment and activate
+mkdir alamovenv 
+python -m venv alamovenv
+source alamovenv/bin/activate
+
+
+# Install alamo using pip (-e for editable mode is optional)
+pip install -e .
+
+# Run the python regression test
+./scripts/runtests.sh --python tests/Py 

--- a/.github/workflows/python.sh
+++ b/.github/workflows/python.sh
@@ -15,4 +15,4 @@ source alamovenv/bin/activate
 pip install -e .
 
 # Run the python regression test
-./scripts/runtests.sh --python tests/Py 
+./scripts/runtests.py --python tests/Py 

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,9 @@ realclean: clean
 	@printf "$(B_ON)$(FG_RED)CLEANING OLD CONFIGURATIONS $(RESET)\n" 
 	rm -rf Makefile.conf Makefile.amrex.conf .make
 
-py: lib
-	python3 ./scripts/make_alamo_package.py
-
-lib: lib/libalamo-$(POSTFIX).so ${AMREX}/lib/libamrex.so
-	@printf $(POSTFIX)
+py: python_ok lib/libalamo-$(POSTFIX).so ${AMREX}/lib/libamrex.so
+	@python3 ./scripts/make_alamo_package.py --postfix=$(POSTFIX) --amrex=$(AMREX)
+	@printf "$(B_ON)$(FG_GREEN)DONE $(RESET)\n" 
 
 info:
 	@printf "$(B_ON)$(FG_BLUE)Compiler version information$(RESET)\n"

--- a/configure
+++ b/configure
@@ -551,6 +551,15 @@ f2.write(f"\t fi\n")
 f2.write(f"\t$(QUIET)git diff > $@\n")
 
 #
+# PYTHON CHECKING
+#
+f2.write(f"python_ok:\n")
+if args.comp == 'g++' and args.debug:
+    f2.write(f"\t#Yes\n")
+else:
+    f2.write(f"""\t$(error $(error Python module requires configuration with --comp=g++ and --debug))\n""")
+    
+#
 # Documentation check
 #
 if (args.docs):

--- a/configure
+++ b/configure
@@ -555,7 +555,7 @@ f2.write(f"\t$(QUIET)git diff > $@\n")
 #
 f2.write(f"python_ok:\n")
 if args.comp == 'g++' and args.debug:
-    f2.write(f"\t#Yes\n")
+    f2.write(f"\n")
 else:
     f2.write(f"""\t$(error $(error Python module requires configuration with --comp=g++ and --debug))\n""")
     

--- a/docs/source/Developers.rst
+++ b/docs/source/Developers.rst
@@ -237,98 +237,25 @@ For instance:
 
 
 
-:fab:`python;fa-fw` Python (In development)
-===========================================
+:fab:`python;fa-fw` Python bindings
+===================================
 
-Alamo supports a (currently limited) Python interface.
-It can be run as simply as
+The following commands can be used to compile Alamo in python mode and install using pip.
+Note that this is only currently supported in debug mode with g++.
 
-.. code-block:: bash
+.. literalinclude:: ../../.github/workflows/python.sh
+   :language: bash
+   :lines: 2-
 
-      python alamo.py
+To run alamo in python it is necessary to run :code:`include alamo`.
+Relevant C++ headers must be included as well.
+Then, you can call most alamo methods using the same general syntax as in C++.
 
-where :code:`alamo.py` is a python script that you write.
-An example (that currently works) is
+.. literalinclude:: ../../tests/Py/input.py
+   :language: bash
 
-.. code-block:: cpp
-
-      import alamo
-
-      alamo.Util.Initialize()
-
-      mytest = alamo.Test.Operator.Elastic()
-
-      mytest.setBounds([1.0,1.0,1.0])
-
-      for lev in [1,2,3]:
-          print("Levels of refinement: " + str(lev))
-      mytest.Define([32,32,32],lev,1,mytest.Grid.XYZ)
-      failed = mytest.TrigTest(0,0,1,"")
-      if failed: print("Test failed")
-      else: print ("Test passed")
-
-      alamo.Util.Finalize()
-
-Note that the C++ namespace structure is mirrored in the Python bindings.
-
-.. WARNING::
-   Note that object constructors require :code:`()`, e.g. :code:`test = alamo.Test.Operator.Elastic()`.
-   If you forget the :code:`()` the python interpreter **will not complain!**
-   Instead, it will give you an extremely cryptic message about member methods not having the right number of arguments.
-   A typical error message might look like this:
-
-   .. code-block:: bash
-
-           Traceback (most recent call last):
-           File "alamo.py", line 7, in <module>
-           mytest.setBounds([1.0,1.0,1.0])
-           TypeError: unbound method Boost.Python.function object must be called with Elastic instance as first argument (got list instance instead)
-
-Compiling Alamo Python interface
---------------------------------
-
-The python interface requires all code to be compiled using the :code:`-fPIC` flag.
-To compile AMReX,
-
-.. code-block:: bash
-
-        ./compile [whatever flags you would normally use
-        make USE_COMPILE_PIC=TRUE
-        make install
-
-To compile Alamo, you need the Boost python library.
-On ubuntu, install with
-
-.. code-block:: bash
-
-        sudo apt install libboost-python-dev
-
-Then to compile Alamo, 
-
-.. code-block:: bash
-
-        ./configure [whatever flags you would normally use] --python
-        make python
-
-This will create a file called :code:`alamo.so` in the Alamo root directory.
-(Note that this file must be in your python path (or your current directory) to use.)
-
-Extending the Alamo Python interface
-------------------------------------
-
-Python bindings are currently limited and you will likely need to add them if you want them for a specific component.
-Alamo uses the Boost Python library to create the Python bindings.
-All of this code is located in the :code:`py/` directory, and mimics the directory structure of :code:`src/`.
-These are all C++ files, but use the :code:`.cpy` extension.
-To add bindings (e.g. to an object) you must
-
-1. Create an appropriately named file (e.g. :code:`py/Test/Operator/Elastic.cpy` to bind :code:`Test::Operator::Elastic`).
-2. Define a function that encapsulates the bindings (e.g. :code:`void exportTestOperatorElastic`).
-3. Write the Boost Python bindings in the function.
-   Keep in mind that you need to specify namespace explicitly.
-4. Include the file in :code:`py/alamo.cpy`
-5. Call the function in :code:`py/alamo.cpy`
-   
+The python interface is designed for surgical testing of python methods.
+It is not designed to be a replacement for the input file system, and cannot be run in optimized mode.
 
 Restart files
 =============

--- a/docs/source/Install/Ubuntu.rst
+++ b/docs/source/Install/Ubuntu.rst
@@ -51,3 +51,10 @@ Build this documentation
    :language: bash
    :lines: 2-
       
+Build and test python
+~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../../.github/workflows/python.sh
+   :language: bash
+   :lines: 2-
+      

--- a/docs/source/Tests.py
+++ b/docs/source/Tests.py
@@ -96,12 +96,32 @@ for testdirname in sorted(glob.glob("../../tests/*")):
     
     testname = os.path.basename(testdirname)
 
+    if os.path.isfile(testdirname+"/input.py"):
+        docfile.write(f"    * - :fab:`python;sd-text-success fa-fw fa-lg`\n\n")
+        docfile.write("      - :ref:`{}`\n".format(testname))
+        docfile.write(f"      - \n\n")
+        docfile.write(f"      - \n\n")
+        docfile.write(f"      - \n\n")
+        with open("Tests/{}.rst".format(testname),"w") as testdocfile:
+            toctreestr += "   Tests/{}\n".format(testname)
+            testdocfile.write(testname + "\n")
+            testdocfile.write("="*len(testname) + "\n")
+
+            readmes = find_files_ignore_case(Path(testdirname), "README.rst")
+            for readme in readmes: testdocfile.write(f".. include:: ../{testdirname}/{readme.name}\n")
+            if readmes: testdocfile.write("\n\n")
+
+            testdocfile.write(".. literalinclude:: ../{}/input.py\n".format(testdirname))
+            testdocfile.write("   :caption: Input file ({}/input.py)\n".format(testdirname))
+            testdocfile.write("   :language: python\n")
+        continue
+
     if not os.path.isfile(testdirname+"/input"):
-        docfile.write("    * - :fas:`circle-xmark;sd-text-danger fa-fw fa-lg`\n\n")
-        docfile.write("      - {}\n\n".format(testname))
-        docfile.write("      - {}\n\n".format(testname))
-        docfile.write("      - {}\n\n".format(testname))
-        docfile.write("      - {}\n\n".format(testname))
+        docfile.write(f"    * - :fas:`circle-xmark;sd-text-danger fa-fw fa-lg`\n\n")
+        docfile.write(f"      - {testname}\n\n")
+        docfile.write(f"      - \n\n")
+        docfile.write(f"      - \n\n")
+        docfile.write(f"      - \n\n")
         continue
 
 

--- a/scripts/make_alamo_package.py
+++ b/scripts/make_alamo_package.py
@@ -51,8 +51,6 @@ def get_version():
         return "0.0.0.dev0"
 
 version = get_version()
-print("Python package version:", version)
-
 
 f = open("setup.py",'w')
 f.write(f"""

--- a/scripts/make_alamo_package.py
+++ b/scripts/make_alamo_package.py
@@ -1,18 +1,68 @@
-import os, subprocess
+import os, subprocess, argparse
 
-alamo_home = os.getcwd()
+parser = argparse.ArgumentParser(description='For use by Makefile generating Alamo python library');
+parser.add_argument('--alamo_home',   default=os.getcwd(), help='Alamo home directory')
+parser.add_argument('--postfix',      required=True, help="Build postfix")
+parser.add_argument('--amrex',required=True, help='AMReX version')
+args=parser.parse_args()
 
 result = subprocess.run(['mpicxx', '--showme:compile'],capture_output=True,text=True).stdout.strip()
 openmpi_includes = [r.replace('-I','') for r in result.split()]
 
+
+def get_version():
+    """Return a PEP 440–compliant version string based on git tags and commit hash."""
+    try:
+        # Most recent tag reachable from HEAD
+        tag = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+        # Number of commits since the tag
+        commits = int(subprocess.run(
+            ["git", "rev-list", f"{tag}..HEAD", "--count"],
+            capture_output=True, text=True, check=True
+        ).stdout.strip())
+
+        # Current commit hash (short)
+        sha = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+        # Check if working tree is dirty
+        dirty = bool(subprocess.run(
+            ["git", "diff", "--quiet", "HEAD"],
+            capture_output=True
+        ).returncode)
+
+        version = tag
+        if commits > 0:
+            version += f".post{commits}"
+        if dirty:
+            version += ".dev0"
+        if commits > 0 or dirty:
+            version += f"+{sha}"
+
+        return version
+    except subprocess.CalledProcessError:
+        # fallback if not in a git repo
+        return "0.0.0.dev0"
+
+version = get_version()
+print("Python package version:", version)
+
+
 f = open("setup.py",'w')
-f.write("""
+f.write(f"""
 from setuptools import setup
 
 setup(
     name='alamo',
+    version='{version}',
     py_modules=['alamo'],
-    install_requires=['cppyy'],
+    install_requires=['cppyy','sympy'],
 )
 """)
 f.close()
@@ -32,10 +82,10 @@ for openmpi_include in openmpi_includes:
     #cppyy.add_include_path('/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi')
 
 f.write(f"""
-cppyy.add_include_path('{alamo_home}/ext/amrex/2d-debug-g++-25.07/include/')
-cppyy.add_include_path('{alamo_home}/src/')
-cppyy.load_library("{alamo_home}/ext/amrex/2d-debug-g++-25.07/lib/libamrex.so")
-cppyy.load_library("{alamo_home}/lib/libalamo-2d-debug-g++.so")
+cppyy.add_include_path('{args.alamo_home}/{args.amrex}/include/')
+cppyy.add_include_path('{args.alamo_home}/src/')
+cppyy.load_library("{args.alamo_home}/{args.amrex}/lib/libamrex.so")
+cppyy.load_library("{args.alamo_home}/lib/libalamo-{args.postfix}.so")
 
 # Create proxy module
 class AlamoModule(types.ModuleType):
@@ -43,7 +93,7 @@ class AlamoModule(types.ModuleType):
         return getattr(cppyy.gbl, name)
 
     def include(self, path):
-        cppyy.include("{alamo_home}/src/" + path)
+        cppyy.include("{args.alamo_home}/src/" + path)
 
 # Replace current module with AlamoModule instance
 sys.modules[__name__].__class__ = AlamoModule

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -115,6 +115,8 @@ parser.add_argument('--mpirun-flags',dest="mpirun_flags",default="",help="Extra 
 parser.add_argument('--fft',dest="fft",default=False,action='store_true',help="Enable fft-based tests")
 parser.add_argument('--fft-only',dest="fft_only",default=False,action='store_true',help="Run fft tests only")
 parser.add_argument('--post-timeout', dest="post_timeout", default=10000, help='How long to wait before skipping results posting')
+parser.add_argument('--python', default=False,action='store_true', help='Include python tests')
+parser.add_argument('--only-python', default=False,action='store_true', help='Run python tests only')
 args=parser.parse_args()
 
 if args.coverage and args.no_coverage:
@@ -125,6 +127,9 @@ if args.memcheck and not args.debug:
     raise Exception("Debug must be enabled with memory check")
 if args.memcheck and not args.serial:
     raise Exception("Memory check supported in serial only")
+
+if args.only_python:
+    args.python = True
 
 if args.post:
     if not os.path.isfile(args.post):
@@ -160,6 +165,39 @@ def test(testdir):
     timeouts = 0
     post_fails = 0
     records = []
+
+
+    
+    # Formatting strings
+    bs = "\b\b\b\b\b\b"
+
+
+    if os.path.isfile(testdir + "/input.py"):
+        print(f"RUN    {color.bold}{testdir}{color.reset}")
+        cmd = f'python {testdir}/input.py'
+        print("  │      Running test............................................",end="",flush=True)
+        try:
+            proc = subprocess.Popen(cmd.split(),stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+            stdout, stderr = proc.communicate(timeout=int(args.timeout))
+            retcode = proc.returncode
+            if retcode: raise subprocess.CalledProcessError(retcode, proc.args, output=stdout, stderr=stderr)
+            print("[{}PASS{}]".format(color.boldgreen,color.reset))
+            tests += 1
+            print("  └ Python test complete ")
+            return fails, checks, warnings, tests, skips, fasters, slowers, timeouts, records
+
+        except subprocess.CalledProcessError as e:
+            print(bs+"[{}FAIL{}]".format(color.red,color.reset))
+            print("  │      {}CMD   : {}{}".format(color.red,' '.join(e.cmd),color.reset))
+            for line in e.stdout.decode('utf-8').split('\n'): print("  │      {}STDOUT: {}{}".format(color.red,clean(line,1000),color.reset))
+            for line in e.stderr.decode('utf-8').split('\n'): print("  │      {}STDERR: {}{}".format(color.red,clean(line,1000),color.reset))
+            fails += 1
+
+        if os.path.isfile(f"{testdir}/input"):
+            raise(Exception(f"Test {testdir} cannot have both input and input.py"))
+
+        return fails, checks, warnings, tests, skips, fasters, slowers, timeouts, records
+
 
     # Parse the input file ./tests/MyTest/input containing #@ comments.
     # Everything commeneted with #@ will be interpreted as a "config" file
@@ -380,7 +418,6 @@ def test(testdir):
 
         print("  ├ " + desc)
         if args.cmd: print("  ├      " + command)
-        bs = "\b\b\b\b\b\b"
         if args.no_backspace:
             print("  │      Running test............................................",end="")
             bs = ""
@@ -752,9 +789,19 @@ class stats:
 # Iterate through all test directories, running the above "test" function
 # for each.
 for testdir in tests:
-    if (not os.path.isdir(testdir)) or (not os.path.isfile(testdir + "/input")):
-        print("{}IGNORE {} (no input){}".format(color.darkgray,testdir,color.reset))
+    if (not os.path.isdir(testdir)):
+        print(f"{color.darkgray}IGNORE {testdir} (no input){color.reset}")
         continue
+    if os.path.isfile(testdir + "/input") and os.path.isfile(testdir + "/input.py"):
+        print(f"{color.darkgray}IGNORE {testdir} (cannot specify both input and input.py){color.reset}")
+        continue
+    if os.path.isfile(testdir + "/input") and args.only_python:
+        print(f"{color.darkgray}IGNORE {testdir} (running python tests only){color.reset}")
+        continue
+    if os.path.isfile(testdir + "/input.py") and not args.python:
+        print(f"{color.darkgray}IGNORE {testdir} (did not specify --python or --only-python){color.reset}")
+        continue
+
     f, c, w, t, s, fa, sl, to, re = test(testdir)
     stats.fails += f
     stats.tests += t

--- a/tests/Py/input.py
+++ b/tests/Py/input.py
@@ -1,0 +1,4 @@
+import alamo
+alamo.include("Util/Util.H")
+alamo.Util.Initialize()
+alamo.Util.Finalize()


### PR DESCRIPTION
- adding an "install-python" test to ensure future python build support 
- added python install script to documentation
- added slightly more helpful documentation to makefile if user tries to build python without proper ./configure commands
- made python build script a little more robust (was previously tied to a single postfix and amrex version)
- added a python regression test (`tests/Py/input.py`)
- updated runtests.py to run python tests if/when desired (skips by default)
- updated documentation to account for python regression tests