### PR TITLE
Adding a check to error out if the ncomp is inconsistent with the num…

### DIFF
--- a/src/Integrator/Mechanics.H
+++ b/src/Integrator/Mechanics.H
@@ -128,6 +128,9 @@ public:
 
         pp.queryclass_enumerate<MODEL>("model",value.models,nmodels);
 
+        Util::Assert(INFO, TEST((int)nmodels == (int)value.models.size()), 
+                     "nmodels does not the # of specified models");
+
         Util::Assert(INFO, TEST(value.models.size() > 0));
         value.RegisterNodalFab(value.eta_mf, value.models.size(), 2, "eta", true);
         // Refinement threshold for eta field

--- a/src/Integrator/Mechanics.H
+++ b/src/Integrator/Mechanics.H
@@ -128,8 +128,8 @@ public:
 
         pp.queryclass_enumerate<MODEL>("model",value.models,nmodels);
 
-        Util::Assert(INFO, TEST((int)nmodels == (int)value.models.size()), 
-                     "nmodels does not the # of specified models");
+        Util::Assert(INFO,   TEST((int)nmodels == (int)value.models.size()), 
+                        "nmodels does not the # of specified models");
 
         Util::Assert(INFO, TEST(value.models.size() > 0));
         value.RegisterNodalFab(value.eta_mf, value.models.size(), 2, "eta", true);

--- a/src/Integrator/Mechanics.H
+++ b/src/Integrator/Mechanics.H
@@ -129,7 +129,7 @@ public:
         pp.queryclass_enumerate<MODEL>("model",value.models,nmodels);
 
         Util::Assert(INFO,   TEST((int)nmodels == (int)value.models.size()), 
-                        "nmodels does not the # of specified models");
+                        "nmodels does not match the # of specified models");
 
         Util::Assert(INFO, TEST(value.models.size() > 0));
         value.RegisterNodalFab(value.eta_mf, value.models.size(), 2, "eta", true);


### PR DESCRIPTION
Currently the mechanics integrator silently ignores initial conditions if `nmodels` is set to 1, even if multiple models are specified. This puts in an assertion to complain if a different number of models is specified. 