### PR TITLE
fix eta healing bug

### DIFF
--- a/src/Integrator/Flame.cpp
+++ b/src/Integrator/Flame.cpp
@@ -439,6 +439,13 @@ void Flame::Advance(int lev, Set::Scalar time, Set::Scalar dt)
 
             Set::Scalar eta_lap = Numeric::Laplacian(eta, i, j, k, 0, DX);
             Set::Scalar df_deta = ((pf.lambda / pf.eps) * dw(eta(i, j, k)) - pf.eps * pf.kappa * eta_lap);
+            
+            if (df_deta < 0) {
+                // Prevent eta from increasing/healing. A bug was found where if the diffuse thickness was too large compared to a void
+                // (region of eta = 0), eta would heal/increase in a non-physcial way, this if statement stops that behavior 
+                df_deta = 0.0;
+            }
+
             etanew(i, j, k) = eta(i, j, k) - L * dt * df_deta;
             if (etanew(i, j, k) <= small) etanew(i, j, k) = small;
 


### PR DESCRIPTION
Fix bug where if the diffuse thickness region is larger than a void (region of eta=0.0), there is a "healing" behavior where eta will increase instead of decreasing.