### PR TITLE
Makefile command to clean tests output directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,11 @@ clean: tidy
 	rm -rf docs/build docs/doxygen docs/html docs/latex
 	rm -f amrex.build.log
 
+clean-tests:
+	@printf "$(B_ON)$(FG_RED)CLEANING TEST OUTPUT DIRECTORIES $(RESET)\n"
+	rm -rf tests/subfolder/*/output*
+	rm -r report/*
+
 realclean: clean
 	@printf "$(B_ON)$(FG_RED)CLEANING AMREX $(RESET)\n" 
 	-make -C ${AMREX_ROOT} realclean

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,8 @@ clean: tidy
 clean-tests:
 	@printf "$(B_ON)$(FG_RED)CLEANING TEST OUTPUT DIRECTORIES $(RESET)\n"
 	rm -rf tests/*/output*
-	rm -r report/*
-	rm report.html
+	rm -rf report/*
+	rm -f report.html
 
 realclean: clean
 	@printf "$(B_ON)$(FG_RED)CLEANING AMREX $(RESET)\n" 

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,9 @@ clean: tidy
 
 clean-tests:
 	@printf "$(B_ON)$(FG_RED)CLEANING TEST OUTPUT DIRECTORIES $(RESET)\n"
-	rm -rf tests/subfolder/*/output*
+	rm -rf tests/*/output*
 	rm -r report/*
+	rm report.html
 
 realclean: clean
 	@printf "$(B_ON)$(FG_RED)CLEANING AMREX $(RESET)\n" 


### PR DESCRIPTION
A simple addition to the Makefile so that `make clean-tests` will recursively remove the local output directories within `tests/`