### PR TITLE
Disable AMReX Fortran builds

### DIFF
--- a/.github/workflows/dependencies-ubuntu-22.04.sh
+++ b/.github/workflows/dependencies-ubuntu-22.04.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 # Make sure your system is up-to-date with standard build software
 #
 sudo apt update
-sudo apt install build-essential g++ gfortran
+sudo apt install build-essential g++
 
 #
 # Use apt (or apt-get) to install these packages

--- a/.github/workflows/dependencies-ubuntu-24.04.sh
+++ b/.github/workflows/dependencies-ubuntu-24.04.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 # Make sure your system is up-to-date with standard build software
 #
 sudo apt update
-sudo apt install build-essential g++ gfortran
+sudo apt install build-essential g++
 
 #
 # Use apt (or apt-get) to install these packages
@@ -17,7 +17,7 @@ sudo apt install libpng-dev
 #
 # [optional] Install these packages if compiling with clang
 #
-sudo apt install clang libgfortran-14-dev libstdc++-14-dev
+sudo apt install clang libstdc++-14-dev
 
 #
 # [optional] These are needed for regression test scripts and

--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -10,7 +10,7 @@ set -eu -o pipefail
 # [ you should only need to do this once ]
 #
 brew update
-brew reinstall --force --binaries llvm gfortran openmpi eigen libpng
+brew reinstall --force --binaries llvm openmpi eigen libpng
 
 #
 # CONFIGURATION
@@ -19,7 +19,6 @@ brew reinstall --force --binaries llvm gfortran openmpi eigen libpng
 EIGEN_PREFIX="$(brew --prefix eigen)"
 LIBPNG_PREFIX="$(brew --prefix libpng)"
 LLVM_PREFIX="$(brew --prefix llvm)"
-GCC_PREFIX="$(brew --prefix gcc)"
 
 #
 # This command updates the include path to be able to find
@@ -39,7 +38,7 @@ export PATH="$LLVM_PREFIX/bin:$PATH"
 #
 # [ you need to include these arguments every time you configure ]
 #
-./configure --comp clang++ --link "$LLVM_PREFIX/lib/c++" "$GCC_PREFIX/lib/gcc/current" "$LIBPNG_PREFIX/lib"
+./configure --comp clang++ --link "$LLVM_PREFIX/lib/c++" "$LIBPNG_PREFIX/lib"
 
 #
 # Compile the code by running make

--- a/.github/workflows/style/check_tabs.sh
+++ b/.github/workflows/style/check_tabs.sh
@@ -9,7 +9,6 @@ find . -type d \( -name .git \
                \) -prune -o \
        -type f \( \( -name "*.H" -o -name "*.h" -o -name "*.hh" -o -name "*.hpp" \
                   -o -name "*.c" -o -name "*.cc" -o -name "*.cpp" -o -name "*.cxx" \
-                  -o -name "*.f" -o -name "*.F" -o -name "*.f90" -o -name "*.F90" \
                   -o -name "*.py" \
                   -o -name "*.md" -o -name "*.rst" \
                   -o -name "*.sh" \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 
 AMREX_TARGET ?= 
 CC ?= mpicxx -cxx=g++
-MPI_LIB ?= -lmpich
 
 RESET              = \033[0m
 B_ON               = \033[1m

--- a/Makefile
+++ b/Makefile
@@ -54,15 +54,13 @@ HDR_ALL = $(shell find src/ -name *.H)
 HDR_TEST = $(shell find src/ -name *Test.H)
 HDR = $(filter-out $(HDR_TEST),$(HDR_ALL))
 SRC = $(shell find src/ -mindepth 2  -name "*.cpp" )
-SRC_F = $(shell find src/ -mindepth 2  -name "*.F90" )
 SRC_MAIN = $(shell find src/ -maxdepth 1  -name "*.cc" )
 EXE = $(subst src/,bin/, $(SRC_MAIN:.cc=-$(POSTFIX))) 
 OBJ = $(subst src/,obj/obj-$(POSTFIX)/, $(SRC:.cpp=.cpp.o)) 
 DEP = $(subst src/,obj/obj-$(POSTFIX)/, $(SRC:.cpp=.cpp.d)) $(subst src/,obj/obj-$(POSTFIX)/, $(SRC_MAIN:.cc=.cc.d))
 OBJ_MAIN = $(subst src/,obj/obj-$(POSTFIX)/, $(SRC_MAIN:.cpp=.cc.o))
-OBJ_F = $(subst src/,obj/obj-$(POSTFIX)/, $(SRC_F:.F90=.F90.o))
 
-NUM = $(words $(SRC) $(SRC_F) $(SRC_MAIN))
+NUM = $(words $(SRC) $(SRC_MAIN))
 CTR = 0
 NUM_DEP = $(words $(DEP))
 CTR_DEP = 0
@@ -123,7 +121,7 @@ info:
 
 bin/%: bin/%-$(POSTFIX) ;
 
-bin/%-$(POSTFIX): ${OBJ_F} ${OBJ} obj/obj-$(POSTFIX)/%.cc.o 
+bin/%-$(POSTFIX): ${OBJ} obj/obj-$(POSTFIX)/%.cc.o
 	$(eval CTR_EXE=$(shell echo $$(($(CTR_EXE)+1))))
 	@printf "$(B_ON)$(FG_BLUE)LINKING$(RESET)$(FG_LIGHTBLUE)     " 
 	@printf '%9s' "($(CTR_EXE)/$(NUM_EXE)) " 
@@ -182,15 +180,7 @@ obj/obj-$(POSTFIX)/IO/WriteMetaData.cpp.o: .FORCE ${AMREX_TARGET} ${DEP_DIFF}
 
 .PHONY: .FORCE
 
-FORT_INCL = $(shell for i in ${CPLUS_INCLUDE_PATH//:/ }; do echo -I'$i'; done)
-
-obj/obj-$(POSTFIX)/%.F90.o: src/%.F90 
-	@printf "$(B_ON)$(FG_YELLOW)COMPILING  $(RESET)$<\n" 
-	@mkdir -p $(dir $@)
-	mpif90 -c $< -o $@  -I${subst :, -I,$(CPLUS_INCLUDE_PATH)}
-	rm *.mod -rf
-
-docs: docs/build/html/index.html .FORCE 
+docs: docs/build/html/index.html .FORCE
 	@printf "$(B_ON)$(FG_MAGENTA)DOCS$(RESET) Done\n" 
 
 docs/build/html/index.html: $(shell find docs/source/ -type f) README.rst .FORCE

--- a/configure
+++ b/configure
@@ -314,6 +314,7 @@ if args.buildamrex and not args.amrex:
     amrex_configure = './configure '
     amrex_configure += ' --dim=' + str(args.dim)
     amrex_configure += ' --prefix=' + postfix_amrex
+    amrex_configure += ' --with-fortran=no'
     if   args.comp == "g++":     amrex_configure += ' --comp=gnu'
     elif args.comp == "clang++": amrex_configure += ' --comp=llvm --allow-different-compiler=yes '
     elif args.comp == "icc":     amrex_configure += ' --comp=intel'
@@ -326,8 +327,8 @@ if args.buildamrex and not args.amrex:
     subprocess.Popen(amrex_configure.split(),cwd=f"ext/{args.amrexfork}/amrex")
     
     f2.write(f"ext/{args.amrexfork}/amrex/"+postfix_amrex+": ${AMREX_SRC}\n")
-    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex BL_NO_FORT=TRUE $(MAKECMD)\n") # --output-sync=target
-    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex BL_NO_FORT=TRUE install\n")
+    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex $(MAKECMD)\n") # --output-sync=target
+    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex install\n")
     f2.write("\ttouch $@\n") # update directory timestamp to prevent build every time
         
     if not args.offline:

--- a/configure
+++ b/configure
@@ -136,8 +136,6 @@ parser.add_argument('--perf',dest='perf',action='store_true',default=False,help=
 parser.add_argument('--coverage',dest='coverage',action='store_true',default=False,help="Enable test coverage with gcov")
 parser.add_argument('--memcheck',dest='memcheck',action='store_true',default=False,help="Use memory checking")
 parser.add_argument('--memcheck-tool',dest='memcheck_tool',default="msan",help="Memory checking toolL MSan (default) or ASan")
-parser.add_argument('--create-gfortran-link',dest='gfortranln',action='store_true',default=False,
-                    help="Create a link to the gfortran library. (Unless you are CircleCI, you should probably not do this!)")
 parser.add_argument('--link',default=None, nargs='+', help='Additional link paths')
 parser.add_argument('--no-comp-cmds',dest='compile_commands',default=False,action='store_true', help='Suppress generation of compile_commands.json for language servers like clangd')
 parser.add_argument('--verbose',default=False,action='store_true',help="Show full make commands - useful if encountering compile/link errors")
@@ -328,8 +326,8 @@ if args.buildamrex and not args.amrex:
     subprocess.Popen(amrex_configure.split(),cwd=f"ext/{args.amrexfork}/amrex")
     
     f2.write(f"ext/{args.amrexfork}/amrex/"+postfix_amrex+": ${AMREX_SRC}\n")
-    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex $(MAKECMD)\n") # --output-sync=target
-    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex install\n")
+    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex BL_NO_FORT=TRUE $(MAKECMD)\n") # --output-sync=target
+    f2.write(f"\t$(MAKE) -C ext/{args.amrexfork}/amrex BL_NO_FORT=TRUE install\n")
     f2.write("\ttouch $@\n") # update directory timestamp to prevent build every time
         
     if not args.offline:
@@ -457,7 +455,6 @@ if mpidist == "openmpi":
     compmpicmd = shellmessage("openmpi comp flags", "mpicxx --showme:compiler").stdout.decode('utf-8').replace('\n','')
     compmpicmd = args.comp + " " + compmpicmd
     shellmessage("openmpi c++ link"   , "mpicxx --showme:link".format(args.comp))
-    shellmessage("openmpi fort link"   , "mpifort --showme:link".format(args.comp))
     shellmessage("openmpi version", "mpicxx --showme:version")
     env = os.environ.copy()
     env.update({'OMPI_CXX': args.comp})
@@ -521,7 +518,6 @@ if args.perf:
 #         flags may cause linker to fail!
 #
 if args.comp == 'g++':
-    f.write("MPI_LIB += -lgfortran\n")
     f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
     if args.coverage:
         f.write("LINKER_FLAGS += -fprofile-arcs\n")
@@ -544,7 +540,6 @@ if args.comp == 'g++':
         f.write("CXX_COMPILE_FLAGS += -O3 -flto\n")
         f.write("LINKER_FLAGS += -flto\n")
 if args.comp == 'clang++':
-    f.write("MPI_LIB += -lgfortran\n")
     f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
     if args.debug:
         f.write("CXX_COMPILE_FLAGS += -ggdb -g3 -fPIC\n")
@@ -555,7 +550,6 @@ if args.comp == 'clang++':
         f.write("CXX_COMPILE_FLAGS += -O3\n")
         f.write("LINKER_FLAGS += -flto \n")    
 if args.comp == 'icc':
-    f.write("MPI_LIB += -lifcore\n")
     if args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
     else:          f.write("CXX_COMPILE_FLAGS += -Ofast -ipo\n") # 
 


### PR DESCRIPTION
Alamo no longer has Fortran source code that needs to interface with the AMReX Fortran interface so this requirement in the build process was unnecessarily complicating developer tooling and CI runs

- Passes `--with-fortran=no` to AMReX to disable building the Fortran interface
- Removes the dead code in the build infrastructure for building the Fortran sources
- Fixes a latent bug that would cause linking errors if `MPI_LIB` was not assigned a value in the `configure` script (which is now a possibility since we no longer link against the Fortran standard library)