### PR TITLE
Make macOS support more robust

### DIFF
--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -1,52 +1,28 @@
-set -eu -o pipefail 
+set -eu -o pipefail
+
+#
+# Assumes Xcode Command Line Tools and Homebrew are installed.
+#   - Xcode CLT: xcode-select --install
+#   - Homebrew:  https://brew.sh
+#
 
 #
 # DEPENDENCIES
-# ============
-#
-
-#
-# Use the Homebrew package manager for macOS to install dependencies
-# [ you should only need to do this once ]
 #
 brew update
-brew reinstall --force --binaries llvm openmpi eigen libpng
+brew install openmpi eigen libpng
 
 #
-# CONFIGURATION
-# =============
+# CONFIGURE
 #
-EIGEN_PREFIX="$(brew --prefix eigen)"
-LIBPNG_PREFIX="$(brew --prefix libpng)"
-LLVM_PREFIX="$(brew --prefix llvm)"
+./configure --comp clang++
 
 #
-# This command updates the include path to be able to find
-# the above libraries
-#
-# [ you need to do this in every new shell OR add to your shell config file (like .bashrc) ]
-#
-export CPLUS_INCLUDE_PATH="$EIGEN_PREFIX/include:$LIBPNG_PREFIX/include"
-
-#
-# Add the LLVM directory first in the path to avoid using Apple Clang
-#
-export PATH="$LLVM_PREFIX/bin:$PATH"
-
-#
-# In the alamo directory, run this command with any additional arguments. 
-#
-# [ you need to include these arguments every time you configure ]
-#
-./configure --comp clang++ --link "$LLVM_PREFIX/lib/c++" "$LIBPNG_PREFIX/lib"
-
-#
-# Compile the code by running make
+# BUILD
 #
 make
 
 #
-# Run the unit test suite
+# TEST
 #
 ./bin/test-3d-clang++
-

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,12 @@ METADATA_FLAGS = -DMETADATA_GITHASH=\"$(METADATA_GITHASH)\" -DMETADATA_USER=\"$(
 
 CXX_COMPILE_FLAGS += -Winline -Wextra -Wall -Wno-comment -std=c++17 $(METADATA_FLAGS)
 
+# Skip on macOS: -Bsymbolic-functions is a GNU ld flag not supported by
+# Apple's ld64, and -lstdc++fs is a pre-GCC-9 std::filesystem shim that
+# doesn't exist in libc++ (used by Apple Clang and Homebrew LLVM).
+ifneq ($(shell uname -s),Darwin)
 LINKER_FLAGS += -Bsymbolic-functions -lstdc++fs
+endif
 
 #CXX_COMPILE_FLAGS += --param inline-unit-growth=100 --param  max-inline-insns-single=1200
 #LINKER_FLAGS      += --param inline-unit-growth=100 --param  max-inline-insns-single=1200

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ LINKER_FLAGS += -Bsymbolic-functions -lstdc++fs
 #LINKER_FLAGS      += --param inline-unit-growth=100 --param  max-inline-insns-single=1200
 
 
-ALAMO_INCLUDE += $(if ${EIGEN}, -isystem ${EIGEN})  $(if ${AMREX_TARGET}, -isystem ${AMREX_TARGET}/include/) -I./src/ $(for pth in ${CPLUS_INCLUDE_PATH}; do echo -I"$pth"; done)
+ALAMO_INCLUDE += $(if ${EIGEN}, -isystem ${EIGEN})  $(if ${AMREX_TARGET}, -isystem ${AMREX_TARGET}/include/) -I./src/ $(foreach pth,$(subst :, ,${CPLUS_INCLUDE_PATH}),-I$(pth))
 LIB     += ${AMREX_TARGET}/lib/libamrex.a -lpthread
 
 HDR_ALL = $(shell find src/ -name *.H)

--- a/configure
+++ b/configure
@@ -709,11 +709,25 @@ if not args.compile_commands:
 
     projectdir = os.getcwd()
 
-    otherflags = ""
-    if args.fft: otherflags += "-DALAMO_FFT"
+    otherflags = []
+    if args.fft: otherflags.append("-DALAMO_FFT")
 
-    if args.amrex: otherflags += f" -I{args.amrex}/include"
-    else: otherflags += f" -I./ext/{args.amrexfork}/amrex/{postfix_amrex}/include"
+    if args.geteigen:
+        otherflags.extend(["-isystem", "./ext/libeigen"])
+    elif args.eigen:
+        otherflags.extend(["-isystem", f"{args.eigen}/include"])
+
+    if args.libpng:
+        otherflags.extend(["-isystem", f"{args.libpng}/include"])
+
+    if args.amrex:
+        otherflags.append(f"-I{args.amrex}/include")
+    else:
+        otherflags.append(f"-I./ext/{args.amrexfork}/amrex/{postfix_amrex}/include")
+
+    for pth in os.environ.get("CPLUS_INCLUDE_PATH", "").split(os.pathsep):
+        if pth:
+            otherflags.append(f"-I{pth}")
 
     cc = compmpicmd
     command_objects = []
@@ -721,12 +735,11 @@ if not args.compile_commands:
         "directory": projectdir,
         "file": srcfile,
         "arguments": [
-            *cc.split(" "),
-            *otherflags.split(" "),
+            *cc.split(),
+            *otherflags,
             "-std=c++17",
             "-I./src/",
             srcfile,
-            
         ],
     } for srcfile in srcfiles]
 

--- a/configure
+++ b/configure
@@ -380,6 +380,38 @@ else:
     warning("AMReX path not specified. This may cause compile errors.")
 
 #
+# AUTO-DETECT EIGEN VIA HOMEBREW ON MACOS
+#
+# Homebrew's prefix (/opt/homebrew on Apple Silicon, /usr/local on Intel) is
+# not in Apple Clang's default include search path, so without this the user
+# would have to pass --eigen explicitly even when eigen is installed via brew.
+#
+if (sys.platform == "darwin"
+        and not args.eigen
+        and not args.geteigen
+        and shutil.which("brew")):
+    try:
+        brew_eigen_prefix = subprocess.run(
+            ["brew", "--prefix", "eigen"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        candidate = os.path.join(brew_eigen_prefix, "include")
+        if os.path.isdir(os.path.join(candidate, "eigen3")):
+            args.eigen = candidate
+            message("Eigen-Autodetect", f"Found Homebrew eigen at {candidate}")
+        else:
+            warning(
+                f"Homebrew reported eigen at {brew_eigen_prefix} but "
+                "include/eigen3 was not found there. Skipping auto-detect."
+            )
+    except subprocess.CalledProcessError:
+        note(
+            "Homebrew is installed but eigen is not. Install it with "
+            + code("brew install eigen")
+            + " or pass --eigen=<path> manually."
+        )
+
+#
 # EIGEN
 #
 if (args.geteigen):

--- a/configure
+++ b/configure
@@ -131,7 +131,6 @@ parser.add_argument('--offline', dest='offline', action='store_true',default=Fal
 parser.add_argument('--omp', dest='omp', action='store_true',default=False, help='Compile with OpenMP')
 parser.add_argument('--docs',dest='docs',action='store_true',help='Check installation of packages for building documentation')
 parser.add_argument('--diff',dest='diff',default=False,action='store_true',help='Use diff2html to generate git diff reports')
-parser.add_argument('--macos',dest='macos',default=False,action='store_true',help='Compile without libpng (currently needed for macos)')
 parser.add_argument('--profile',dest='profile',action='store_true',default=False,help="Enable tiny profiling in AMReX")
 parser.add_argument('--perf',dest='perf',action='store_true',default=False,help="Add profile flags")
 parser.add_argument('--coverage',dest='coverage',action='store_true',default=False,help="Enable test coverage with gcov")
@@ -469,7 +468,11 @@ if (sys.platform == "darwin"
 #
 # MAC OS SUPPORT
 #
-if args.macos:
+# Apple's ld64 won't coalesce weak symbols across TUs the way GNU ld does;
+# AMREX_FORCE_INLINE makes templated definitions inline-deduped instead.
+#
+if sys.platform == "darwin":
+    message("Darwin", "Defining ALAMO_SINGLE_DEFINITION=AMREX_FORCE_INLINE (ld64 weak-symbol workaround)")
     f.write("ALAMO_INCLUDE += -DALAMO_SINGLE_DEFINITION=AMREX_FORCE_INLINE\n")
 
 #

--- a/configure
+++ b/configure
@@ -124,6 +124,7 @@ parser.add_argument('--build-amrex-branch',dest="buildamrexbranch",default=None,
 parser.add_argument('--build-amrex-tag',dest="buildamrextag",default=None, help='AMReX Branch (You probably don\'t need to change this!)' )
 parser.add_argument('--eigen', default="", help='Path to Eigen installation prefix (containing include/eigen3/) []')
 parser.add_argument('--get-eigen', dest="geteigen",action='store_true',default=False, help='Download Eigen automatically')
+parser.add_argument('--libpng', default="", help='Path to libpng installation prefix (containing include/ and lib/) []')
 parser.add_argument('--debug', dest='debug', action='store_true', help='Compile in debug mode')
 parser.add_argument('--no-debug', dest='debug', action='store_false', help='[Compile in production mode]')
 parser.add_argument('--offline', dest='offline', action='store_true',default=False, help='[Compile in production mode]')
@@ -436,6 +437,36 @@ elif (args.eigen != ""):
 
 
 #
+# AUTO-DETECT LIBPNG VIA HOMEBREW ON MACOS
+#
+# Same rationale as eigen above: Homebrew's prefix is not in Apple Clang's
+# default include or library search path.
+#
+if (sys.platform == "darwin"
+        and not args.libpng
+        and shutil.which("brew")):
+    try:
+        brew_libpng_prefix = subprocess.run(
+            ["brew", "--prefix", "libpng"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        if (os.path.isdir(os.path.join(brew_libpng_prefix, "include"))
+                and os.path.isdir(os.path.join(brew_libpng_prefix, "lib"))):
+            args.libpng = brew_libpng_prefix
+            message("libpng-Autodetect", f"Found Homebrew libpng at {brew_libpng_prefix}")
+        else:
+            warning(
+                f"Homebrew reported libpng at {brew_libpng_prefix} but "
+                "include/ or lib/ was not found there. Skipping auto-detect."
+            )
+    except subprocess.CalledProcessError:
+        note(
+            "Homebrew is installed but libpng is not. Install it with "
+            + code("brew install libpng")
+            + " or pass --libpng=<prefix> manually."
+        )
+
+#
 # MAC OS SUPPORT
 #
 if args.macos:
@@ -444,6 +475,14 @@ if args.macos:
 #
 # LINK LIBPNG
 #
+if args.libpng:
+    if not os.path.isdir(os.path.join(args.libpng, "include")):
+        raise Exception(color.red+"ERROR"+color.reset+": libpng prefix must contain include/ subdirectory")
+    if not os.path.isdir(os.path.join(args.libpng, "lib")):
+        raise Exception(color.red+"ERROR"+color.reset+": libpng prefix must contain lib/ subdirectory")
+    message("libpng-Directory", args.libpng)
+    f.write(f"ALAMO_INCLUDE += -isystem {args.libpng}/include\n")
+    f.write(f"LIB += -L{args.libpng}/lib -Wl,-rpath,{args.libpng}/lib\n")
 f.write("LIB += -lpng \n")
 
 #

--- a/configure
+++ b/configure
@@ -116,7 +116,7 @@ if os.path.exists(pre_args.config):
 
 parser = argparse.ArgumentParser(description='Configure ALAMO');
 parser.add_argument('--dim', default=3, type=int, help='Spatial dimension [3]')
-parser.add_argument('--comp', default="g++", help='Compiler. Options: [g++], clang++, icc')
+parser.add_argument('--comp', default="g++", help='Compiler. Options: [g++], clang++, icc (or a path to one of these executables)')
 parser.add_argument('--amrex', default=None, help='Path to AMReX installation []')
 parser.add_argument('--build-amrex', dest="buildamrex",action='store_true',default=True, help='Download and build AMReX automatically')
 parser.add_argument('--build-amrex-fork', dest="amrexfork",default="AMReX-Codes", help='Specify an AMReX fork')
@@ -151,13 +151,20 @@ parser.set_defaults(**defaults)
 #
 
 args=parser.parse_args()
+
+# Accept a path or a versioned name (e.g. /spack/.../bin/g++-15) as --comp by
+# normalizing to the bare compiler name for type checks. Invocations still
+# use args.comp so the original path/binary is actually executed.
+comp_basename = os.path.basename(args.comp)
+comp_basename = re.sub(r"-\d+(\.\d+)*$", "", comp_basename)
+
 if args.buildamrexbranch and args.buildamrextag:
     raise(Exception(error("You cannot specify build-amrex-tag and build-amrex-branch at the same time")))
 if args.memcheck and not args.debug: 
     raise(Exception(error("To use memcheck you must also add the --debug flag")))
 if args.memcheck and args.coverage: 
     raise(Exception(error("Cannot run memcheck and coverage at the same time currently")))
-if args.memcheck and args.memcheck_tool == "msan" and not args.comp=="clang++":
+if args.memcheck and args.memcheck_tool == "msan" and not comp_basename=="clang++":
     raise(Exception(error("MSan only works with clang, use --comp=clang++")))
 
 if pre_args.save:
@@ -219,7 +226,7 @@ if args.memcheck:
 if args.profile: postfix += "-profile"
 if args.perf: postfix += "-perf"
 if args.coverage: postfix += "-coverage"
-postfix += "-" + args.comp
+postfix += "-" + comp_basename
 f.write("POSTFIX = " + postfix + '\n')
 
 #
@@ -315,9 +322,9 @@ if args.buildamrex and not args.amrex:
     amrex_configure += ' --dim=' + str(args.dim)
     amrex_configure += ' --prefix=' + postfix_amrex
     amrex_configure += ' --with-fortran=no'
-    if   args.comp == "g++":     amrex_configure += ' --comp=gnu'
-    elif args.comp == "clang++": amrex_configure += ' --comp=llvm --allow-different-compiler=yes '
-    elif args.comp == "icc":     amrex_configure += ' --comp=intel'
+    if   comp_basename =="g++":     amrex_configure += ' --comp=gnu'
+    elif comp_basename =="clang++": amrex_configure += ' --comp=llvm --allow-different-compiler=yes '
+    elif comp_basename =="icc":     amrex_configure += ' --comp=intel'
     if args.debug: amrex_configure += ' --debug=yes --enable-pic=yes'
     if args.profile: amrex_configure += ' --enable-tiny-profile=yes'
     
@@ -499,11 +506,11 @@ if args.link:
 #
 # CHECK COMPILER AND SET OPTIONS
 #
-if   (args.comp == "g++"):     f.write("COMP = GCC\n")
-elif (args.comp == "clang++"): f.write("COMP = CLANG\n")
-elif (args.comp == "icc"):     f.write("COMP = INTEL\n")
+if   (comp_basename =="g++"):     f.write("COMP = GCC\n")
+elif (comp_basename =="clang++"): f.write("COMP = CLANG\n")
+elif (comp_basename =="icc"):     f.write("COMP = INTEL\n")
 else: raise Exception(color.red + "ERROR" + color.reset + ": Compiler must be g++, clang++, or icc")
-message("Comp-Type", str(args.comp))
+message("Comp-Type", comp_basename)
 shellmessage("Comp-Version",args.comp+" --version")
 
 
@@ -528,7 +535,7 @@ message("mpi implementation", mpidist)
 if mpidist == "openmpi":
     compmpicmd = shellmessage("openmpi comp flags", "mpicxx --showme:compiler").stdout.decode('utf-8').replace('\n','')
     compmpicmd = args.comp + " " + compmpicmd
-    shellmessage("openmpi c++ link"   , "mpicxx --showme:link".format(args.comp))
+    shellmessage("openmpi c++ link"   , "mpicxx --showme:link")
     shellmessage("openmpi version", "mpicxx --showme:version")
     env = os.environ.copy()
     env.update({'OMPI_CXX': args.comp})
@@ -591,7 +598,7 @@ if args.perf:
 #   note: this must come after the MPI section, otherwise the order of
 #         flags may cause linker to fail!
 #
-if args.comp == 'g++':
+if comp_basename =='g++':
     f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
     if args.coverage:
         f.write("LINKER_FLAGS += -fprofile-arcs\n")
@@ -613,7 +620,7 @@ if args.comp == 'g++':
     else:
         f.write("CXX_COMPILE_FLAGS += -O3 -flto\n")
         f.write("LINKER_FLAGS += -flto\n")
-if args.comp == 'clang++':
+if comp_basename =='clang++':
     f.write("CXX_COMPILE_FLAGS += -Wpedantic\n")
     if args.debug:
         f.write("CXX_COMPILE_FLAGS += -ggdb -g3 -fPIC\n")
@@ -623,7 +630,7 @@ if args.comp == 'clang++':
     else:
         f.write("CXX_COMPILE_FLAGS += -O3\n")
         f.write("LINKER_FLAGS += -flto \n")    
-if args.comp == 'icc':
+if comp_basename =='icc':
     if args.debug: f.write("CXX_COMPILE_FLAGS += -ggdb -g3\n")
     else:          f.write("CXX_COMPILE_FLAGS += -Ofast -ipo\n") # 
 
@@ -662,7 +669,7 @@ f2.write(f"\t$(QUIET)git diff > $@\n")
 # PYTHON CHECKING
 #
 f2.write(f"python_ok:\n")
-if args.comp == 'g++' and args.debug:
+if comp_basename =='g++' and args.debug:
     f2.write(f"\n")
 else:
     f2.write(f"""\t$(error $(error Python module requires configuration with --comp=g++ and --debug))\n""")

--- a/configure
+++ b/configure
@@ -122,7 +122,7 @@ parser.add_argument('--build-amrex', dest="buildamrex",action='store_true',defau
 parser.add_argument('--build-amrex-fork', dest="amrexfork",default="AMReX-Codes", help='Specify an AMReX fork')
 parser.add_argument('--build-amrex-branch',dest="buildamrexbranch",default=None, help='Specify an AMReX branch (You probably don\'t need to change this!)' )
 parser.add_argument('--build-amrex-tag',dest="buildamrextag",default=None, help='AMReX Branch (You probably don\'t need to change this!)' )
-parser.add_argument('--eigen', default="", help='Path to Eigen installation []')
+parser.add_argument('--eigen', default="", help='Path to Eigen installation prefix (containing include/eigen3/) []')
 parser.add_argument('--get-eigen', dest="geteigen",action='store_true',default=False, help='Download Eigen automatically')
 parser.add_argument('--debug', dest='debug', action='store_true', help='Compile in debug mode')
 parser.add_argument('--no-debug', dest='debug', action='store_false', help='[Compile in production mode]')
@@ -395,20 +395,19 @@ if (sys.platform == "darwin"
             ["brew", "--prefix", "eigen"],
             capture_output=True, text=True, check=True,
         ).stdout.strip()
-        candidate = os.path.join(brew_eigen_prefix, "include")
-        if os.path.isdir(os.path.join(candidate, "eigen3")):
-            args.eigen = candidate
-            message("Eigen-Autodetect", f"Found Homebrew eigen at {candidate}")
+        if os.path.isdir(os.path.join(brew_eigen_prefix, "include", "eigen3")):
+            args.eigen = brew_eigen_prefix
+            message("Eigen-Autodetect", f"Found Homebrew Eigen at {brew_eigen_prefix}")
         else:
             warning(
-                f"Homebrew reported eigen at {brew_eigen_prefix} but "
+                f"Homebrew reported Eigen at {brew_eigen_prefix} but "
                 "include/eigen3 was not found there. Skipping auto-detect."
             )
     except subprocess.CalledProcessError:
         note(
-            "Homebrew is installed but eigen is not. Install it with "
+            "Homebrew is installed but Eigen is not. Install it with "
             + code("brew install eigen")
-            + " or pass --eigen=<path> manually."
+            + " or pass --eigen=<prefix> manually."
         )
 
 #
@@ -430,10 +429,10 @@ if (args.geteigen):
     message("Eigen-Directory","ext/libeigen/")
     f.write("EIGEN = ./ext/libeigen/\n")
 elif (args.eigen != ""):
-    if not os.path.isdir(args.eigen + "/eigen3"):
-        raise Exception(color.red+"ERROR"+color.reset+": Eigen directory must contain eigen3 subdirectory")
+    if not os.path.isdir(os.path.join(args.eigen, "include", "eigen3")):
+        raise Exception(color.red+"ERROR"+color.reset+": Eigen prefix must contain include/eigen3/ subdirectory")
     message("Eigen-Directory",args.eigen)
-    f.write("EIGEN = " + args.eigen + "\n")
+    f.write(f"EIGEN = {args.eigen}/include\n")
 
 
 #

--- a/src/IC/PSRead.H
+++ b/src/IC/PSRead.H
@@ -14,7 +14,7 @@ using namespace std;
 #include <vector>
 #include <algorithm>
 #include <iterator>
-#include "mpi.h"
+#include <mpi.h>
 #include "IO/ParmParse.H"
 
 namespace IC

--- a/src/Util/Util.cpp
+++ b/src/Util/Util.cpp
@@ -18,7 +18,7 @@
 #include "Color.H"
 #include "Numeric/Stencil.H"
 #include "Util/MPI.H"
-#include "mpi.h"
+#include <mpi.h>
 
 namespace Util
 {


### PR DESCRIPTION
**NOTE: This PR is in draft because it depends on the changes in #282. Once #282 has merged, I will retarget the PR (or reopen if retargeting is not possible).**

This PR can be roughly broken down in three broad sections, all of which directly or indirectly solve many of the pain points when developing Alamo on macOS. If I've done this right, **developers on Linux systems should experience no changes to their workflow because of this PR**.

## Improving the macOS out-of-the-box experience
- Auto-detect Homebrew Eigen and libpng on Darwin
- Auto-define `ALAMO_SINGLE_DEFINITION=AMREX_FORCE_INLINE` on Darwin to fix ld64 duplicate-symbol errors on weak templates
- Skip GNU-only linker flags (`-Bsymbolic-functions`, `-lstdc++fs`) on Darwin
- Revise `install-macos.sh`
- Remove `--macOS` flag (folded into Darwin auto-detect)

## Configure script improvements
- New `--libpng=<prefix>` flag mirrors `--eigen`
- `--eigen` now takes installation prefix (was: include dir) for symmetry with `--libpng`
- `--comp` accepts compiler paths and version suffixes (_e.g._, `/opt/homebrew/opt/gcc/bin/g++-15`)
- `compile_commands.json now` includes Eigen, libpng, and `CPLUS_INCLUDE_PATH` entries

## Bug fixes
- Fix `CPLUS_INCLUDE_PATH` parsing in the `Makefile` (the `$(for ...)` snippet was invalid Make and silently produced no flags)
- Change `#include "mpi.h"` to `#include <mpi.h>` to avoid silently matching Alamo's `MPI.H` on case-insensitive filesystems