### PR TITLE
Improve elastic MLMG and Newton solver robustness

### DIFF
--- a/src/BC/Constant.cpp
+++ b/src/BC/Constant.cpp
@@ -1,4 +1,6 @@
 #include "Constant.H"
+#include "AMReX_Array.H"
+#include "AMReX_GpuContainers.H"
 
 namespace BC
 {
@@ -65,109 +67,142 @@ Constant::FillBoundary (amrex::BaseFab<Set::Scalar> &a_in,
 
     Util::Assert(INFO,TEST(a_in.nComp() == (int)m_ncomp));
 
+    AMREX_D_TERM(   amrex::Real DX_0 = DX[0];,
+                    amrex::Real DX_1 = DX[1];,
+                    amrex::Real DX_2 = DX[2];);
+
     amrex::Box box = a_box;
     box.grow(ngrow);
-    const amrex::Dim3 lo= amrex::lbound(m_geom.Domain()), hi = amrex::ubound(m_geom.Domain());
+    const amrex::Dim3
+        lo= amrex::lbound(m_geom.Domain()),
+        hi = amrex::ubound(m_geom.Domain());
 
     amrex::Array4<amrex::Real> const& in = a_in.array();
 
     for (int n = 0; n < a_in.nComp(); n++)
     {
-        amrex::ParallelFor (box,[=] AMREX_GPU_DEVICE(int i, int j, int k)
-        {
-            amrex::IntVect glevel;
-            AMREX_D_TERM(   glevel[0] = std::max(std::min(0,i-lo.x),i-hi.x); ,
-                            glevel[1] = std::max(std::min(0,j-lo.y),j-hi.y); ,
-                            glevel[2] = std::max(std::min(0,k-lo.z),k-hi.z); );
-        
-            if (glevel[0]<0 && (face == Orientation::xlo || face == Orientation::All)) // Left boundary
-            {
-                if (BCUtil::IsDirichlet(m_bc_type[Face::XLO][n]))
-                    in(i,j,k,n) = m_bc_val[Face::XLO][n](time);
-                else if(BCUtil::IsNeumann(m_bc_type[Face::XLO][n]))
-                    in(i,j,k,n) = in(i-glevel[0],j,k,n) - (m_bc_val[Face::XLO].size() > 0 ? m_bc_val[Face::XLO][n](time)*DX[0] : 0);
-                else if(BCUtil::IsReflectEven(m_bc_type[Face::XLO][n]))
-                    in(i,j,k,n) = in(1-glevel[0],j,k,n);
-                else if(BCUtil::IsReflectOdd(m_bc_type[Face::XLO][n]))
-                    in(i,j,k,n) = -in(1-glevel[0],j,k,n);
-                else if(BCUtil::IsPeriodic(m_bc_type[Face::XLO][n])) {}
-                else
-                    Util::Abort(INFO, "Incorrect boundary conditions");
-            }
-            else if (glevel[0]>0 && (face == Orientation::xhi || face == Orientation::All)) // Right boundary
-            {
-                if (BCUtil::IsDirichlet(m_bc_type[Face::XHI][n]))
-                    in(i,j,k,n) = m_bc_val[Face::XHI][n](time);
-                else if(BCUtil::IsNeumann(m_bc_type[Face::XHI][n]))
-                    in(i,j,k,n) = in(i-glevel[0],j,k,n) - (m_bc_val[Face::XHI].size() > 0 ? m_bc_val[Face::XHI][n](time)*DX[0] : 0);
-                else if(BCUtil::IsReflectEven(m_bc_type[Face::XHI][n]))
-                    in(i,j,k,n) = in(hi.x-glevel[0],j,k,n);
-                else if(BCUtil::IsReflectOdd(m_bc_type[Face::XHI][n]))
-                    in(i,j,k,n) = -in(hi.x-glevel[0],j,k,n);
-                else if(BCUtil::IsPeriodic(m_bc_type[Face::XHI][n])) {}
-                else
-                    Util::Abort(INFO, "Incorrect boundary conditions");
-            }
-        
-            else if (glevel[1]<0 && (face == Orientation::ylo || face == Orientation::All)) // Bottom boundary
-            {
-                if (BCUtil::IsDirichlet(m_bc_type[Face::YLO][n]))
-                    in(i,j,k,n) = m_bc_val[Face::YLO][n](time);
-                else if (BCUtil::IsNeumann(m_bc_type[Face::YLO][n]))
-                    in(i,j,k,n) = in(i,j-glevel[1],k,n) - (m_bc_val[Face::YLO].size() > 0 ? m_bc_val[Face::YLO][n](time)*DX[1] : 0);
-                else if (BCUtil::IsReflectEven(m_bc_type[Face::YLO][n]))
-                    in(i,j,k,n) = in(i,j-glevel[1],k,n);
-                else if (BCUtil::IsReflectOdd(m_bc_type[Face::YLO][n]))
-                    in(i,j,k,n) = -in(i,j-glevel[1],k,n);
-                else if(BCUtil::IsPeriodic(m_bc_type[Face::YLO][n])) {}
-                else
-                    Util::Abort(INFO, "Incorrect boundary conditions");
-            }
-            else if (glevel[1]>0 && (face == Orientation::yhi || face == Orientation::All)) // Top boundary
-            {
-                if (BCUtil::IsDirichlet(m_bc_type[Face::YHI][n]))
-                    in(i,j,k,n) = m_bc_val[Face::YHI][n](time);
-                else if (BCUtil::IsNeumann(m_bc_type[Face::YHI][n]))
-                    in(i,j,k,n) = in(i,j-glevel[1],k,n) - (m_bc_val[Face::YHI].size() > 0 ? m_bc_val[Face::YHI][n](time)*DX[1] : 0);
-                else if (BCUtil::IsReflectEven(m_bc_type[Face::YHI][n]))
-                    in(i,j,k,n) = in(i,hi.y-glevel[1],k,n);
-                else if (BCUtil::IsReflectOdd(m_bc_type[Face::YHI][n]))
-                    in(i,j,k,n) = -in(i,hi.y-glevel[1],k,n);
-                else if(BCUtil::IsPeriodic(m_bc_type[Face::YHI][n])) {}
-                else
-                    Util::Abort(INFO, "Incorrect boundary conditions");
-            }
+        auto bc_type_xlo_n = this->m_bc_type[Face::XLO][n];
+        auto bc_val_xlo_size = m_bc_val[Face::XLO].size();
+        auto bc_val_xlo_n = bc_val_xlo_size ? m_bc_val[Face::XLO][n](time) : 0.0;
 
-#if AMREX_SPACEDIM>2
-            else if (glevel[2]<0 && (face == Orientation::zlo || face == Orientation::All))
+        auto bc_type_xhi_n = this->m_bc_type[Face::XHI][n];
+        auto bc_val_xhi_size = m_bc_val[Face::XHI].size();
+        auto bc_val_xhi_n = bc_val_xhi_size ? m_bc_val[Face::XHI][n](time) : 0.0;
+
+        #if AMREX_SPACEDIM > 1
+        auto bc_type_ylo_n = this->m_bc_type[Face::YLO][n];
+        auto bc_val_ylo_size = m_bc_val[Face::YLO].size();
+        auto bc_val_ylo_n = bc_val_ylo_size ? m_bc_val[Face::YLO][n](time) : 0.0;
+
+        auto bc_type_yhi_n = this->m_bc_type[Face::YHI][n];
+        auto bc_val_yhi_size = m_bc_val[Face::YHI].size();
+        auto bc_val_yhi_n = bc_val_yhi_size ? m_bc_val[Face::YHI][n](time) : 0.0;
+        #endif
+
+        #if AMREX_SPACEDIM > 2
+        auto bc_type_zlo_n = this->m_bc_type[Face::ZLO][n];
+        auto bc_val_zlo_size = m_bc_val[Face::ZLO].size();
+        auto bc_val_zlo_n = bc_val_zlo_size ? m_bc_val[Face::ZLO][n](time) : 0.0;
+
+        auto bc_type_zhi_n = this->m_bc_type[Face::ZHI][n];
+        auto bc_val_zhi_size = m_bc_val[Face::ZHI].size();
+        auto bc_val_zhi_n = bc_val_zhi_size ? m_bc_val[Face::ZHI][n](time) : 0.0;
+        #endif
+
+
+        amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+
+            AMREX_D_TERM(   int glevel_0 = std::max(std::min(0,i-lo.x),i-hi.x); ,
+                            int glevel_1 = std::max(std::min(0,j-lo.y),j-hi.y); ,
+                            int glevel_2 = std::max(std::min(0,k-lo.z),k-hi.z); );
+        
+            if (glevel_0 < 0 && (face == Orientation::xlo || face == Orientation::All)) // Left boundary
             {
-                if (BCUtil::IsDirichlet(m_bc_type[Face::ZLO][n]))
-                    in(i,j,k,n) = m_bc_val[Face::ZLO][n](time);
-                else if (BCUtil::IsNeumann(m_bc_type[Face::ZLO][n]))
-                    in(i,j,k,n) = in(i,j,k-glevel[2],n) - (m_bc_val[Face::ZLO].size() > 0 ? m_bc_val[Face::ZLO][n](time)*DX[2] : 0);
-                else if (BCUtil::IsReflectEven(m_bc_type[Face::ZLO][n]))
-                    in(i,j,k,n) = in(i,j,1-glevel[2],n);
-                else if (BCUtil::IsReflectOdd(m_bc_type[Face::ZLO][n]))
-                    in(i,j,k,n) = -in(i,j,1-glevel[2],n);
-                else if(BCUtil::IsPeriodic(m_bc_type[Face::ZLO][n])) {}
-                else Util::Abort(INFO, "Incorrect boundary conditions");
+                if (BCUtil::IsDirichlet(bc_type_xlo_n))
+                    in(i,j,k,n) = bc_val_xlo_n;
+                else if(BCUtil::IsNeumann(bc_type_xlo_n))
+                    in(i,j,k,n) = in(i-glevel_0,j,k,n) - bc_val_xlo_n*DX_0;
+                else if(BCUtil::IsReflectEven(bc_type_xlo_n))
+                    in(i,j,k,n) = in(1-glevel_0,j,k,n);
+                else if(BCUtil::IsReflectOdd(bc_type_xlo_n))
+                    in(i,j,k,n) = -in(1-glevel_0,j,k,n);
+                else if(BCUtil::IsPeriodic(bc_type_xlo_n)){}
+                else
+                    Util::Abort(INFO, "Incorrect boundary conditions");
             }
-            else if (glevel[2]>0 && (face == Orientation::zhi || face == Orientation::All))
+            else if (glevel_0>0 && (face == Orientation::xhi || face == Orientation::All)) // Right boundary
             {
-                if (BCUtil::IsDirichlet(m_bc_type[Face::ZHI][n]))
-                    in(i,j,k,n) = m_bc_val[Face::ZHI][n](time);
-                else if(BCUtil::IsNeumann(m_bc_type[Face::ZHI][n]))
-                    in(i,j,k,n) = in(i,j,k-glevel[2],n) - (m_bc_val[Face::ZHI].size() > 0 ? m_bc_val[Face::ZHI][n](time)*DX[2] : 0);
-                else if(BCUtil::IsReflectEven(m_bc_type[Face::ZHI][n]))
-                    in(i,j,k,n) = in(i,j,hi.z-glevel[2],n);
-                else if(BCUtil::IsReflectOdd(m_bc_type[Face::ZHI][n]))
-                    in(i,j,k,n) = -in(i,j,hi.z-glevel[2],n);
-                else if(BCUtil::IsPeriodic(m_bc_type[Face::ZHI][n])) {}
-                else Util::Abort(INFO, "Incorrect boundary conditions");
+                if (BCUtil::IsDirichlet(bc_type_xhi_n))
+                    in(i,j,k,n) = bc_val_xhi_n;
+                else if(BCUtil::IsNeumann(bc_type_xhi_n))
+                    in(i,j,k,n) = in(i-glevel_0,j,k,n) - bc_val_xhi_n*DX_0;
+                else if(BCUtil::IsReflectEven(bc_type_xhi_n))
+                    in(i,j,k,n) = in(hi.x-glevel_0,j,k,n);
+                else if(BCUtil::IsReflectOdd(bc_type_xhi_n))
+                    in(i,j,k,n) = -in(hi.x-glevel_0,j,k,n);
+                else if(BCUtil::IsPeriodic(bc_type_xhi_n)){}
+                else
+                    Util::Abort(INFO, "Incorrect boundary conditions");
+            }
+            else if (glevel_1<0 && (face == Orientation::ylo || face == Orientation::All)) // Bottom boundary
+            {
+                if (BCUtil::IsDirichlet(bc_type_ylo_n))
+                    in(i,j,k,n) = bc_val_ylo_n;
+                else if (BCUtil::IsNeumann(bc_type_ylo_n))
+                    in(i,j,k,n) = in(i,j-glevel_1,k,n) - bc_val_ylo_n*DX_1;
+                else if (BCUtil::IsReflectEven(bc_type_ylo_n))
+                    in(i,j,k,n) = in(i,j-glevel_1,k,n);
+                else if (BCUtil::IsReflectOdd(bc_type_ylo_n))
+                    in(i,j,k,n) = -in(i,j-glevel_1,k,n);
+                else if(BCUtil::IsPeriodic(bc_type_ylo_n)){}
+                else
+                    Util::Abort(INFO, "Incorrect boundary conditions");
+            }
+            else if (glevel_1>0 && (face == Orientation::yhi || face == Orientation::All)) // Top boundary
+            {
+                if (BCUtil::IsDirichlet(bc_type_yhi_n))
+                    in(i,j,k,n) = bc_val_yhi_n;
+                else if (BCUtil::IsNeumann(bc_type_yhi_n))
+                    in(i,j,k,n) = in(i,j-glevel_1,k,n) - bc_val_yhi_n*DX_1;
+                else if (BCUtil::IsReflectEven(bc_type_yhi_n))
+                    in(i,j,k,n) = in(i,hi.y-glevel_1,k,n);
+                else if (BCUtil::IsReflectOdd(bc_type_yhi_n))
+                    in(i,j,k,n) = -in(i,hi.y-glevel_1,k,n);
+                else if(BCUtil::IsPeriodic(bc_type_yhi_n)){}
+                else
+                    Util::Abort(INFO, "Incorrect boundary conditions");
+            }
+#if AMREX_SPACEDIM>2
+            else if (glevel_2<0 && (face == Orientation::zlo || face == Orientation::All))
+            {
+                if (BCUtil::IsDirichlet(bc_type_zlo_n))
+                    in(i,j,k,n) = bc_val_zlo_n;
+                else if (BCUtil::IsNeumann(bc_type_zlo_n))
+                    in(i,j,k,n) = in(i,j,k-glevel_2,n) - bc_val_zlo_n*DX_2;
+                else if (BCUtil::IsReflectEven(bc_type_zlo_n))
+                    in(i,j,k,n) = in(i,j,1-glevel_2,n);
+                else if (BCUtil::IsReflectOdd(bc_type_zlo_n))
+                    in(i,j,k,n) = -in(i,j,1-glevel_2,n);
+                else if(BCUtil::IsPeriodic(bc_type_zlo_n)){}
+                else
+                    Util::Abort(INFO, "Incorrect boundary conditions");
+            }
+            else if (glevel_2>0 && (face == Orientation::zhi || face == Orientation::All))
+            {
+                if (BCUtil::IsDirichlet(bc_type_zhi_n))
+                    in(i,j,k,n) = bc_val_zhi_n;
+                else if(BCUtil::IsNeumann(bc_type_zhi_n))
+                    in(i,j,k,n) = in(i,j,k-glevel_2,n) - bc_val_zhi_n*DX_2;
+                else if(BCUtil::IsReflectEven(bc_type_zhi_n))
+                    in(i,j,k,n) = in(i,j,hi.z-glevel_2,n);
+                else if(BCUtil::IsReflectOdd(bc_type_zhi_n))
+                    in(i,j,k,n) = -in(i,j,hi.z-glevel_2,n);
+                else if(BCUtil::IsPeriodic(bc_type_zhi_n)){}
+                else
+                    Util::Abort(INFO, "Incorrect boundary conditions");
             }
 #endif
         });
-
         // Average the value of corner cells based on the neighboring ghost cells.
         // This fixes NAN issues that can arise from neumann conditions calculated in ghost cells
         // Fixes this issue in 2D only for now.

--- a/src/BC/Operator/Elastic/Constant.H
+++ b/src/BC/Operator/Elastic/Constant.H
@@ -18,9 +18,24 @@
 #define BC_OPERATOR_ELASTIC_CONSTANT_H
 
 // #include "Operator/Elastic.H"
+#include "AMReX_Loop.H"
 #include "IO/ParmParse.H"
 #include "Numeric/Interpolator/Linear.H"
 #include "BC/Operator/Elastic/Elastic.H"
+
+#ifdef ALAMO_GPU
+#define ALAMO_ELASTIC_BC_FOR amrex::ParallelFor
+#define ALAMO_ELASTIC_BC_DEVICE AMREX_GPU_DEVICE
+#define ALAMO_ELASTIC_BC_TYPE(face, dir) bc_type[face][dir]
+#define ALAMO_ELASTIC_BC_VAL(face, dir) bc_val[face][dir]
+#define ALAMO_ELASTIC_BC_PERIODIC(dir) periodic[dir]
+#else
+#define ALAMO_ELASTIC_BC_FOR amrex::LoopConcurrentOnCpu
+#define ALAMO_ELASTIC_BC_DEVICE
+#define ALAMO_ELASTIC_BC_TYPE(face, dir) m_bc_type[face][dir]
+#define ALAMO_ELASTIC_BC_VAL(face, dir) m_bc_val[face][dir](m_time)
+#define ALAMO_ELASTIC_BC_PERIODIC(dir) a_geom.isPeriodic(dir)
+#endif
 
 namespace BC
 {
@@ -105,12 +120,23 @@ public:
             amrex::Box domain(a_geom.growPeriodicDomain(2));
             domain.convert(amrex::IntVect::TheNodeVector());
             const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
+#ifdef ALAMO_GPU
+            amrex::GpuArray<amrex::GpuArray<Type, AMREX_SPACEDIM>, m_nfaces> bc_type;
+            amrex::GpuArray<amrex::GpuArray<Set::Scalar, AMREX_SPACEDIM>, m_nfaces> bc_val;
+            for (int face = 0; face < m_nfaces; ++face)
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+                {
+                    bc_type[face][dir] = m_bc_type[face][dir];
+                    bc_val[face][dir] = m_bc_val[face][dir](m_time);
+                }
+            const amrex::GpuArray<int, AMREX_SPACEDIM> periodic = a_geom.isPeriodicArray();
+#endif
             for (amrex::MFIter mfi(*a_rhs, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
                 amrex::Box bx = mfi.grownnodaltilebox();
                 bx = bx & domain;
                 amrex::Array4<Set::Vector> const& rhs       = a_rhs->array(mfi);
-                amrex::ParallelFor (bx,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                ALAMO_ELASTIC_BC_FOR(bx, [=] ALAMO_ELASTIC_BC_DEVICE (int i, int j, int k) noexcept {
                     
                 for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
                 {
@@ -161,21 +187,21 @@ public:
 
                     #endif
 
-                    if (a_geom.isPeriodic(0) && a_geom.isPeriodic(1))
+                    if (ALAMO_ELASTIC_BC_PERIODIC(0) && ALAMO_ELASTIC_BC_PERIODIC(1))
                     {
                         if (face == Face::XLO || face == Face::XHI ||
                             face == Face::YLO || face == Face::YHI) continue;
                     }
-                    if (a_geom.isPeriodic(0))
+                    if (ALAMO_ELASTIC_BC_PERIODIC(0))
                     {
                         if (face == Face::XLO || face==Face::XHI) continue;
                     }
-                    if (a_geom.isPeriodic(1))
+                    if (ALAMO_ELASTIC_BC_PERIODIC(1))
                     {
                         if (face == Face::YLO || face==Face::YHI) continue;
                     }
                     #if AMREX_SPACEDIM == 3
-                    if (a_geom.isPeriodic(2))
+                    if (ALAMO_ELASTIC_BC_PERIODIC(2))
                     {
                         if (face == Face::ZLO || face==Face::ZHI) continue;
                     }
@@ -183,10 +209,10 @@ public:
 
                     if (!(face == Face::INT))
                     {
-                        if (a_homogeneous && m_bc_type[face][dir] == Type::Displacement) 
+                        if (a_homogeneous && ALAMO_ELASTIC_BC_TYPE(face, dir) == Type::Displacement)
                             rhs(i,j,k)(dir) = 0.0;
                         else 
-                            rhs(i,j,k)(dir) = m_bc_val[face][dir](m_time);
+                            rhs(i,j,k)(dir) = ALAMO_ELASTIC_BC_VAL(face, dir);
                     }
                 }
             });
@@ -202,13 +228,24 @@ public:
             amrex::Box domain(a_geom.Domain());
             domain.convert(amrex::IntVect::TheNodeVector());
             const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
+#ifdef ALAMO_GPU
+            amrex::GpuArray<amrex::GpuArray<Type, AMREX_SPACEDIM>, m_nfaces> bc_type;
+            amrex::GpuArray<amrex::GpuArray<Set::Scalar, AMREX_SPACEDIM>, m_nfaces> bc_val;
+            for (int face = 0; face < m_nfaces; ++face)
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+                {
+                    bc_type[face][dir] = m_bc_type[face][dir];
+                    bc_val[face][dir] = m_bc_val[face][dir](m_time);
+                }
+            const amrex::GpuArray<int, AMREX_SPACEDIM> periodic = a_geom.isPeriodicArray();
+#endif
             for (amrex::MFIter mfi(*a_rhs, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
                 amrex::Box bx = mfi.tilebox();
                 bx.grow(2);
                 bx = bx & domain;
                 amrex::Array4<amrex::Real> const& rhs       = a_rhs->array(mfi);
-                amrex::ParallelFor (bx,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                ALAMO_ELASTIC_BC_FOR(bx, [=] ALAMO_ELASTIC_BC_DEVICE (int i, int j, int k) noexcept {
                     
                 for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
                 {
@@ -259,180 +296,64 @@ public:
 
                     #endif
                     
-                    if (a_geom.isPeriodic(0) && a_geom.isPeriodic(1))
+                    if (ALAMO_ELASTIC_BC_PERIODIC(0) && ALAMO_ELASTIC_BC_PERIODIC(1))
                     {
                         if (face == Face::XLO || face == Face::XHI ||
                             face == Face::YLO || face == Face::YHI) continue;
                     }
-                    if (a_geom.isPeriodic(0))
+                    if (ALAMO_ELASTIC_BC_PERIODIC(0))
                     {
                         if (face == Face::XLO || face==Face::XHI) continue;
                     }
-                    if (a_geom.isPeriodic(1))
+                    if (ALAMO_ELASTIC_BC_PERIODIC(1))
                     {
                         if (face == Face::YLO || face==Face::YHI) continue;
                     }
 
                     if (!(face == Face::INT))
                     {
-                        if (a_homogeneous && m_bc_type[face][dir] == Type::Displacement) 
+                        if (a_homogeneous && ALAMO_ELASTIC_BC_TYPE(face, dir) == Type::Displacement)
                             rhs(i,j,k,dir) = 0.0;
                         else 
-                            rhs(i,j,k,dir) = m_bc_val[face][dir](m_time);
+                            rhs(i,j,k,dir) = ALAMO_ELASTIC_BC_VAL(face, dir);
                     }
                 }
             });
         }                    
     }
 
-    virtual
+#ifndef ALAMO_GPU
+    AMREX_GPU_HOST_DEVICE
     std::array<Type,AMREX_SPACEDIM> getType (
-                const int &i, const int &j, [[maybe_unused]] const int &k,
+                const int &i, const int &j, const int &k,
                 const amrex::Box &domain) override
     {
-        amrex::IntVect m(AMREX_D_DECL(i,j,k));
-        const amrex::Dim3 lo = amrex::lbound(domain), hi = amrex::ubound(domain);
-
-        // Corners
-        #if AMREX_SPACEDIM == 2
-        if (m[0] == lo.x && m[1] == lo.y)                  return m_bc_type[Face::XLO_YLO];
-        if (m[0] == lo.x && m[1] == hi.y)                  return m_bc_type[Face::XLO_YHI];
-        if (m[0] == hi.x && m[1] == lo.y)                  return m_bc_type[Face::XHI_YLO];
-        if (m[0] == hi.x && m[1] == hi.y)                  return m_bc_type[Face::XHI_YHI];
-        if (m[0] == lo.x)                                  return m_bc_type[Face::XLO];
-        if (m[0] == hi.x)                                  return m_bc_type[Face::XHI];
-        if (m[1] == lo.y)                                  return m_bc_type[Face::YLO];
-        if (m[1] == hi.y)                                  return m_bc_type[Face::YHI];
-        
-        #elif AMREX_SPACEDIM == 3
-        
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == lo.z) return m_bc_type[Face::XLO_YLO_ZLO];
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == hi.z) return m_bc_type[Face::XLO_YLO_ZHI];
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == lo.z) return m_bc_type[Face::XLO_YHI_ZLO];
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == hi.z) return m_bc_type[Face::XLO_YHI_ZHI];
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == lo.z) return m_bc_type[Face::XHI_YLO_ZLO];
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == hi.z) return m_bc_type[Face::XHI_YLO_ZHI];
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == lo.z) return m_bc_type[Face::XHI_YHI_ZLO];
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == hi.z) return m_bc_type[Face::XHI_YHI_ZHI];
-        
-        if (m[1] == lo.y && m[2] == lo.z)                  return m_bc_type[Face::YLO_ZLO];
-        if (m[1] == lo.y && m[2] == hi.z)                  return m_bc_type[Face::YLO_ZHI];
-        if (m[1] == hi.y && m[2] == lo.z)                  return m_bc_type[Face::YHI_ZLO];
-        if (m[1] == hi.y && m[2] == hi.z)                  return m_bc_type[Face::YHI_ZHI];
-        if (m[2] == lo.z && m[0] == lo.x)                  return m_bc_type[Face::ZLO_XLO];
-        if (m[2] == lo.z && m[0] == hi.x)                  return m_bc_type[Face::ZLO_XHI];
-        if (m[2] == hi.z && m[0] == lo.x)                  return m_bc_type[Face::ZHI_XLO];
-        if (m[2] == hi.z && m[0] == hi.x)                  return m_bc_type[Face::ZHI_XHI];
-        if (m[0] == lo.x && m[1] == lo.y)                  return m_bc_type[Face::XLO_YLO];
-        if (m[0] == lo.x && m[1] == hi.y)                  return m_bc_type[Face::XLO_YHI];
-        if (m[0] == hi.x && m[1] == lo.y)                  return m_bc_type[Face::XHI_YLO];
-        if (m[0] == hi.x && m[1] == hi.y)                  return m_bc_type[Face::XHI_YHI];
-        
-        if (m[0] == lo.x)                                  return m_bc_type[Face::XLO];
-        if (m[0] == hi.x)                                  return m_bc_type[Face::XHI];
-        if (m[1] == lo.y)                                  return m_bc_type[Face::YLO];
-        if (m[1] == hi.y)                                  return m_bc_type[Face::YHI];
-        if (m[2] == lo.z)                                  return m_bc_type[Face::ZLO];
-        if (m[2] == hi.z)                                  return m_bc_type[Face::ZHI];
-        
-        #endif        
-
-        return {AMREX_D_DECL(Type::None,Type::None,Type::None)};
+        return Elastic::typeOf(m_bc_type, i, j, k, domain);
     }
 
-
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     Set::Vector operator () (const Set::Vector &u,
                 const Set::Matrix &gradu,
                 const Set::Matrix &sigma,
                 const int &i, const int &j, const int &k,
                 const amrex::Box &domain) override
     {
-        (void)i; (void)j; (void)k; // Suppress "unused variable" warnings
-        //Set::Vector f;
-
-        const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
-        
-        amrex::IntVect m(AMREX_D_DECL(i,j,k));
-
-        // Corners
-        #if AMREX_SPACEDIM == 2
-        
-        if (m[0] == lo.x && m[1] == lo.y)                  return set(m_bc_type[Face::XLO_YLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, -SQRT2INV));
-        if (m[0] == lo.x && m[1] == hi.y)                  return set(m_bc_type[Face::XLO_YHI],     u, gradu, sigma, Set::Vector(-SQRT2INV, +SQRT2INV));
-        if (m[0] == hi.x && m[1] == lo.y)                  return set(m_bc_type[Face::XHI_YLO],     u, gradu, sigma, Set::Vector(+SQRT2INV, -SQRT2INV));
-        if (m[0] == hi.x && m[1] == hi.y)                  return set(m_bc_type[Face::XHI_YHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, +SQRT2INV));
-        
-        if (m[0] == lo.x)                                  return set(m_bc_type[Face::XLO],         u, gradu, sigma, Set::Vector(-1, 0));
-        if (m[0] == hi.x)                                  return set(m_bc_type[Face::XHI],         u, gradu, sigma, Set::Vector(+1, 0));
-        if (m[1] == lo.y)                                  return set(m_bc_type[Face::YLO],         u, gradu, sigma, Set::Vector( 0,-1));
-        if (m[1] == hi.y)                                  return set(m_bc_type[Face::YHI],         u, gradu, sigma, Set::Vector( 0,+1));
-        
-        #elif AMREX_SPACEDIM == 3
-        
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == lo.z) return set(m_bc_type[Face::XLO_YLO_ZLO], u, gradu, sigma, Set::Vector(-SQRT3INV,-SQRT3INV,-SQRT3INV));
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == hi.z) return set(m_bc_type[Face::XLO_YLO_ZHI], u, gradu, sigma, Set::Vector(-SQRT3INV,-SQRT3INV,+SQRT3INV));
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == lo.z) return set(m_bc_type[Face::XLO_YHI_ZLO], u, gradu, sigma, Set::Vector(-SQRT3INV,+SQRT3INV,-SQRT3INV));
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == hi.z) return set(m_bc_type[Face::XLO_YHI_ZHI], u, gradu, sigma, Set::Vector(-SQRT3INV,+SQRT3INV,+SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == lo.z) return set(m_bc_type[Face::XHI_YLO_ZLO], u, gradu, sigma, Set::Vector(+SQRT3INV,-SQRT3INV,-SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == hi.z) return set(m_bc_type[Face::XHI_YLO_ZHI], u, gradu, sigma, Set::Vector(+SQRT3INV,-SQRT3INV,+SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == lo.z) return set(m_bc_type[Face::XHI_YHI_ZLO], u, gradu, sigma, Set::Vector(+SQRT3INV,+SQRT3INV,-SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == hi.z) return set(m_bc_type[Face::XHI_YHI_ZHI], u, gradu, sigma, Set::Vector(+SQRT3INV,+SQRT3INV,+SQRT3INV));
-        
-        if (m[1] == lo.y && m[2] == lo.z)                  return set(m_bc_type[Face::YLO_ZLO],     u, gradu, sigma, Set::Vector(0,        -SQRT2INV,-SQRT2INV));
-        if (m[1] == lo.y && m[2] == hi.z)                  return set(m_bc_type[Face::YLO_ZHI],     u, gradu, sigma, Set::Vector(0,        -SQRT2INV,+SQRT2INV));
-        if (m[1] == hi.y && m[2] == lo.z)                  return set(m_bc_type[Face::YHI_ZLO],     u, gradu, sigma, Set::Vector(0,        +SQRT2INV,-SQRT2INV));
-        if (m[1] == hi.y && m[2] == hi.z)                  return set(m_bc_type[Face::YHI_ZHI],     u, gradu, sigma, Set::Vector(0,        +SQRT2INV,+SQRT2INV));
-        if (m[2] == lo.z && m[0] == lo.x)                  return set(m_bc_type[Face::ZLO_XLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, 0,       -SQRT2INV));
-        if (m[2] == lo.z && m[0] == hi.x)                  return set(m_bc_type[Face::ZLO_XHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, 0,       -SQRT2INV));
-        if (m[2] == hi.z && m[0] == lo.x)                  return set(m_bc_type[Face::ZHI_XLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, 0,       +SQRT2INV));
-        if (m[2] == hi.z && m[0] == hi.x)                  return set(m_bc_type[Face::ZHI_XHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, 0,       +SQRT2INV));
-        if (m[0] == lo.x && m[1] == lo.y)                  return set(m_bc_type[Face::XLO_YLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, -SQRT2INV,0       ));
-        if (m[0] == lo.x && m[1] == hi.y)                  return set(m_bc_type[Face::XLO_YHI],     u, gradu, sigma, Set::Vector(-SQRT2INV, +SQRT2INV,0       ));
-        if (m[0] == hi.x && m[1] == lo.y)                  return set(m_bc_type[Face::XHI_YLO],     u, gradu, sigma, Set::Vector(+SQRT2INV, -SQRT2INV,0       ));
-        if (m[0] == hi.x && m[1] == hi.y)                  return set(m_bc_type[Face::XHI_YHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, +SQRT2INV,0       ));
-        
-        if (m[0] == lo.x)                                  return set(m_bc_type[Face::XLO],         u, gradu, sigma, Set::Vector(-1, 0, 0));
-        if (m[0] == hi.x)                                  return set(m_bc_type[Face::XHI],         u, gradu, sigma, Set::Vector(+1, 0, 0));
-        if (m[1] == lo.y)                                  return set(m_bc_type[Face::YLO],         u, gradu, sigma, Set::Vector( 0,-1, 0));
-        if (m[1] == hi.y)                                  return set(m_bc_type[Face::YHI],         u, gradu, sigma, Set::Vector( 0,+1, 0));
-        if (m[2] == lo.z)                                  return set(m_bc_type[Face::ZLO],         u, gradu, sigma, Set::Vector( 0, 0,-1));
-        if (m[2] == hi.z)                                  return set(m_bc_type[Face::ZHI],         u, gradu, sigma, Set::Vector( 0, 0,+1));
-        
-        #endif
-        
-        Util::Abort(INFO,"Boundary condition error");
-        return Set::Vector::Zero();
+        return Elastic::eval(m_bc_type, u, gradu, sigma, i, j, k, domain);
     }
 
     AMREX_FORCE_INLINE
-    Set::Vector set(std::array<Type,AMREX_SPACEDIM> &bc_type, 
+    AMREX_GPU_HOST_DEVICE
+    Set::Vector set(std::array<Type,AMREX_SPACEDIM> &bc_type,
                     const Set::Vector &u, const Set::Matrix &gradu, const Set::Matrix &sigma, Set::Vector n) const
     {
-        Set::Vector f = Set::Vector::Zero();
-        for (int i = 0; i < AMREX_SPACEDIM; i++)
-        {
-            if      (bc_type[i] == Type::Displacement) 
-                f(i) = u(i);
-            else if (bc_type[i] == Type::Traction)
-                f(i) = (sigma*n)(i);
-            else if (bc_type[i] == Type::Neumann)
-                f(i) = (gradu*n)(i);
-            else
-                continue;
-        }
-        return f;
+        return Elastic::set(bc_type, u, gradu, sigma, n);
     }
+#endif
+
 
 protected:
     
-    #if AMREX_SPACEDIM==2
-    static const int m_nfaces = 8;
-    #elif AMREX_SPACEDIM==3
-    static const int m_nfaces = 26;
-    #endif
-
-    std::array<std::array<Type,                                      AMREX_SPACEDIM>, m_nfaces> m_bc_type; 
     std::array<std::array<Numeric::Interpolator::Linear<Set::Scalar>,AMREX_SPACEDIM>, m_nfaces> m_bc_val; 
 
 public:

--- a/src/BC/Operator/Elastic/Elastic.H
+++ b/src/BC/Operator/Elastic/Elastic.H
@@ -23,11 +23,11 @@ public:
     virtual ~Elastic() = default;
 
 public:
-    enum Type {Displacement, Traction, Periodic, Neumann, None}; 
+    enum Type {Displacement, Traction, Periodic, Neumann, None};
 
     #if AMREX_SPACEDIM==2
     enum Face{
-        XLO, YLO, XHI, YHI, 
+        XLO, YLO, XHI, YHI,
         XLO_YLO, XLO_YHI, XHI_YLO, XHI_YHI,
         INT
     };
@@ -43,9 +43,22 @@ public:
     };
     #endif
 
-    enum Direction {AMREX_D_DECL(X=0,Y=1,Z=2)}; 
+    enum Direction {AMREX_D_DECL(X=0,Y=1,Z=2)};
 
-    void 
+    #if AMREX_SPACEDIM==2
+    static const int m_nfaces = 8;
+    #elif AMREX_SPACEDIM==3
+    static const int m_nfaces = 26;
+    #endif
+
+    // The boundary-condition *type* per (face,direction). This is the only state
+    // the in-kernel boundary operator needs, and it is plain-old-data (an array of
+    // Type enums), so it can be captured by value into a device kernel. The
+    // value data (Constant::m_bc_val interpolators, Expression::m_bc_func parsers)
+    // lives in the derived classes and is only consumed by Init() on the host.
+    using BcTypeArray = std::array<std::array<Type,AMREX_SPACEDIM>, m_nfaces>;
+
+    void
     SetTime(const Set::Scalar a_time) {m_time = a_time;}
 
     virtual void
@@ -79,20 +92,199 @@ public:
 #define SQRT3INV 0.57735026919
 #define SQRT2INV 0.70710678118
 
+    // Device-copyable accessor: copy this on the host and capture it into a
+    // device ParallelFor, then call eval()/typeOf() below.
+    AMREX_GPU_HOST_DEVICE
+    const BcTypeArray& GetBcTypeArray() const { return m_bc_type; }
+
+    // ----------------------------------------------------------------------
+    // Static, device-callable boundary logic. These are shared by every BC
+    // type (Constant/TensionTest/Expression) because they all dispatch purely
+    // on the (face,direction) Type. Operating on a passed-in m_bc_type avoids
+    // dereferencing a host object/vtable on the device.
+    // ----------------------------------------------------------------------
+
+    AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
+    static Set::Vector set(const std::array<Type,AMREX_SPACEDIM> &bc_type,
+                    const Set::Vector &u, const Set::Matrix &gradu, const Set::Matrix &sigma, Set::Vector n)
+    {
+        Set::Vector f = Set::Vector::Zero();
+        for (int i = 0; i < AMREX_SPACEDIM; i++)
+        {
+            if      (bc_type[i] == Type::Displacement)
+                f(i) = u(i);
+            else if (bc_type[i] == Type::Traction)
+                f(i) = (sigma*n)(i);
+            else if (bc_type[i] == Type::Neumann)
+                f(i) = (gradu*n)(i);
+            else
+                continue;
+        }
+        return f;
+    }
+
+    AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
+    static std::array<Type,AMREX_SPACEDIM> typeOf (
+                const BcTypeArray &m_bc_type,
+                const int &i, const int &j, [[maybe_unused]] const int &k,
+                const amrex::Box &domain)
+    {
+        amrex::IntVect m(AMREX_D_DECL(i,j,k));
+        const amrex::Dim3 lo = amrex::lbound(domain), hi = amrex::ubound(domain);
+
+        // Corners
+        #if AMREX_SPACEDIM == 2
+        if (m[0] == lo.x && m[1] == lo.y)                  return m_bc_type[Face::XLO_YLO];
+        if (m[0] == lo.x && m[1] == hi.y)                  return m_bc_type[Face::XLO_YHI];
+        if (m[0] == hi.x && m[1] == lo.y)                  return m_bc_type[Face::XHI_YLO];
+        if (m[0] == hi.x && m[1] == hi.y)                  return m_bc_type[Face::XHI_YHI];
+        if (m[0] == lo.x)                                  return m_bc_type[Face::XLO];
+        if (m[0] == hi.x)                                  return m_bc_type[Face::XHI];
+        if (m[1] == lo.y)                                  return m_bc_type[Face::YLO];
+        if (m[1] == hi.y)                                  return m_bc_type[Face::YHI];
+
+        #elif AMREX_SPACEDIM == 3
+
+        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == lo.z) return m_bc_type[Face::XLO_YLO_ZLO];
+        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == hi.z) return m_bc_type[Face::XLO_YLO_ZHI];
+        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == lo.z) return m_bc_type[Face::XLO_YHI_ZLO];
+        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == hi.z) return m_bc_type[Face::XLO_YHI_ZHI];
+        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == lo.z) return m_bc_type[Face::XHI_YLO_ZLO];
+        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == hi.z) return m_bc_type[Face::XHI_YLO_ZHI];
+        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == lo.z) return m_bc_type[Face::XHI_YHI_ZLO];
+        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == hi.z) return m_bc_type[Face::XHI_YHI_ZHI];
+
+        if (m[1] == lo.y && m[2] == lo.z)                  return m_bc_type[Face::YLO_ZLO];
+        if (m[1] == lo.y && m[2] == hi.z)                  return m_bc_type[Face::YLO_ZHI];
+        if (m[1] == hi.y && m[2] == lo.z)                  return m_bc_type[Face::YHI_ZLO];
+        if (m[1] == hi.y && m[2] == hi.z)                  return m_bc_type[Face::YHI_ZHI];
+        if (m[2] == lo.z && m[0] == lo.x)                  return m_bc_type[Face::ZLO_XLO];
+        if (m[2] == lo.z && m[0] == hi.x)                  return m_bc_type[Face::ZLO_XHI];
+        if (m[2] == hi.z && m[0] == lo.x)                  return m_bc_type[Face::ZHI_XLO];
+        if (m[2] == hi.z && m[0] == hi.x)                  return m_bc_type[Face::ZHI_XHI];
+        if (m[0] == lo.x && m[1] == lo.y)                  return m_bc_type[Face::XLO_YLO];
+        if (m[0] == lo.x && m[1] == hi.y)                  return m_bc_type[Face::XLO_YHI];
+        if (m[0] == hi.x && m[1] == lo.y)                  return m_bc_type[Face::XHI_YLO];
+        if (m[0] == hi.x && m[1] == hi.y)                  return m_bc_type[Face::XHI_YHI];
+
+        if (m[0] == lo.x)                                  return m_bc_type[Face::XLO];
+        if (m[0] == hi.x)                                  return m_bc_type[Face::XHI];
+        if (m[1] == lo.y)                                  return m_bc_type[Face::YLO];
+        if (m[1] == hi.y)                                  return m_bc_type[Face::YHI];
+        if (m[2] == lo.z)                                  return m_bc_type[Face::ZLO];
+        if (m[2] == hi.z)                                  return m_bc_type[Face::ZHI];
+
+        #endif
+
+        return {AMREX_D_DECL(Type::None,Type::None,Type::None)};
+    }
+
+    AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
+    static Set::Vector eval (const BcTypeArray &m_bc_type,
+                const Set::Vector &u,
+                const Set::Matrix &gradu,
+                const Set::Matrix &sigma,
+                const int &i, const int &j, const int &k,
+                const amrex::Box &domain)
+    {
+        (void)i; (void)j; (void)k; // Suppress "unused variable" warnings
+
+        const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
+
+        amrex::IntVect m(AMREX_D_DECL(i,j,k));
+
+        // Corners
+        #if AMREX_SPACEDIM == 2
+
+        if (m[0] == lo.x && m[1] == lo.y)                  return set(m_bc_type[Face::XLO_YLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, -SQRT2INV));
+        if (m[0] == lo.x && m[1] == hi.y)                  return set(m_bc_type[Face::XLO_YHI],     u, gradu, sigma, Set::Vector(-SQRT2INV, +SQRT2INV));
+        if (m[0] == hi.x && m[1] == lo.y)                  return set(m_bc_type[Face::XHI_YLO],     u, gradu, sigma, Set::Vector(+SQRT2INV, -SQRT2INV));
+        if (m[0] == hi.x && m[1] == hi.y)                  return set(m_bc_type[Face::XHI_YHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, +SQRT2INV));
+
+        if (m[0] == lo.x)                                  return set(m_bc_type[Face::XLO],         u, gradu, sigma, Set::Vector(-1, 0));
+        if (m[0] == hi.x)                                  return set(m_bc_type[Face::XHI],         u, gradu, sigma, Set::Vector(+1, 0));
+        if (m[1] == lo.y)                                  return set(m_bc_type[Face::YLO],         u, gradu, sigma, Set::Vector( 0,-1));
+        if (m[1] == hi.y)                                  return set(m_bc_type[Face::YHI],         u, gradu, sigma, Set::Vector( 0,+1));
+
+        #elif AMREX_SPACEDIM == 3
+
+        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == lo.z) return set(m_bc_type[Face::XLO_YLO_ZLO], u, gradu, sigma, Set::Vector(-SQRT3INV,-SQRT3INV,-SQRT3INV));
+        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == hi.z) return set(m_bc_type[Face::XLO_YLO_ZHI], u, gradu, sigma, Set::Vector(-SQRT3INV,-SQRT3INV,+SQRT3INV));
+        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == lo.z) return set(m_bc_type[Face::XLO_YHI_ZLO], u, gradu, sigma, Set::Vector(-SQRT3INV,+SQRT3INV,-SQRT3INV));
+        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == hi.z) return set(m_bc_type[Face::XLO_YHI_ZHI], u, gradu, sigma, Set::Vector(-SQRT3INV,+SQRT3INV,+SQRT3INV));
+        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == lo.z) return set(m_bc_type[Face::XHI_YLO_ZLO], u, gradu, sigma, Set::Vector(+SQRT3INV,-SQRT3INV,-SQRT3INV));
+        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == hi.z) return set(m_bc_type[Face::XHI_YLO_ZHI], u, gradu, sigma, Set::Vector(+SQRT3INV,-SQRT3INV,+SQRT3INV));
+        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == lo.z) return set(m_bc_type[Face::XHI_YHI_ZLO], u, gradu, sigma, Set::Vector(+SQRT3INV,+SQRT3INV,-SQRT3INV));
+        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == hi.z) return set(m_bc_type[Face::XHI_YHI_ZHI], u, gradu, sigma, Set::Vector(+SQRT3INV,+SQRT3INV,+SQRT3INV));
+
+        if (m[1] == lo.y && m[2] == lo.z)                  return set(m_bc_type[Face::YLO_ZLO],     u, gradu, sigma, Set::Vector(0,        -SQRT2INV,-SQRT2INV));
+        if (m[1] == lo.y && m[2] == hi.z)                  return set(m_bc_type[Face::YLO_ZHI],     u, gradu, sigma, Set::Vector(0,        -SQRT2INV,+SQRT2INV));
+        if (m[1] == hi.y && m[2] == lo.z)                  return set(m_bc_type[Face::YHI_ZLO],     u, gradu, sigma, Set::Vector(0,        +SQRT2INV,-SQRT2INV));
+        if (m[1] == hi.y && m[2] == hi.z)                  return set(m_bc_type[Face::YHI_ZHI],     u, gradu, sigma, Set::Vector(0,        +SQRT2INV,+SQRT2INV));
+        if (m[2] == lo.z && m[0] == lo.x)                  return set(m_bc_type[Face::ZLO_XLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, 0,       -SQRT2INV));
+        if (m[2] == lo.z && m[0] == hi.x)                  return set(m_bc_type[Face::ZLO_XHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, 0,       -SQRT2INV));
+        if (m[2] == hi.z && m[0] == lo.x)                  return set(m_bc_type[Face::ZHI_XLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, 0,       +SQRT2INV));
+        if (m[2] == hi.z && m[0] == hi.x)                  return set(m_bc_type[Face::ZHI_XHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, 0,       +SQRT2INV));
+        if (m[0] == lo.x && m[1] == lo.y)                  return set(m_bc_type[Face::XLO_YLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, -SQRT2INV,0       ));
+        if (m[0] == lo.x && m[1] == hi.y)                  return set(m_bc_type[Face::XLO_YHI],     u, gradu, sigma, Set::Vector(-SQRT2INV, +SQRT2INV,0       ));
+        if (m[0] == hi.x && m[1] == lo.y)                  return set(m_bc_type[Face::XHI_YLO],     u, gradu, sigma, Set::Vector(+SQRT2INV, -SQRT2INV,0       ));
+        if (m[0] == hi.x && m[1] == hi.y)                  return set(m_bc_type[Face::XHI_YHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, +SQRT2INV,0       ));
+
+        if (m[0] == lo.x)                                  return set(m_bc_type[Face::XLO],         u, gradu, sigma, Set::Vector(-1, 0, 0));
+        if (m[0] == hi.x)                                  return set(m_bc_type[Face::XHI],         u, gradu, sigma, Set::Vector(+1, 0, 0));
+        if (m[1] == lo.y)                                  return set(m_bc_type[Face::YLO],         u, gradu, sigma, Set::Vector( 0,-1, 0));
+        if (m[1] == hi.y)                                  return set(m_bc_type[Face::YHI],         u, gradu, sigma, Set::Vector( 0,+1, 0));
+        if (m[2] == lo.z)                                  return set(m_bc_type[Face::ZLO],         u, gradu, sigma, Set::Vector( 0, 0,-1));
+        if (m[2] == hi.z)                                  return set(m_bc_type[Face::ZHI],         u, gradu, sigma, Set::Vector( 0, 0,+1));
+
+        #endif
+
+        Util::Abort(INFO,"Boundary condition error");
+        return Set::Vector::Zero();
+    }
+
+#ifndef ALAMO_GPU
     virtual
+    AMREX_GPU_HOST_DEVICE
     std::array<Type,AMREX_SPACEDIM> getType (
                 const int &i, const int &j, const int &k,
                 const amrex::Box &domain) = 0;
 
     virtual
+    AMREX_GPU_HOST_DEVICE
     Set::Vector operator () (const Set::Vector &u,
                 const Set::Matrix &gradu,
                 const Set::Matrix &sigma,
                 const int &i, const int &j, const int &k,
                 const amrex::Box &domain) = 0;
+#else
+    // Non-static convenience wrappers for GPU call sites that hold a concrete
+    // BC object without requiring virtual dispatch.
+    AMREX_GPU_HOST_DEVICE
+    std::array<Type,AMREX_SPACEDIM> getType (
+                const int &i, const int &j, const int &k,
+                const amrex::Box &domain) const
+    {
+        return typeOf(m_bc_type, i, j, k, domain);
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    Set::Vector operator () (const Set::Vector &u,
+                const Set::Matrix &gradu,
+                const Set::Matrix &sigma,
+                const int &i, const int &j, const int &k,
+                const amrex::Box &domain) const
+    {
+        return eval(m_bc_type, u, gradu, sigma, i, j, k, domain);
+    }
+#endif
 
 protected:
     Set::Scalar m_time = 0.0;
+    BcTypeArray m_bc_type;
 };
 }
 }

--- a/src/BC/Operator/Elastic/Expression.H
+++ b/src/BC/Operator/Elastic/Expression.H
@@ -6,6 +6,7 @@
 #ifndef BC_OPERATOR_ELASTIC_EXPRESSION_H
 #define BC_OPERATOR_ELASTIC_EXPRESSION_H
 
+#include "AMReX_Loop.H"
 #include "IO/ParmParse.H"
 #include "BC/Operator/Elastic/Elastic.H"
 
@@ -58,6 +59,8 @@ public:
         const amrex::Geometry &a_geom,
         bool a_homogeneous = false) const override
     {
+            ALAMO_GPU_UNSUPPORTED_HOST_LOOP("BC::Operator::Elastic::Expression vector");
+
             amrex::Box domain(a_geom.Domain());
             domain.convert(amrex::IntVect::TheNodeVector());
             const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
@@ -67,7 +70,7 @@ public:
                 bx.grow(2);
                 bx = bx & domain;
                 amrex::Array4<Set::Vector> const& rhs       = a_rhs->array(mfi);
-                amrex::ParallelFor (bx,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                amrex::LoopConcurrentOnCpu (bx,[=] (int i, int j, int k) {
                     
                 for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
                 {
@@ -146,6 +149,8 @@ public:
         const amrex::Geometry &a_geom,
         bool a_homogeneous = false) const override
     {
+            ALAMO_GPU_UNSUPPORTED_HOST_LOOP("BC::Operator::Elastic::Expression scalar");
+
             amrex::Box domain(a_geom.Domain());
             domain.convert(amrex::IntVect::TheNodeVector());
             const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
@@ -155,7 +160,7 @@ public:
                 bx.grow(2);
                 bx = bx & domain;
                 amrex::Array4<amrex::Real> const& rhs       = a_rhs->array(mfi);
-                amrex::ParallelFor (bx,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                amrex::LoopConcurrentOnCpu (bx,[=] (int i, int j, int k) {
                     
                 for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
                 {
@@ -230,155 +235,42 @@ public:
 
 
 
-    virtual
+
+
+
+#ifndef ALAMO_GPU
+    AMREX_GPU_HOST_DEVICE
     std::array<Type,AMREX_SPACEDIM> getType (
-                const int &i, const int &j, [[maybe_unused]] const int &k,
+                const int &i, const int &j, const int &k,
                 const amrex::Box &domain) override
     {
-        (void)i, (void)j, (void)k;
-        amrex::IntVect m(AMREX_D_DECL(i,j,k));
-        const amrex::Dim3 lo = amrex::lbound(domain), hi = amrex::ubound(domain);
-
-        // Corners
-        #if AMREX_SPACEDIM == 2
-        if (m[0] == lo.x && m[1] == lo.y)                  return m_bc_type[Face::XLO_YLO];
-        if (m[0] == lo.x && m[1] == hi.y)                  return m_bc_type[Face::XLO_YHI];
-        if (m[0] == hi.x && m[1] == lo.y)                  return m_bc_type[Face::XHI_YLO];
-        if (m[0] == hi.x && m[1] == hi.y)                  return m_bc_type[Face::XHI_YHI];
-        if (m[0] == lo.x)                                  return m_bc_type[Face::XLO];
-        if (m[0] == hi.x)                                  return m_bc_type[Face::XHI];
-        if (m[1] == lo.y)                                  return m_bc_type[Face::YLO];
-        if (m[1] == hi.y)                                  return m_bc_type[Face::YHI];
-        
-        #elif AMREX_SPACEDIM == 3
-        
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == lo.z) return m_bc_type[Face::XLO_YLO_ZLO];
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == hi.z) return m_bc_type[Face::XLO_YLO_ZHI];
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == lo.z) return m_bc_type[Face::XLO_YHI_ZLO];
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == hi.z) return m_bc_type[Face::XLO_YHI_ZHI];
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == lo.z) return m_bc_type[Face::XHI_YLO_ZLO];
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == hi.z) return m_bc_type[Face::XHI_YLO_ZHI];
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == lo.z) return m_bc_type[Face::XHI_YHI_ZLO];
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == hi.z) return m_bc_type[Face::XHI_YHI_ZHI];
-        
-        if (m[1] == lo.y && m[2] == lo.z)                  return m_bc_type[Face::YLO_ZLO];
-        if (m[1] == lo.y && m[2] == hi.z)                  return m_bc_type[Face::YLO_ZHI];
-        if (m[1] == hi.y && m[2] == lo.z)                  return m_bc_type[Face::YHI_ZLO];
-        if (m[1] == hi.y && m[2] == hi.z)                  return m_bc_type[Face::YHI_ZHI];
-        if (m[2] == lo.z && m[0] == lo.x)                  return m_bc_type[Face::ZLO_XLO];
-        if (m[2] == lo.z && m[0] == hi.x)                  return m_bc_type[Face::ZLO_XHI];
-        if (m[2] == hi.z && m[0] == lo.x)                  return m_bc_type[Face::ZHI_XLO];
-        if (m[2] == hi.z && m[0] == hi.x)                  return m_bc_type[Face::ZHI_XHI];
-        if (m[0] == lo.x && m[1] == lo.y)                  return m_bc_type[Face::XLO_YLO];
-        if (m[0] == lo.x && m[1] == hi.y)                  return m_bc_type[Face::XLO_YHI];
-        if (m[0] == hi.x && m[1] == lo.y)                  return m_bc_type[Face::XHI_YLO];
-        if (m[0] == hi.x && m[1] == hi.y)                  return m_bc_type[Face::XHI_YHI];
-        
-        if (m[0] == lo.x)                                  return m_bc_type[Face::XLO];
-        if (m[0] == hi.x)                                  return m_bc_type[Face::XHI];
-        if (m[1] == lo.y)                                  return m_bc_type[Face::YLO];
-        if (m[1] == hi.y)                                  return m_bc_type[Face::YHI];
-        if (m[2] == lo.z)                                  return m_bc_type[Face::ZLO];
-        if (m[2] == hi.z)                                  return m_bc_type[Face::ZHI];
-        
-        #endif        
-        
-        return {AMREX_D_DECL(Type::None,Type::None,Type::None)};
+        return Elastic::typeOf(m_bc_type, i, j, k, domain);
     }
-    
 
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     Set::Vector operator () (const Set::Vector &u,
                 const Set::Matrix &gradu,
                 const Set::Matrix &sigma,
                 const int &i, const int &j, const int &k,
                 const amrex::Box &domain) override
     {
-        (void)i; (void)j; (void)k; // Suppress "unused variable" warnings
-        //Set::Vector f;
-
-        const amrex::Dim3 lo= amrex::lbound(domain), hi = amrex::ubound(domain);
-        
-        amrex::IntVect m(AMREX_D_DECL(i,j,k));
-
-        // Corners
-        #if AMREX_SPACEDIM == 2
-        
-        if (m[0] == lo.x && m[1] == lo.y)                  return set(m_bc_type[Face::XLO_YLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, -SQRT2INV));
-        if (m[0] == lo.x && m[1] == hi.y)                  return set(m_bc_type[Face::XLO_YHI],     u, gradu, sigma, Set::Vector(-SQRT2INV, +SQRT2INV));
-        if (m[0] == hi.x && m[1] == lo.y)                  return set(m_bc_type[Face::XHI_YLO],     u, gradu, sigma, Set::Vector(+SQRT2INV, -SQRT2INV));
-        if (m[0] == hi.x && m[1] == hi.y)                  return set(m_bc_type[Face::XHI_YHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, +SQRT2INV));
-        
-        if (m[0] == lo.x)                                  return set(m_bc_type[Face::XLO],         u, gradu, sigma, Set::Vector(-1, 0));
-        if (m[0] == hi.x)                                  return set(m_bc_type[Face::XHI],         u, gradu, sigma, Set::Vector(+1, 0));
-        if (m[1] == lo.y)                                  return set(m_bc_type[Face::YLO],         u, gradu, sigma, Set::Vector( 0,-1));
-        if (m[1] == hi.y)                                  return set(m_bc_type[Face::YHI],         u, gradu, sigma, Set::Vector( 0,+1));
-        
-        #elif AMREX_SPACEDIM == 3
-        
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == lo.z) return set(m_bc_type[Face::XLO_YLO_ZLO], u, gradu, sigma, Set::Vector(-SQRT3INV,-SQRT3INV,-SQRT3INV));
-        if (m[0] == lo.x &&  m[1] == lo.y && m[2] == hi.z) return set(m_bc_type[Face::XLO_YLO_ZHI], u, gradu, sigma, Set::Vector(-SQRT3INV,-SQRT3INV,+SQRT3INV));
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == lo.z) return set(m_bc_type[Face::XLO_YHI_ZLO], u, gradu, sigma, Set::Vector(-SQRT3INV,+SQRT3INV,-SQRT3INV));
-        if (m[0] == lo.x &&  m[1] == hi.y && m[2] == hi.z) return set(m_bc_type[Face::XLO_YHI_ZHI], u, gradu, sigma, Set::Vector(-SQRT3INV,+SQRT3INV,+SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == lo.z) return set(m_bc_type[Face::XHI_YLO_ZLO], u, gradu, sigma, Set::Vector(+SQRT3INV,-SQRT3INV,-SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == lo.y && m[2] == hi.z) return set(m_bc_type[Face::XHI_YLO_ZHI], u, gradu, sigma, Set::Vector(+SQRT3INV,-SQRT3INV,+SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == lo.z) return set(m_bc_type[Face::XHI_YHI_ZLO], u, gradu, sigma, Set::Vector(+SQRT3INV,+SQRT3INV,-SQRT3INV));
-        if (m[0] == hi.x &&  m[1] == hi.y && m[2] == hi.z) return set(m_bc_type[Face::XHI_YHI_ZHI], u, gradu, sigma, Set::Vector(+SQRT3INV,+SQRT3INV,+SQRT3INV));
-        
-        if (m[1] == lo.y && m[2] == lo.z)                  return set(m_bc_type[Face::YLO_ZLO],     u, gradu, sigma, Set::Vector(0,        -SQRT2INV,-SQRT2INV));
-        if (m[1] == lo.y && m[2] == hi.z)                  return set(m_bc_type[Face::YLO_ZHI],     u, gradu, sigma, Set::Vector(0,        -SQRT2INV,+SQRT2INV));
-        if (m[1] == hi.y && m[2] == lo.z)                  return set(m_bc_type[Face::YHI_ZLO],     u, gradu, sigma, Set::Vector(0,        +SQRT2INV,-SQRT2INV));
-        if (m[1] == hi.y && m[2] == hi.z)                  return set(m_bc_type[Face::YHI_ZHI],     u, gradu, sigma, Set::Vector(0,        +SQRT2INV,+SQRT2INV));
-        if (m[2] == lo.z && m[0] == lo.x)                  return set(m_bc_type[Face::ZLO_XLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, 0,       -SQRT2INV));
-        if (m[2] == lo.z && m[0] == hi.x)                  return set(m_bc_type[Face::ZLO_XHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, 0,       -SQRT2INV));
-        if (m[2] == hi.z && m[0] == lo.x)                  return set(m_bc_type[Face::ZHI_XLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, 0,       +SQRT2INV));
-        if (m[2] == hi.z && m[0] == hi.x)                  return set(m_bc_type[Face::ZHI_XHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, 0,       +SQRT2INV));
-        if (m[0] == lo.x && m[1] == lo.y)                  return set(m_bc_type[Face::XLO_YLO],     u, gradu, sigma, Set::Vector(-SQRT2INV, -SQRT2INV,0       ));
-        if (m[0] == lo.x && m[1] == hi.y)                  return set(m_bc_type[Face::XLO_YHI],     u, gradu, sigma, Set::Vector(-SQRT2INV, +SQRT2INV,0       ));
-        if (m[0] == hi.x && m[1] == lo.y)                  return set(m_bc_type[Face::XHI_YLO],     u, gradu, sigma, Set::Vector(+SQRT2INV, -SQRT2INV,0       ));
-        if (m[0] == hi.x && m[1] == hi.y)                  return set(m_bc_type[Face::XHI_YHI],     u, gradu, sigma, Set::Vector(+SQRT2INV, +SQRT2INV,0       ));
-        
-        if (m[0] == lo.x)                                  return set(m_bc_type[Face::XLO],         u, gradu, sigma, Set::Vector(-1, 0, 0));
-        if (m[0] == hi.x)                                  return set(m_bc_type[Face::XHI],         u, gradu, sigma, Set::Vector(+1, 0, 0));
-        if (m[1] == lo.y)                                  return set(m_bc_type[Face::YLO],         u, gradu, sigma, Set::Vector( 0,-1, 0));
-        if (m[1] == hi.y)                                  return set(m_bc_type[Face::YHI],         u, gradu, sigma, Set::Vector( 0,+1, 0));
-        if (m[2] == lo.z)                                  return set(m_bc_type[Face::ZLO],         u, gradu, sigma, Set::Vector( 0, 0,-1));
-        if (m[2] == hi.z)                                  return set(m_bc_type[Face::ZHI],         u, gradu, sigma, Set::Vector( 0, 0,+1));
-        
-        #endif
-        
-        Util::Abort(INFO,"Boundary condition error");
-        return Set::Vector::Zero();
+        return Elastic::eval(m_bc_type, u, gradu, sigma, i, j, k, domain);
     }
 
     AMREX_FORCE_INLINE
-    Set::Vector set(std::array<Type,AMREX_SPACEDIM> &bc_type, 
+    AMREX_GPU_HOST_DEVICE
+    Set::Vector set(std::array<Type,AMREX_SPACEDIM> &bc_type,
                     const Set::Vector &u, const Set::Matrix &gradu, const Set::Matrix &sigma, Set::Vector n) const
     {
-        Set::Vector f = Set::Vector::Zero();
-        for (int i = 0; i < AMREX_SPACEDIM; i++)
-        {
-            if      (bc_type[i] == Type::Displacement) 
-                f(i) = u(i);
-            else if (bc_type[i] == Type::Traction)
-                f(i) = (sigma*n)(i);
-            else if (bc_type[i] == Type::Neumann)
-                f(i) = (gradu*n)(i);
-            else if (bc_type[i] == Periodic)
-                continue;
-        }
-        return f;
+        return Elastic::set(bc_type, u, gradu, sigma, n);
     }
+#endif
+
 
 protected:
     
-    #if AMREX_SPACEDIM==2
-    static const int m_nfaces = 8;
-    #elif AMREX_SPACEDIM==3
-    static const int m_nfaces = 26;
-    #endif
 
-    std::array<std::array<Type,            AMREX_SPACEDIM>, m_nfaces> m_bc_type; 
     //std::array<std::array<FunctionParserAD,AMREX_SPACEDIM>, m_nfaces> m_bc_func; 
     std::array<std::array<amrex::Parser,AMREX_SPACEDIM>, m_nfaces> m_bc_func_parser; 
     std::array<std::array<amrex::ParserExecutor<4>,AMREX_SPACEDIM>, m_nfaces> m_bc_func; 

--- a/src/BC/Operator/Elastic/TensionTest.H
+++ b/src/BC/Operator/Elastic/TensionTest.H
@@ -40,8 +40,13 @@ public:
     ~TensionTest() {};
 
     using Constant::Init;
+#ifdef ALAMO_GPU
+    using Elastic::operator();
+    using Elastic::set;
+#else
     using Constant::operator();
     using Constant::set;
+#endif
 
     enum LoadingMode {TRAC,DISP};
 

--- a/src/Integrator/Base/Mechanics.H
+++ b/src/Integrator/Base/Mechanics.H
@@ -37,8 +37,8 @@ public:
         delete bc;
     }
 
-    // The mechanics integrator manages the solution of an elastic 
-    // solve using the MLMG solver. 
+    // The mechanics integrator manages the solution of an elastic
+    // solve using the MLMG solver.
     static void Parse(Mechanics& value, IO::ParmParse& pp)
     {
         BL_PROFILE("Integrator::Base::Mechanics::Parse");
@@ -55,6 +55,13 @@ public:
             pp_query_default("plot_psi", value.plot_psi, true); // Include :math:`\psi` field in output
             pp_query_default("plot_stress", value.plot_stress, true); // Include stress in output
             pp_query_default("plot_strain", value.plot_strain, true); // Include strain in output
+            AMREX_D_TERM(
+                pp_query_default("output_stress_symmetry.xlo", value.m_output_stress_symmetry_lo[0], 0);
+                pp_query_default("output_stress_symmetry.xhi", value.m_output_stress_symmetry_hi[0], 0);,
+                pp_query_default("output_stress_symmetry.ylo", value.m_output_stress_symmetry_lo[1], 0);
+                pp_query_default("output_stress_symmetry.yhi", value.m_output_stress_symmetry_hi[1], 0);,
+                pp_query_default("output_stress_symmetry.zlo", value.m_output_stress_symmetry_lo[2], 0);
+                pp_query_default("output_stress_symmetry.zhi", value.m_output_stress_symmetry_hi[2], 0););
 
             // Select the mechanical boundary conditions
             pp.select<BC::Operator::Elastic::Constant,BC::Operator::Elastic::TensionTest,BC::Operator::Elastic::Expression>("bc",value.bc);
@@ -142,16 +149,29 @@ public:
             }}
         });
         
+#ifdef ALAMO_GPU
+        if (value.m_type == Type::Dynamic)
+            Util::Abort(INFO, "elastic.type=dynamic is not GPU-safe: dynamic mechanics uses host BC polymorphism inside device kernels");
+#endif
         if (value.m_type == Type::Disable) return;
 
         value.RegisterGeneralFab(value.disp_mf, 1, 2, value.plot_disp, "disp", value.m_time_evolving);
         value.RegisterGeneralFab(value.rhs_mf, 1, 2, value.plot_rhs, "rhs", value.m_time_evolving);
-        value.RegisterGeneralFab(value.stress_mf, 1, 2, value.plot_stress, "stress", value.m_time_evolving);
+        // Keep the constitutive nodal stress as the internal mechanics field.
+        // Conservative solves write a separately derived face-consistent field,
+        // preventing plot semantics from feeding back into material advancement
+        // or integrated-traction diagnostics.
+        const bool separate_static_stress_output =
+            value.m_type == Type::Static && value.plot_stress;
+        value.RegisterGeneralFab(value.stress_mf, 1, 2,
+            value.plot_stress && !separate_static_stress_output,
+            "stress", value.m_time_evolving);
+        if (separate_static_stress_output)
+            value.RegisterGeneralFab(value.output_stress_mf, 1, 0, true, "stress", false);
         value.RegisterGeneralFab(value.strain_mf, 1, 2, value.plot_strain, "strain", value.m_time_evolving);
 
         if (value.m_print_model) value.RegisterGeneralFab(value.model_mf, 1, 2, "model", value.m_time_evolving);
         else value.RegisterGeneralFab(value.model_mf, 1, 2, value.m_time_evolving);
-
 
         value.RegisterIntegratedVariable(&(value.disp_hi[0].data()[0]), "disp_xhi_x");
         value.RegisterIntegratedVariable(&(value.disp_hi[0].data()[1]), "disp_xhi_y");
@@ -163,10 +183,9 @@ public:
         value.RegisterIntegratedVariable(&(value.trac_hi[1].data()[1]), "trac_yhi_y");
 
         if (value.m_print_residual) value.RegisterGeneralFab(value.res_mf, 1, 2, "res", false);
-
     }
 
-protected:
+public:
     /// \brief Use the #ic object to initialize#Temp
     void Initialize(int lev) override
     {
@@ -174,6 +193,8 @@ protected:
         if (m_type == Mechanics<MODEL>::Type::Disable) return;
 
         disp_mf[lev]->setVal(Set::Vector::Zero());
+        if (m_type == Type::Static && plot_stress)
+            output_stress_mf[lev]->setVal(Set::Matrix::Zero());
         //disp_old_mf[lev]->setVal(Set::Vector::Zero());
 
         if (m_type == Type::Dynamic)
@@ -216,26 +237,48 @@ protected:
         elastic_op.SetHomogeneous(false);
         elastic_op.SetBC(bc);
         IO::ParmParse pp("elasticop");
-
-        // Elastic operator
         pp.queryclass(elastic_op);
 
         solver.Define(elastic_op);
+        Util::Message(INFO, "ELASTIC SOLVE: t=", a_time, " step=", a_step, " m_type=", (int)m_type);
         if (psi_on) solver.setPsi(psi_mf);
 
         for (int lev = 0; lev <= finest_level; ++lev)
             if (m_zero_out_displacement) disp_mf[lev]->setVal(Set::Vector::Zero());
 
         solver.solve(disp_mf, rhs_mf, model_mf, tol_rel, tol_abs);
-        if (m_print_residual) solver.compLinearSolverResidual(res_mf, disp_mf, rhs_mf);
+        if (m_print_residual) solver.compResidual(res_mf, disp_mf, rhs_mf, model_mf);
         solver.Clear();
 
+        // elastic_op is a local that is about to go out of scope and free its
+        // internal per-AMR/MG-level buffers (m_ddw_mf, m_psi_mf, coefficient
+        // caches, ...) used throughout the whole V-cycle. Without a full-device
+        // sync here, a straggler kernel from deep in the MLMG solve (any level,
+        // any stream in AMReX's per-MFIter stream pool) can still be in flight
+        // when that memory is freed -- it then gets immediately reused by the
+        // *next* timestep's freshly-constructed elastic_op, causing intermittent
+        // CUDA-700 / host segfaults far from the actual race. Same UAF family as
+        // the dsol_mf fix in Solver::Nonlocal::Newton::solve(), but at the
+        // broader elastic_op lifetime boundary rather than one buffer.
+        amrex::Gpu::streamSynchronizeAll();
+
+        const bool use_face_consistent_output = solver.usesConservativeFaceFlux();
+        const auto output_stress_symmetry_lo = m_output_stress_symmetry_lo;
+        const auto output_stress_symmetry_hi = m_output_stress_symmetry_hi;
         for (int lev = 0; lev <= disp_mf.finest_level; lev++)
         {
             amrex::Box domain = geom[lev].Domain();
             domain.convert(amrex::IntVect::TheNodeVector());
+            const amrex::Dim3 lo = amrex::lbound(domain);
+            const amrex::Dim3 hi = amrex::ubound(domain);
+            amrex::GpuArray<int, AMREX_SPACEDIM> output_periodic;
+            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+                output_periodic[dir] = geom[lev].isPeriodic(dir);
 
-            const amrex::Real* DX = geom[lev].CellSize();
+            // Device-safe cell size: DX is a Set::Vector copied into the device
+            // closure; DX.data() is valid on device (a raw Geom().CellSize()
+            // host pointer would fault when dereferenced in the kernel).
+            Set::Vector DX(geom[lev].CellSize());
             for (MFIter mfi(*disp_mf[lev], false); mfi.isValid(); ++mfi)
             {
                 amrex::Box bx = mfi.nodaltilebox();
@@ -252,22 +295,80 @@ protected:
                     auto sten = Numeric::GetStencil(i, j, k, bx);
                     if (model(i, j, k).kinvar == Model::Solid::KinematicVariable::F)
                     {
-                        Set::Matrix F = Set::Matrix::Identity() + Numeric::Gradient(disp, i, j, k, DX, sten);
+                        Set::Matrix F = Set::Matrix::Identity() + Numeric::Gradient(disp, i, j, k, DX.data(), sten);
                         stress(i, j, k) = model(i, j, k).DW(F);
                         strain(i, j, k) = F;
                     }
                     else
                     {
-                        Set::Matrix gradu = Numeric::Gradient(disp, i, j, k, DX, sten);
+                        Set::Matrix gradu = Numeric::Gradient(disp, i, j, k, DX.data(), sten);
                         stress(i, j, k) = model(i, j, k).DW(gradu);
                         strain(i, j, k) = 0.5 * (gradu + gradu.transpose());
                     }
                 });
+
+                if (plot_stress)
+                {
+                    const amrex::Box plot_bx = mfi.nodaltilebox() & domain;
+                    amrex::Array4<const MODEL> const& plot_model = model_mf[lev]->const_array(mfi);
+                    amrex::Array4<const Set::Matrix> const& nodal_stress = stress_mf[lev]->const_array(mfi);
+                    amrex::Array4<Set::Matrix> const& output_stress = output_stress_mf[lev]->array(mfi);
+
+                    amrex::ParallelFor(plot_bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                    {
+                        const bool on_boundary = AMREX_D_TERM(
+                            (!output_periodic[0] && (i == lo.x || i == hi.x)),
+                            || (!output_periodic[1] && (j == lo.y || j == hi.y)),
+                            || (!output_periodic[2] && (k == lo.z || k == hi.z)));
+                        const bool on_symmetry = AMREX_D_TERM(
+                            (!output_periodic[0]
+                                && ((i == lo.x && output_stress_symmetry_lo[0])
+                                    || (i == hi.x && output_stress_symmetry_hi[0]))),
+                            || (!output_periodic[1]
+                                && ((j == lo.y && output_stress_symmetry_lo[1])
+                                    || (j == hi.y && output_stress_symmetry_hi[1]))),
+                            || (!output_periodic[2]
+                                && ((k == lo.z && output_stress_symmetry_lo[2])
+                                    || (k == hi.z && output_stress_symmetry_hi[2]))));
+                        const bool on_non_symmetry_boundary = AMREX_D_TERM(
+                            (!output_periodic[0]
+                                && ((i == lo.x && !output_stress_symmetry_lo[0])
+                                    || (i == hi.x && !output_stress_symmetry_hi[0]))),
+                            || (!output_periodic[1]
+                                && ((j == lo.y && !output_stress_symmetry_lo[1])
+                                    || (j == hi.y && !output_stress_symmetry_hi[1]))),
+                            || (!output_periodic[2]
+                                && ((k == lo.z && !output_stress_symmetry_lo[2])
+                                    || (k == hi.z && !output_stress_symmetry_hi[2]))));
+                        if (use_face_consistent_output
+                            && (!on_boundary || (on_symmetry && !on_non_symmetry_boundary)))
+                        {
+                            output_stress(i, j, k) = on_symmetry
+                                ? Solver::Nonlocal::Detail::NodalStressFromSymmetryFaces(
+                                    plot_model, disp, i, j, k, DX.data(), lo, hi,
+                                    output_stress_symmetry_lo, output_stress_symmetry_hi)
+                                : Solver::Nonlocal::Detail::NodalStressFromFaces(
+                                    plot_model, disp, i, j, k, DX.data());
+                        }
+                        else
+                        {
+                            // The conservative operator applies its BC directly
+                            // on physical-boundary rows, where the centered face
+                            // tangential stencil is not defined outside the domain.
+                            output_stress(i, j, k) = nodal_stress(i, j, k);
+                        }
+                    });
+                }
             }
             stress_mf[lev]->setMultiGhost(true);
             stress_mf[lev]->FillBoundaryAndSync(geom[lev].periodicity());
             strain_mf[lev]->setMultiGhost(true);
             strain_mf[lev]->FillBoundaryAndSync(geom[lev].periodicity());
+            if (plot_stress)
+            {
+                output_stress_mf[lev]->setMultiGhost(true);
+                output_stress_mf[lev]->FillBoundaryAndSync(geom[lev].periodicity());
+            }
         }
     }
 
@@ -275,7 +376,7 @@ protected:
     {
         BL_PROFILE("Integrator::Base::Mechanics::Advance");
         if (m_type == Mechanics<MODEL>::Type::Disable) return;
-        const amrex::Real* DX = geom[lev].CellSize();
+        Set::Vector DX(geom[lev].CellSize()); // device-safe cell size (copied into device closure)
 
         amrex::Box domain = geom[lev].Domain();
         domain.convert(amrex::IntVect::TheNodeVector());
@@ -287,6 +388,10 @@ protected:
             std::swap(*disp_mf[lev], *disp_old_mf[lev]);
             std::swap(*vel_mf[lev], *vel_old_mf[lev]);
 
+            auto bc = this->bc;
+            auto mu_newton = this->mu_newton;
+            auto mu_dashpot = this->mu_dashpot;
+            auto rho = this->rho;
 
             for (amrex::MFIter mfi(*disp_mf[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
@@ -302,10 +407,10 @@ protected:
                 Set::Patch<MODEL>             model = model_mf.Patch(lev,mfi);
 
                 amrex::Box bx = mfi.grownnodaltilebox() & domain;
-                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     auto sten = Numeric::GetStencil(i,j,k,bx);
-                    eps(i, j, k) = Numeric::Gradient(u, i, j, k, DX,sten);
+                    eps(i, j, k) = Numeric::Gradient(u, i, j, k, DX.data(),sten);
                     sig(i, j, k) = model(i, j, k).DW(eps(i, j, k));
                     //ddw(i,j,k) = model(i,j,k).DDW(eps(i,j,k));
                 });
@@ -319,7 +424,7 @@ protected:
 
                     if (AMREX_D_TERM(xmax || xmin, || ymax || ymin, || zmax || zmin))
                     {
-                        auto sten = Numeric::GetStencil(i,j,k,domain);                        
+                        auto sten = Numeric::GetStencil(i,j,k,domain);
 
                         auto bctype = bc->getType(i,j,k,domain);
 
@@ -331,12 +436,12 @@ protected:
                             }
                             else if (bctype[d] == BC::Operator::Elastic::Elastic::Type::Traction)
                             {
-                                
+
                                 Set::Vector N = Set::Normal(AMREX_D_DECL(xmin,ymin,zmin),
                                                             AMREX_D_DECL(xmax,ymax,zmax));
-                                
-                                auto [phi, offdiag] = Numeric::GradientSplit(u,i,j,k,DX,sten);
-                                
+
+                                auto [phi, offdiag] = Numeric::GradientSplit(u,i,j,k,DX.data(),sten);
+
                                 Set::Matrix A = Set::Matrix::Zero();
                                 Set::Vector rhs = b(i,j,k);
                                 Set::Matrix DW_F0 = model(i,j,k).DW(Set::Matrix::Zero());
@@ -353,7 +458,7 @@ protected:
 
                                                 rhs(p) -= ddw(p,q,r,s) * eps(i,j,k)(r,s) * N(q);
                                             }
-                                        
+
                                         rhs(p) -= DW_F0(p,q)*N(q);
                                     }
                                 Set::Vector delta_u = (A.inverse() * rhs);
@@ -371,9 +476,9 @@ protected:
                     {
                         //Set::Matrix      gradu = Numeric::Gradient(u,i,j,k,DX);
                         //Set::Matrix3 gradgradu = Numeric::Hessian(u,i,j,k,DX);
-                        
+
                         //Set::Vector f = ddw(i,j,k)*gradgradu;
-                        Set::Vector f = Numeric::Divergence(sig, i, j, k, DX);
+                        Set::Vector f = Numeric::Divergence(sig, i, j, k, DX.data());
 
                         //MATRIX4 AMREX_D_DECL(
                         //    Cgrad1 = (Numeric::Stencil<MATRIX4, 1, 0, 0>::D(ddw, i, j, k, 0, DX)),
@@ -383,10 +488,10 @@ protected:
                         //f += AMREX_D_TERM(  ( Cgrad1*gradu).col(0),
                         //                    +(Cgrad2*gradu).col(1),
                         //                    +(Cgrad3*gradu).col(2));
-                        
-                        Set::Vector lapv = Numeric::Laplacian(v, i, j, k, DX);
+
+                        Set::Vector lapv = Numeric::Laplacian(v, i, j, k, DX.data());
                         f += mu_newton * lapv + b(i,j,k) - mu_dashpot*v(i,j,k);
-                        
+
                         Set::Vector udotdot = f / rho;
                         vnew(i, j, k) = v(i, j, k) + dt * udotdot;
                         unew(i, j, k) = u(i, j, k) + dt * v(i, j, k);
@@ -406,9 +511,10 @@ protected:
                 model(i, j, k).Advance(dt, eps(i, j, k), sig(i, j, k),time);
             });
         }
-        
+
         model_mf[lev]->setMultiGhost(true);
         model_mf[lev]->FillBoundaryAndSync(geom[lev].periodicity());
+
     }
 
     void Integrate(int amrlev, Set::Scalar /*time*/, int /*step*/,
@@ -425,11 +531,13 @@ protected:
         }
 
         const amrex::Real* DX = geom[amrlev].CellSize();
-        amrex::Box domain = geom[amrlev].Domain();
-        domain.convert(amrex::IntVect::TheNodeVector());
+        const amrex::Box& cell_domain = geom[amrlev].Domain();
+        const Dim3 cell_hi = amrex::ubound(cell_domain);
 
-        amrex::Box box = a_box;
-        box.convert(amrex::IntVect::TheNodeVector());
+        // Integrate over the disjoint, uncovered cell boxes supplied by
+        // IntegrateVariables. Converting those boxes to nodal first makes
+        // adjacent boxes overlap and double-counts AMR boundary segments.
+        const amrex::Box& box = a_box;
 
 
         //Set::Scalar dv = AMREX_D_TERM(DX[0], *DX[1], *DX[2]);
@@ -440,33 +548,120 @@ protected:
         Set::Vector da(DX[1] * DX[2], 0, 0);
 #endif
 
-        const Dim3 /*lo= amrex::lbound(domain),*/ hi = amrex::ubound(domain);
-        const Dim3 /*boxlo= amrex::lbound(box),*/ boxhi = amrex::ubound(box);
-
         amrex::Array4<const Set::Matrix> const& stress = (*stress_mf[amrlev]).array(mfi);
         amrex::Array4<const Set::Vector> const& disp = (*disp_mf[amrlev]).array(mfi);
-        amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k)
-        {
+
+        // GPU: trac_hi / disp_hi are host-resident members.  Accumulating into them
+        // directly inside a ParallelFor dereferences a host pointer on the device
+        // (CUDA illegal memory access -- error 700) and races between nodes.  Mirror
+        // the sum-reduction pattern used in Flame::Integrate: compute per-box partial
+        // sums on the device, then add them to the host members afterwards.  These are
+        // "extensive" integrated variables, so IntegrateVariables zeroes them and sums
+        // them across ranks.  The trac contribution is a genuine face integral (sum);
+        // the disp diagnostic samples the last face node (matching the prior CPU
+        // serial-loop "last write wins" for a single box) but anchored to the
+        // global domain so multi-box face splits do not add one sample per box.
 #if AMREX_SPACEDIM == 2
-            if (i == hi.x && j < boxhi.y)
-            {
-                trac_hi[0] += (0.5 * (stress(i, j, k) + stress(i, j + 1, k)) * da0);
-                disp_hi[0] = disp(i, j, k);
-            }
-            if (j == hi.y && i < boxhi.x)
-            {
-                trac_hi[1] += (0.5 * (stress(i, j, k) + stress(i + 1, j, k)) * da1);
-                disp_hi[1] = disp(i, j, k);
-            }
+        {
+            amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum,
+                            amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
+            amrex::ReduceData<Set::Scalar, Set::Scalar, Set::Scalar, Set::Scalar> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+            reduce_op.eval(box, reduce_data,
+                [=] AMREX_GPU_DEVICE(int i, int j, int k) -> ReduceTuple
+                {
+                    Set::Scalar tx = 0.0, ty = 0.0, dx = 0.0, dy = 0.0;
+                    if (i == cell_hi.x)
+                    {
+                        Set::Vector t = (0.5 * (stress(i + 1, j, k)
+                            + stress(i + 1, j + 1, k)) * da0);
+                        tx = t(0); ty = t(1);
+                        if (j == cell_hi.y)
+                        {
+                            dx = disp(i + 1, j, k)(0);
+                            dy = disp(i + 1, j, k)(1);
+                        }
+                    }
+                    return {tx, ty, dx, dy};
+                });
+            ReduceTuple hv = reduce_data.value(reduce_op);
+            trac_hi[0](0) += amrex::get<0>(hv);
+            trac_hi[0](1) += amrex::get<1>(hv);
+            disp_hi[0](0) += amrex::get<2>(hv);
+            disp_hi[0](1) += amrex::get<3>(hv);
+        }
+        {
+            amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum,
+                            amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
+            amrex::ReduceData<Set::Scalar, Set::Scalar, Set::Scalar, Set::Scalar> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+            reduce_op.eval(box, reduce_data,
+                [=] AMREX_GPU_DEVICE(int i, int j, int k) -> ReduceTuple
+                {
+                    Set::Scalar tx = 0.0, ty = 0.0, dx = 0.0, dy = 0.0;
+                    if (j == cell_hi.y)
+                    {
+                        Set::Vector t = (0.5 * (stress(i, j + 1, k)
+                            + stress(i + 1, j + 1, k)) * da1);
+                        tx = t(0); ty = t(1);
+                        if (i == cell_hi.x)
+                        {
+                            dx = disp(i, j + 1, k)(0);
+                            dy = disp(i, j + 1, k)(1);
+                        }
+                    }
+                    return {tx, ty, dx, dy};
+                });
+            ReduceTuple hv = reduce_data.value(reduce_op);
+            trac_hi[1](0) += amrex::get<0>(hv);
+            trac_hi[1](1) += amrex::get<1>(hv);
+            disp_hi[1](0) += amrex::get<2>(hv);
+            disp_hi[1](1) += amrex::get<3>(hv);
+        }
 #elif AMREX_SPACEDIM == 3
-            if (i == hi.x && (j < boxhi.y && k < boxhi.z))
-            {
-                trac_hi[0] += (0.25 * (stress(i, j, k) + stress(i, j + 1, k)
-                    + stress(i, j, k + 1) + stress(i, j + 1, k + 1)) * da);
-                disp_hi[0] = disp(i, j, k);
-            }
+        {
+            amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
+            amrex::ReduceData<Set::Scalar, Set::Scalar, Set::Scalar> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+            reduce_op.eval(box, reduce_data,
+                [=] AMREX_GPU_DEVICE(int i, int j, int k) -> ReduceTuple
+                {
+                    Set::Scalar tx = 0.0, ty = 0.0, tz = 0.0;
+                    if (i == cell_hi.x)
+                    {
+                        Set::Vector t = (0.25 * (stress(i + 1, j, k)
+                            + stress(i + 1, j + 1, k)
+                            + stress(i + 1, j, k + 1)
+                            + stress(i + 1, j + 1, k + 1)) * da);
+                        tx = t(0); ty = t(1); tz = t(2);
+                    }
+                    return {tx, ty, tz};
+                });
+            ReduceTuple hv = reduce_data.value(reduce_op);
+            trac_hi[0](0) += amrex::get<0>(hv);
+            trac_hi[0](1) += amrex::get<1>(hv);
+            trac_hi[0](2) += amrex::get<2>(hv);
+        }
+        {
+            amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
+            amrex::ReduceData<Set::Scalar, Set::Scalar> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+            reduce_op.eval(box, reduce_data,
+                [=] AMREX_GPU_DEVICE(int i, int j, int k) -> ReduceTuple
+                {
+                    Set::Scalar dx = 0.0, dy = 0.0;
+                    if (i == cell_hi.x && j == cell_hi.y && k == cell_hi.z)
+                    {
+                        dx = disp(i + 1, j, k)(0);
+                        dy = disp(i + 1, j, k)(1);
+                    }
+                    return {dx, dy};
+                });
+            ReduceTuple hv = reduce_data.value(reduce_op);
+            disp_hi[0](0) += amrex::get<0>(hv);
+            disp_hi[0](1) += amrex::get<1>(hv);
+        }
 #endif
-        });
 
     }
 
@@ -474,6 +669,8 @@ protected:
     {
         BL_PROFILE("Integrator::Base::Mechanics::TagCellsForRefinement");
         if (m_type == Type::Disable) return;
+
+        auto m_elastic_ref_threshold = this->m_elastic_ref_threshold;
 
         Set::Vector DX(geom[lev].CellSize());
         Set::Scalar DXnorm = DX.lpNorm<2>();
@@ -506,7 +703,10 @@ protected:
     Set::Field<Set::Vector> rhs_mf;
     Set::Field<Set::Vector> res_mf;
     Set::Field<Set::Matrix> stress_mf;
+    Set::Field<Set::Matrix> output_stress_mf;
     Set::Field<Set::Matrix> strain_mf;
+    amrex::GpuArray<int, AMREX_SPACEDIM> m_output_stress_symmetry_lo{};
+    amrex::GpuArray<int, AMREX_SPACEDIM> m_output_stress_symmetry_hi{};
 
     // Only use these if using the "dynamics" option
     Set::Field<Set::Vector> disp_old_mf;
@@ -536,7 +736,6 @@ protected:
     int m_max_coarsening_level = -1;
 
     bool m_zero_out_displacement = false;
-
     bool plot_disp = true;
     bool plot_stress = true;
     bool plot_strain = true;

--- a/src/Integrator/Flame.H
+++ b/src/Integrator/Flame.H
@@ -116,11 +116,14 @@ protected:
     struct {
         int on = 0;
         Set::Scalar Telastic = NAN;
-        model_type model_ap, model_htpb;
+        model_type model_ap, model_htpb, model_void;
         Set::Scalar traction = NAN;
         int phirefinement = -1;
         Set::Scalar etacutoff = NAN;
         Set::Scalar apply_chamber_pressure = NAN;
+        // The legacy masked formulation uses eta as psi.  The conservative
+        // formulation instead resolves a finite-stiffness void material.
+        int use_psi = 1;
     } elastic;
 
     // Chamber state variables (not inputs)

--- a/src/Integrator/Flame.cpp
+++ b/src/Integrator/Flame.cpp
@@ -232,10 +232,12 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
         // Phi refinement criteria
         pp_query_default("elastic.phirefinement", value.elastic.phirefinement, 1);
 
+        // Opt into the conservative face-flux formulation by using an explicit,
+        // finite-stiffness void material instead of an eta mask.
+        pp_query_default("elastic.use_psi", value.elastic.use_psi, 1);
+
         // Elastic integrator
         pp.queryclass<Base::Mechanics<model_type>>("elastic",value);
-
-
 
         // Reference temperature for thermal expansion 
         // (temperature at which the material is strain-free)
@@ -244,6 +246,9 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
         pp.queryclass<Model::Solid::Finite::NeoHookeanPredeformed>("model_ap", value.elastic.model_ap);
         // elastic model of HTPB
         pp.queryclass<Model::Solid::Finite::NeoHookeanPredeformed>("model_htpb", value.elastic.model_htpb);
+        if (!value.elastic.use_psi)
+            pp.queryclass<Model::Solid::Finite::NeoHookeanPredeformed>(
+                "model_void", value.elastic.model_void);
 
         // eta cutoff value to stop applying the traction force and/or chamber pressure to the RHS.
         // Below this vlaue the RHS is set to 0.0
@@ -254,14 +259,14 @@ Flame::Parse(Flame& value, IO::ParmParse& pp)
 
         // Use our current eta field as the psi field for the solver
         value.psi_on = false;
-        value.solver.setPsi(value.eta_mf);
+        value.solver.setConservativeFaceFlux(!value.elastic.use_psi);
+        if (value.elastic.use_psi)
+            value.solver.setPsi(value.eta_mf);
 
         if (IO::ParmParse::InTraversalMode()) return;
 
         Util::AssertException(INFO, TEST(value.m_type != Disable), "You must specify elastic type to be dynamic or static");
     });
-
-
 
     bool allow_unused;
     // Set this to true to allow unused inputs without error.
@@ -332,6 +337,7 @@ void Flame::UpdateModel(int /*a_step*/, Set::Scalar /*a_time*/)
             Set::Patch<const Set::Scalar> eta   = eta_mf.Patch(lev,mfi);
             Set::Patch<Set::Vector>       rhs   = rhs_mf.Patch(lev,mfi);
             Set::Scalar Tcutoff = thermal.Tcutoff;
+            const bool use_psi = elastic.use_psi;
 
             if (elastic.on)
             {
@@ -341,7 +347,11 @@ void Flame::UpdateModel(int /*a_step*/, Set::Scalar /*a_time*/)
                 {   
                     Set::Vector grad_eta = Numeric::CellGradientOnNode(eta, i, j, k, 0, DX);
 
-                    if (temp(i,j,k) > Tcutoff && eta(i,j,k) > elastic.etacutoff && elastic.apply_chamber_pressure)
+                    if (!use_psi)
+                        {
+                            rhs(i, j, k) = -elastic.traction * grad_eta;
+                        }
+                    else if (temp(i,j,k) > Tcutoff && eta(i,j,k) > elastic.etacutoff && elastic.apply_chamber_pressure)
                         {
                             rhs(i, j, k) = (elastic.traction) * grad_eta - chamber.pressure*grad_eta;
                             // std::cout << "Applying chamber pressure" << std::endl;
@@ -369,7 +379,23 @@ void Flame::UpdateModel(int /*a_step*/, Set::Scalar /*a_time*/)
                     model_htpb.F0 *= (temp_avg - elastic.Telastic);
                     model_htpb.F0 += Set::Matrix::Identity();
 
-                    model(i, j, k) = (model_ap * phi_avg + model_htpb * (1. - phi_avg));
+                    model_type solid_model =
+                        model_ap * phi_avg + model_htpb * (1. - phi_avg);
+                    if (elastic.use_psi)
+                    {
+                        model(i, j, k) = solid_model;
+                    }
+                    else
+                    {
+                        model_type model_void = elastic.model_void;
+                        model_void.F0 -= Set::Matrix::Identity();
+                        model_void.F0 *= (temp_avg - elastic.Telastic);
+                        model_void.F0 += Set::Matrix::Identity();
+                        const Set::Scalar eta_value =
+                            Numeric::Interpolate::CellToNodeAverage(eta, i, j, k, 0);
+                        model(i, j, k) = solid_model * eta_value
+                            + model_void * (1.0 - eta_value);
+                    }
                 });
             }
             else
@@ -386,7 +412,8 @@ void Flame::UpdateModel(int /*a_step*/, Set::Scalar /*a_time*/)
                 });
             }
         }
-        Util::RealFillBoundary(*model_mf[lev], geom[lev]);
+        model_mf[lev]->setMultiGhost(true);
+        model_mf[lev]->FillBoundaryAndSync(geom[lev].periodicity());
 
     }
 }

--- a/src/Numeric/Stencil.H
+++ b/src/Numeric/Stencil.H
@@ -19,8 +19,12 @@ namespace Numeric
 {
 
 enum StencilType { Lo, Hi, Central };
+AMREX_GPU_HOST_DEVICE
 static std::array<StencilType, AMREX_SPACEDIM>
-DefaultType = { AMREX_D_DECL(StencilType::Central, StencilType::Central, StencilType::Central) };
+DefaultType()
+{
+    return {AMREX_D_DECL(StencilType::Central, StencilType::Central, StencilType::Central)};
+};
 [[maybe_unused]] static std::array<StencilType, AMREX_SPACEDIM>
 XLo         = { AMREX_D_DECL(StencilType::Lo,      StencilType::Central, StencilType::Central) };
 [[maybe_unused]] static std::array<StencilType, AMREX_SPACEDIM>
@@ -40,6 +44,7 @@ ZHi         = { AMREX_D_DECL(StencilType::Central, StencilType::Central, Stencil
 
 [[nodiscard]]
 static
+AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 std::array<StencilType, AMREX_SPACEDIM>
 GetStencil(const int i, const int j, const int k, const amrex::Box domain)
@@ -63,18 +68,16 @@ template<class T, int x, int y, int z>
 struct Stencil
 {};
 
-//
-// FIRST order derivatives
-//
-
 template<class T>
 struct Stencil<T, 1, 0, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE 
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+        static T D( const amrex::Array4<const T>& f,
+                    const int& i, const int& j, const int& k, const int& m,
+                    const Set::Scalar dx[AMREX_SPACEDIM],
+                    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[0] == StencilType::Lo)
             return (f(i, j, k, m) - f(i - 1, j, k, m)) / dx[0]; // 1st order stencil
@@ -83,25 +86,27 @@ struct Stencil<T, 1, 0, 0>
         else
             return (f(i + 1, j, k, m) - f(i - 1, j, k, m)) * 0.5 / dx[0];
     };
-    [[nodiscard]] AMREX_FORCE_INLINE
-    static std::pair<Set::Scalar,T>
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static Set::Jet<Set::Scalar,T>
     Dsplit( const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[0] == StencilType::Lo)
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 1.0 / dx[0],
                 -f(i - 1, j, k, m) / dx[0]
                 ); // 1st order
         else if (stencil[0] == StencilType::Hi)
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 -1.0 / dx[0],
                 f(i + 1, j, k, m) / dx[0]
                 ); // 1st order
         else
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 0.0,
                 (f(i + 1, j, k, m) - f(i - 1, j, k, m)) * 0.5 / dx[0]
                 );
@@ -111,11 +116,13 @@ struct Stencil<T, 1, 0, 0>
 template<class T>
 struct Stencil<T, 0, 1, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[1] == StencilType::Lo)
             return (f(i, j, k, m) - f(i, j - 1, k, m)) / dx[1];
@@ -124,25 +131,27 @@ struct Stencil<T, 0, 1, 0>
         else
             return (f(i, j + 1, k, m) - f(i, j - 1, k, m)) * 0.5 / dx[1];
     };
-    [[nodiscard]] AMREX_FORCE_INLINE
-    static std::pair<Set::Scalar,T>
-    Dsplit(const amrex::Array4<const T>& f,
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static Set::Jet<Set::Scalar,T>
+    Dsplit( const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[1] == StencilType::Lo)
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 1.0 / dx[1],
                 - f(i, j - 1, k, m) / dx[1]
                 );
         else if (stencil[1] == StencilType::Hi)
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 - 1.0 / dx[1],
                 f(i, j + 1, k, m) / dx[1]
                 );
         else
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 0.0,
                 (f(i, j + 1, k, m) - f(i, j - 1, k, m)) * 0.5 / dx[1]
                 );
@@ -152,11 +161,13 @@ struct Stencil<T, 0, 1, 0>
 template<class T>
 struct Stencil<T, 0, 0, 1>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[2] == StencilType::Lo)
             return (f(i, j, k, m) - f(i, j, k - 1, m)) / dx[2];
@@ -165,43 +176,43 @@ struct Stencil<T, 0, 0, 1>
         else
             return (f(i, j, k + 1, m) - f(i, j, k - 1, m)) * 0.5 / dx[2];
     };
-    [[nodiscard]] AMREX_FORCE_INLINE
-    static std::pair<Set::Scalar, T>
-    Dsplit(const amrex::Array4<const T>& f,
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static Set::Jet<Set::Scalar, T>
+    Dsplit( const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[2] == StencilType::Lo)
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 1.0 / dx[2],
                 -f(i, j, k - 1, m) / dx[2]
                 );
         else if (stencil[2] == StencilType::Hi)
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 -1.0 / dx[2],
                 f(i, j, k + 1, m) / dx[2]
                 );
         else
-            return std::make_pair(
+            return Set::Jet<Set::Scalar,T>(
                 0.0,
                 (f(i, j, k + 1, m) - f(i, j, k - 1, m)) * 0.5 / dx[2]
                 );
     };
 };
 
-//
-// SECOND order derivatives
-//
-
 template<class T>
 struct Stencil<T, 2, 0, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[0] == StencilType::Central)
             return (f(i + 1, j, k, m) - 2.0 * f(i, j, k, m) + f(i - 1, j, k, m)) / dx[0] / dx[0];
@@ -213,11 +224,13 @@ struct Stencil<T, 2, 0, 0>
 template<class T>
 struct Stencil<T, 0, 2, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[1] == StencilType::Central)
             return (f(i, j + 1, k, m) - 2.0 * f(i, j, k, m) + f(i, j - 1, k, m)) / dx[1] / dx[1];
@@ -229,11 +242,13 @@ struct Stencil<T, 0, 2, 0>
 template<class T>
 struct Stencil<T, 0, 0, 2>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         if (stencil[2] == StencilType::Central)
             return (f(i, j, k + 1, m) - 2.0 * f(i, j, k, m) + f(i, j, k - 1, m)) / dx[2] / dx[2];
@@ -245,11 +260,13 @@ struct Stencil<T, 0, 0, 2>
 template<class T>
 struct Stencil<T, 1, 1, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         int ihi = 1, ilo = 1, jhi = 1, jlo = 1;
         Set::Scalar ifac = 0.5, jfac = 0.5;
@@ -264,11 +281,13 @@ struct Stencil<T, 1, 1, 0>
 template<class T>
 struct Stencil<T, 1, 0, 1>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         int khi = 1, klo = 1, ihi = 1, ilo = 1;
         Set::Scalar kfac = 0.5, ifac = 0.5;
@@ -283,11 +302,13 @@ struct Stencil<T, 1, 0, 1>
 template<class T>
 struct Stencil<T, 0, 1, 1>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T D(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            const Set::Scalar dx[AMREX_SPACEDIM],
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T D( const amrex::Array4<const T>& f,
+                const int& i, const int& j, const int& k, const int& m,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         int jhi = 1, jlo = 1, khi = 1, klo = 1;
         Set::Scalar jfac = 0.5, kfac = 0.5;
@@ -300,14 +321,12 @@ struct Stencil<T, 0, 1, 1>
     };
 };
 
-//
-// FOURTH order derivatives
-//
-
 template<class T>
 struct Stencil<T, 4, 0, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -319,7 +338,9 @@ struct Stencil<T, 4, 0, 0>
 template<class T>
 struct Stencil<T, 0, 4, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -331,7 +352,9 @@ struct Stencil<T, 0, 4, 0>
 template<class T>
 struct Stencil<T, 0, 0, 4>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -346,7 +369,9 @@ struct Stencil<T, 0, 0, 4>
 template<class T>
 struct Stencil<T, 3, 1, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -364,7 +389,9 @@ struct Stencil<T, 3, 1, 0>
 template<class T>
 struct Stencil<T, 1, 3, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -382,7 +409,9 @@ struct Stencil<T, 1, 3, 0>
 template<class T>
 struct Stencil<T, 0, 3, 1>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -398,7 +427,9 @@ struct Stencil<T, 0, 3, 1>
 template<class T>
 struct Stencil<T, 0, 1, 3>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -414,7 +445,9 @@ struct Stencil<T, 0, 1, 3>
 template<class T>
 struct Stencil<T, 1, 0, 3>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -431,7 +464,9 @@ struct Stencil<T, 1, 0, 3>
 template<class T>
 struct Stencil<T, 3, 0, 1>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -448,7 +483,9 @@ struct Stencil<T, 3, 0, 1>
 template<class T>
 struct Stencil<T, 2, 2, 0>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -466,7 +503,9 @@ struct Stencil<T, 2, 2, 0>
 template<class T>
 struct Stencil<T, 0, 2, 2>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -483,7 +522,9 @@ struct Stencil<T, 0, 2, 2>
 template<class T>
 struct Stencil<T, 2, 0, 2>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -502,7 +543,9 @@ struct Stencil<T, 2, 0, 2>
 template<class T>
 struct Stencil<T, 2, 1, 1>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -519,7 +562,9 @@ struct Stencil<T, 2, 1, 1>
 template<class T>
 struct Stencil<T, 1, 2, 1>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -536,7 +581,9 @@ struct Stencil<T, 1, 2, 1>
 template<class T>
 struct Stencil<T, 1, 1, 2>
 {
-    [[nodiscard]] AMREX_FORCE_INLINE
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
         static T D(const amrex::Array4<const T>& f,
             const int& i, const int& j, const int& k, const int& m,
             const Set::Scalar dx[AMREX_SPACEDIM])
@@ -550,12 +597,14 @@ struct Stencil<T, 1, 1, 2>
     };
 };
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Scalar
-Laplacian(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k, const int& m,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM>& stencil = DefaultType)
+Laplacian(  const amrex::Array4<const Set::Scalar>& f,
+            const int& i, const int& j, const int& k, const int& m,
+            const Set::Scalar dx[AMREX_SPACEDIM],
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Scalar ret = 0.0;
     ret += (Numeric::Stencil<Set::Scalar, 2, 0, 0>::D(f, i, j, k, m, dx, stencil));
@@ -568,11 +617,13 @@ Laplacian(const amrex::Array4<const Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Vector
-Laplacian(const amrex::Array4<const Set::Vector>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar dx[AMREX_SPACEDIM])
+Laplacian(  const amrex::Array4<const Set::Vector>& f,
+            const int& i, const int& j, const int& k,
+            const Set::Scalar dx[AMREX_SPACEDIM])
 {
     Set::Vector ret = Set::Vector::Zero();
     ret += (Numeric::Stencil<Set::Vector, 2, 0, 0>::D(f, i, j, k, 0, dx));
@@ -585,12 +636,14 @@ Laplacian(const amrex::Array4<const Set::Vector>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Vector
-Divergence(const amrex::Array4<const Set::Matrix>& dw,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar DX[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM>& stencil = DefaultType)
+Divergence( const amrex::Array4<const Set::Matrix>& dw,
+            const int& i, const int& j, const int& k,
+            const Set::Scalar DX[AMREX_SPACEDIM],
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Vector ret = Set::Vector::Zero();
 
@@ -657,12 +710,14 @@ Divergence(const amrex::Array4<const Set::Matrix>& dw,
 }
 
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Scalar
-Divergence(const amrex::Array4<const Set::Scalar> &f,
-    const int &i, const int &j, const int &k, const int &m,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType,AMREX_SPACEDIM> stencil = DefaultType)
+Divergence( const amrex::Array4<const Set::Scalar> &f,
+            const int &i, const int &j, const int &k, const int &m,
+            const Set::Scalar dx[AMREX_SPACEDIM],
+            std::array<StencilType,AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Scalar ret;
     ret = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(f, i, j, k, m, dx, stencil));
@@ -676,12 +731,14 @@ Divergence(const amrex::Array4<const Set::Scalar> &f,
 }
 
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Vector
-Gradient(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k, const int& m,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+Gradient(   const amrex::Array4<const Set::Scalar>& f,
+            const int& i, const int& j, const int& k, const int& m,
+            const Set::Scalar dx[AMREX_SPACEDIM],
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Vector ret;
     ret(0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(f, i, j, k, m, dx, stencil));
@@ -694,7 +751,9 @@ Gradient(const amrex::Array4<const Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Vector
 CellGradientOnNode(const amrex::Array4<const Set::Scalar>& f,
     const int& i, const int& j, const int& k, const int& m,
@@ -715,8 +774,10 @@ CellGradientOnNode(const amrex::Array4<const Set::Scalar>& f,
 }
 
 
-template<class T>
-[[nodiscard]] AMREX_FORCE_INLINE
+template <class T>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 std::array<T, AMREX_SPACEDIM>
 CellGradientOnNode(const amrex::Array4<const T>& f,
     const int& i, const int& j, const int& k, const int& m,
@@ -739,12 +800,14 @@ CellGradientOnNode(const amrex::Array4<const T>& f,
 
 
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix
-Gradient(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+Gradient(   const amrex::Array4<const Set::Scalar>& f,
+            const int& i, const int& j, const int& k,
+            const Set::Scalar dx[AMREX_SPACEDIM],
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Matrix ret;
     ret(0, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(f, i, j, k, 0, dx, stencil));
@@ -763,12 +826,14 @@ Gradient(const amrex::Array4<const Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix
-Gradient(const amrex::Array4<const Set::Vector>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+Gradient(   const amrex::Array4<const Set::Vector>& f,
+            const int& i, const int& j, const int& k,
+            const Set::Scalar dx[AMREX_SPACEDIM],
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Matrix ret;
 
@@ -785,37 +850,112 @@ Gradient(const amrex::Array4<const Set::Vector>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
-std::pair<Set::Vector,Set::Matrix>
+/// \brief Displacement gradient at the midpoint of a positive coordinate face.
+/// Normal derivative is the centered face difference; tangential derivatives average the two endpoint nodal derivatives.
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+FaceGradient(const amrex::Array4<const Set::Vector>& f,
+             const int i, const int j, const int k, const int face,
+             const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    Set::Matrix ret = Set::Matrix::Zero();
+    const int ip = i + (face == 0);
+    const int jp = j + (face == 1);
+    const int kp = k + (face == 2);
+
+    ret.col(face) = (f(ip, jp, kp) - f(i, j, k)) / dx[face];
+
+#if AMREX_SPACEDIM > 1
+    if (face != 0)
+        ret.col(0) = (f(i + 1, j, k) - f(i - 1, j, k)
+                    + f(ip + 1, jp, kp) - f(ip - 1, jp, kp))
+                   / (4.0 * dx[0]);
+    if (face != 1)
+        ret.col(1) = (f(i, j + 1, k) - f(i, j - 1, k)
+                    + f(ip, jp + 1, kp) - f(ip, jp - 1, kp))
+                   / (4.0 * dx[1]);
+#endif
+#if AMREX_SPACEDIM > 2
+    if (face != 2)
+        ret.col(2) = (f(i, j, k + 1) - f(i, j, k - 1)
+                    + f(ip, jp, kp + 1) - f(ip, jp, kp - 1))
+                   / (4.0 * dx[2]);
+#endif
+    return ret;
+}
+
+/// \brief Scalar-MultiFab overload of `FaceGradient`.
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+FaceGradient(const amrex::Array4<const Set::Scalar>& f,
+             const int i, const int j, const int k, const int face,
+             const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    Set::Matrix ret = Set::Matrix::Zero();
+    const int ip = i + (face == 0);
+    const int jp = j + (face == 1);
+    const int kp = k + (face == 2);
+
+    for (int n = 0; n < AMREX_SPACEDIM; ++n)
+    {
+        ret(n, face) = (f(ip, jp, kp, n) - f(i, j, k, n)) / dx[face];
+#if AMREX_SPACEDIM > 1
+        if (face != 0)
+            ret(n, 0) = (f(i + 1, j, k, n) - f(i - 1, j, k, n)
+                       + f(ip + 1, jp, kp, n) - f(ip - 1, jp, kp, n))
+                      / (4.0 * dx[0]);
+        if (face != 1)
+            ret(n, 1) = (f(i, j + 1, k, n) - f(i, j - 1, k, n)
+                       + f(ip, jp + 1, kp, n) - f(ip, jp - 1, kp, n))
+                      / (4.0 * dx[1]);
+#endif
+#if AMREX_SPACEDIM > 2
+        if (face != 2)
+            ret(n, 2) = (f(i, j, k + 1, n) - f(i, j, k - 1, n)
+                       + f(ip, jp, kp + 1, n) - f(ip, jp, kp - 1, n))
+                      / (4.0 * dx[2]);
+#endif
+    }
+    return ret;
+}
+
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Jet<Set::Vector,Set::Matrix>
 GradientSplit(  const amrex::Array4<const Set::Vector>& f,
                 const int& i, const int& j, const int& k,
                 const Set::Scalar dx[AMREX_SPACEDIM],
-                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Vector diag;
     Set::Matrix offdiag;
 
-    std::pair<Set::Scalar,Set::Vector> ret;
+    Set::Jet<Set::Scalar, Set::Vector> ret;
 #if AMREX_SPACEDIM > 0
     ret = Numeric::Stencil<Set::Vector, 1, 0, 0>::Dsplit(f, i, j, k, 0, dx, stencil);
-    diag(0)        = ret.first;
-    offdiag.col(0) = ret.second;
+    diag(0)        = ret.zero;
+    offdiag.col(0) = ret.first;
 #endif
 #if AMREX_SPACEDIM > 1
     ret = Numeric::Stencil<Set::Vector, 0, 1, 0>::Dsplit(f, i, j, k, 0, dx, stencil);
-    diag(1)        = ret.first;
-    offdiag.col(1) = ret.second;
+    diag(1)        = ret.zero;
+    offdiag.col(1) = ret.first;
 #endif
 #if AMREX_SPACEDIM > 2
     ret = Numeric::Stencil<Set::Vector, 0, 0, 1>::Dsplit(f, i, j, k, 0, dx, stencil);
-    diag(2)        = ret.first;
-    offdiag.col(2) = ret.second;
+    diag(2)        = ret.zero;
+    offdiag.col(2) = ret.first;
 #endif
-    return std::make_pair(diag,offdiag);
+    return Set::Jet(diag, offdiag);
 }
 
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Set::Vector
 NodeGradientOnCell(const amrex::Array4<const Set::Scalar>& f,
     const int& i, const int& j, const int& k,
@@ -855,7 +995,9 @@ NodeGradientOnCell(const amrex::Array4<const Set::Vector>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Vector
 NodeGradientOnCell(const amrex::Array4<const Set::Scalar>& f,
     const int& i, const int& j, const int& k, const int& m,
@@ -875,12 +1017,14 @@ NodeGradientOnCell(const amrex::Array4<const Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix3
-Gradient(const amrex::Array4<const Set::Matrix>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+Gradient(   const amrex::Array4<const Set::Matrix>& f,
+            const int& i, const int& j, const int& k,
+            const Set::Scalar dx[AMREX_SPACEDIM],
+            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Matrix3 ret;
 
@@ -899,12 +1043,14 @@ Gradient(const amrex::Array4<const Set::Matrix>& f,
 
 template<class T>
 [[nodiscard]] AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 std::array<T,AMREX_SPACEDIM>
 Gradient_Diagonal(  const Set::Scalar dx[AMREX_SPACEDIM],
-                    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType);
+                    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType());
 
 template<>
 [[nodiscard]] AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 std::array<Set::Matrix,AMREX_SPACEDIM>
 Gradient_Diagonal(  const Set::Scalar dx[AMREX_SPACEDIM],
                     std::array<StencilType, AMREX_SPACEDIM> stencil)
@@ -931,6 +1077,7 @@ Gradient_Diagonal(  const Set::Scalar dx[AMREX_SPACEDIM],
 
 template<>
 [[nodiscard]] AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 std::array<Set::Matrix3,AMREX_SPACEDIM>
 Gradient_Diagonal(  const Set::Scalar dx[AMREX_SPACEDIM],
                     std::array<StencilType, AMREX_SPACEDIM> stencil)
@@ -965,10 +1112,11 @@ Gradient_Diagonal(  const Set::Scalar dx[AMREX_SPACEDIM],
 
 
 [[nodiscard]] AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 Set::Matrix3
-NodeGradientOnCell(const amrex::Array4<const Set::Matrix>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar dx[AMREX_SPACEDIM])
+NodeGradientOnCell( const amrex::Array4<const Set::Matrix>& f,
+                    const int& i, const int& j, const int& k,
+                    const Set::Scalar dx[AMREX_SPACEDIM])
 {
     Set::Matrix3 ret;
 
@@ -986,12 +1134,14 @@ NodeGradientOnCell(const amrex::Array4<const Set::Matrix>& f,
 }
 
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix3
-MatrixGradient(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+MatrixGradient( const amrex::Array4<const Set::Scalar>& f,
+                const int& i, const int& j, const int& k,
+                const Set::Scalar dx[AMREX_SPACEDIM],
+                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Matrix3 ret;
 #if AMREX_SPACEDIM == 1
@@ -1038,13 +1188,14 @@ MatrixGradient(const amrex::Array4<const Set::Scalar>& f,
 }
 
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix
 Hessian(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k, const int& m,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType
-)
+        const int& i, const int& j, const int& k, const int& m,
+        const Set::Scalar dx[AMREX_SPACEDIM],
+        std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Matrix ret;
     ret(0, 0) = (Numeric::Stencil<Set::Scalar, 2, 0, 0>::D(f, i, j, k, m, dx, stencil));
@@ -1063,12 +1214,14 @@ Hessian(const amrex::Array4<const Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix3
 Hessian(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar DX[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+        const int& i, const int& j, const int& k,
+        const Set::Scalar DX[AMREX_SPACEDIM],
+        std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Matrix3 ret;
     // 1D 
@@ -1113,12 +1266,14 @@ Hessian(const amrex::Array4<const Set::Scalar>& f,
 
 // Returns Hessian of a vector field.
 // Return value: ret[i](j,k) = ret_{i,jk}
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix3
 Hessian(const amrex::Array4<const Set::Vector>& f,
-    const int& i, const int& j, const int& k,
-    const Set::Scalar dx[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+        const int& i, const int& j, const int& k,
+        const Set::Scalar dx[AMREX_SPACEDIM],
+        std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
 {
     Set::Matrix3 ret;
 
@@ -1156,10 +1311,12 @@ Hessian(const amrex::Array4<const Set::Vector>& f,
 }
 
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix
-FieldToMatrix(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k)
+FieldToMatrix(  const amrex::Array4<const Set::Scalar>& f,
+                const int& i, const int& j, const int& k)
 {
     Set::Matrix ret;
 #if AMREX_SPACEDIM == 1
@@ -1178,10 +1335,12 @@ FieldToMatrix(const amrex::Array4<const Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Matrix
-FieldToMatrix(const amrex::Array4<Set::Scalar>& f,
-    const int& i, const int& j, const int& k)
+FieldToMatrix(  const amrex::Array4<Set::Scalar>& f,
+                const int& i, const int& j, const int& k)
 {
     Set::Matrix ret;
 #if AMREX_SPACEDIM == 1
@@ -1200,10 +1359,12 @@ FieldToMatrix(const amrex::Array4<Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Vector
-FieldToVector(const amrex::Array4<const Set::Scalar>& f,
-    const int& i, const int& j, const int& k)
+FieldToVector(  const amrex::Array4<const Set::Scalar>& f,
+                const int& i, const int& j, const int& k)
 {
     Set::Vector ret;
     ret(0) = f(i, j, k, 0);
@@ -1216,10 +1377,12 @@ FieldToVector(const amrex::Array4<const Set::Scalar>& f,
     return ret;
 }
 
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
 Set::Vector
-FieldToVector(const amrex::Array4<Set::Scalar>& f,
-    const int& i, const int& j, const int& k)
+FieldToVector(  const amrex::Array4<Set::Scalar>& f,
+                const int& i, const int& j, const int& k)
 {
     Set::Vector ret;
     ret(0) = f(i, j, k, 0);
@@ -1232,11 +1395,12 @@ FieldToVector(const amrex::Array4<Set::Scalar>& f,
     return ret;
 }
 
+AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void
-MatrixToField(const amrex::Array4<Set::Scalar>& f,
-    const int& i, const int& j, const int& k,
-    Set::Matrix matrix)
+MatrixToField(  const amrex::Array4<Set::Scalar>& f,
+                const int& i, const int& j, const int& k,
+                Set::Matrix matrix)
 {
 #if AMREX_SPACEDIM == 1
     f(i, j, k, 0) = matrix(0, 0);
@@ -1250,11 +1414,12 @@ MatrixToField(const amrex::Array4<Set::Scalar>& f,
 #endif
 }
 
+AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void
-VectorToField(const amrex::Array4<Set::Scalar>& f,
-    const int& i, const int& j, const int& k,
-    Set::Vector vector)
+VectorToField(  const amrex::Array4<Set::Scalar>& f,
+                const int& i, const int& j, const int& k,
+                Set::Vector vector)
 {
     f(i, j, k, 0) = vector(0);
 #if AMREX_SPACEDIM > 1
@@ -1267,17 +1432,21 @@ VectorToField(const amrex::Array4<Set::Scalar>& f,
 
 template<int index, int SYM>
 [[nodiscard]] 
+AMREX_GPU_HOST_DEVICE
 Set::Matrix3 
-Divergence(const amrex::Array4<const Set::Matrix4<AMREX_SPACEDIM, SYM>>&,
-    const int, const int, const int, const Set::Scalar[AMREX_SPACEDIM],
-    std::array<StencilType, AMREX_SPACEDIM> /*stecil*/ = DefaultType)
+Divergence( const amrex::Array4<const Set::Matrix4<AMREX_SPACEDIM, SYM>>&,
+            const int, const int, const int, const Set::Scalar[AMREX_SPACEDIM],
+            std::array<StencilType, AMREX_SPACEDIM> /*stecil*/ = DefaultType())
 {
     Util::Abort(INFO, "Not implemented yet"); return Set::Matrix3::Zero();
 }
 
-template<>
-[[nodiscard]] AMREX_FORCE_INLINE
-Set::Matrix3 Divergence<2, Set::Sym::Isotropic>(const amrex::Array4<const Set::Matrix4<AMREX_SPACEDIM, Set::Sym::Isotropic>>& C,
+template <>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix3 Divergence<2, Set::Sym::Isotropic>(
+    const amrex::Array4<const Set::Matrix4<AMREX_SPACEDIM, Set::Sym::Isotropic>>& C,
     const int i, const int j, const int k, const Set::Scalar dx[AMREX_SPACEDIM],
     std::array<StencilType, AMREX_SPACEDIM> stencil)
 {
@@ -1314,14 +1483,14 @@ Set::Matrix3 Divergence<2, Set::Sym::Isotropic>(const amrex::Array4<const Set::M
 
 
 template<int dim>
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Set::Matrix4<dim, Set::Sym::Full>
 DoubleHessian(const amrex::Array4<const Set::Scalar>& f,
     const int& i, const int& j, const int& k, const int& m,
     const Set::Scalar dx[AMREX_SPACEDIM]);
 
 template<>
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Set::Matrix4<2, Set::Sym::Full>
 DoubleHessian<2>(const amrex::Array4<const Set::Scalar>& f,
     const int& i, const int& j, const int& k, const int& m,
@@ -1342,7 +1511,7 @@ DoubleHessian<2>(const amrex::Array4<const Set::Scalar>& f,
 }
 
 template<>
-[[nodiscard]] AMREX_FORCE_INLINE
+[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Set::Matrix4<3, Set::Sym::Full>
 DoubleHessian<3>(const amrex::Array4<const Set::Scalar>& f,
     const int& i, const int& j, const int& k, const int& m,
@@ -1385,11 +1554,13 @@ DoubleHessian<3>(const amrex::Array4<const Set::Scalar>& f,
 struct Interpolate
 {
 public:
-    template<class T>
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T CellToNodeAverage(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+    template <class T>
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T CellToNodeAverage( const amrex::Array4<const T>& f,
+                                const int& i, const int& j, const int& k, const int& m,
+                                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         int AMREX_D_DECL(
             ilo = (stencil[0] == Numeric::StencilType::Lo ? 0 : 1),
@@ -1402,13 +1573,16 @@ public:
             ,
             +f(i, j, k - klo, m) + f(i - ilo, j, k - klo, m)
             + f(i, j - jlo, k - klo, m) + f(i - ilo, j - jlo, k - klo, m)
-        )) * fac;
+        )) * AMREX_D_PICK(0.5, 0.25, 0.125);
     }
-    template<class T>
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T CellToNodeAverage(const amrex::Array4<T>& f,
-            const int& i, const int& j, const int& k, const int& m,
-            std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType)
+
+    template <class T>
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T CellToNodeAverage( const amrex::Array4<T>& f,
+                                const int& i, const int& j, const int& k, const int& m,
+                                std::array<StencilType, AMREX_SPACEDIM> stencil = DefaultType())
     {
         int AMREX_D_DECL(
             ilo = (stencil[0] == Numeric::StencilType::Lo ? 0 : 1),
@@ -1421,12 +1595,14 @@ public:
             ,
             +f(i, j, k - klo, m) + f(i - ilo, j, k - klo, m)
             + f(i, j - jlo, k - klo, m) + f(i - ilo, j - jlo, k - klo, m)
-        )) * fac;
+        )) * AMREX_D_PICK(0.5, 0.25, 0.125);
     }
-    template<class T>
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T NodeToCellAverage(const amrex::Array4<const T>& f,
-            const int& i, const int& j, const int& k, const int& m)
+    template <class T>
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T NodeToCellAverage( const amrex::Array4<const T>& f,
+                                const int& i, const int& j, const int& k, const int& m)
     {
         return (AMREX_D_TERM(f(i, j, k, m) + f(i + 1, j, k, m)
             ,
@@ -1434,12 +1610,14 @@ public:
             ,
             +f(i, j, k + 1, m) + f(i + 1, j, k + 1, m)
             + f(i, j + 1, k + 1, m) + f(i + 1, j + 1, k + 1, m)
-        )) * fac;
+        )) * AMREX_D_PICK(0.5, 0.25, 0.125);
     }
-    template<class T>
-    [[nodiscard]] AMREX_FORCE_INLINE
-        static T NodeToCellAverage(const amrex::Array4<T>& f,
-            const int& i, const int& j, const int& k, const int& m)
+    template <class T>
+    [[nodiscard]]
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static T NodeToCellAverage( const amrex::Array4<T>& f,
+                                const int& i, const int& j, const int& k, const int& m)
     {
         return (AMREX_D_TERM(f(i, j, k, m) + f(i + 1, j, k, m)
             ,
@@ -1447,9 +1625,8 @@ public:
             ,
             +f(i, j, k + 1, m) + f(i + 1, j, k + 1, m)
             + f(i, j + 1, k + 1, m) + f(i + 1, j + 1, k + 1, m)
-        )) * fac;
+        )) * AMREX_D_PICK(0.5, 0.25, 0.125);
     }
-    constexpr static Set::Scalar fac = AMREX_D_PICK(0.5, 0.25, 0.125);
 };
 
 }

--- a/src/Operator/Elastic.H
+++ b/src/Operator/Elastic.H
@@ -55,6 +55,8 @@ public:
     void SetPsi (int amrlev, const amrex::MultiFab& a_psi);
     void SetPsi (int amrlev, const amrex::MultiFab& a_psi, const Set::Scalar &a_psi_small)
     {m_psi_small = a_psi_small; SetPsi(amrlev,a_psi);}
+    void SetConservativeFaceFlux(bool a_enabled)
+    { m_conservative_face_flux = a_enabled; }
 
     /// The different types of Boundary Condtiions are listed in the `BC::Operator::Elastic` documentation
     ///
@@ -88,8 +90,6 @@ public:
     ///
     void Energy (int amrlev, amrex::MultiFab& energy, const amrex::MultiFab& u, bool a_homogeneous=false);
 
-    //void Energy (int amrlev, amrex::MultiFab& energies, const amrex::MultiFab& u, std::vector<SOLID> models, bool a_homogeneous=false);
-
     /// This function is depricated and should not be used. Use the other `SetBC` function.
     ///
     void SetBC(const std::array<std::array<BC,AMREX_SPACEDIM>,AMREX_SPACEDIM> &a_bc_lo,
@@ -108,8 +108,10 @@ public:
     
     using Operator::Reflux;
 
-protected:
+public:
 
+
+    using Operator::Diagonal;
     virtual void Diagonal (int amrlev, int mglev, amrex::MultiFab& diag) override;
 
     virtual void Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) const override final;
@@ -122,6 +124,14 @@ protected:
 
     virtual int getNComp() const override {return AMREX_SPACEDIM;};
     virtual bool isCrossStencil () const { return false; }
+protected:
+    bool useQuadraticAmrInterpolation() const override
+    { return m_conservative_face_flux; }
+    bool retainCoarseFineResidualRow() const override
+    { return m_conservative_face_flux; }
+    bool relaxCoarseFineGhostRows() const override
+    { return !m_conservative_face_flux; }
+public:
     virtual void prepareForSolve () override
     {
         if (!m_model_set) Util::Abort(INFO,"Attempting to use operator before calling SetModel!");
@@ -129,39 +139,25 @@ protected:
         Operator<Grid::Node>::prepareForSolve();
     };
 
-private:
+public:
     /// Simple arrays storing boundary conditions for each component and each face.
     std::array<std::array<BC,AMREX_SPACEDIM>, AMREX_SPACEDIM> m_bc_lo; // m_bc_lo[face][dimension]
     std::array<std::array<BC,AMREX_SPACEDIM>, AMREX_SPACEDIM> m_bc_hi; // m_bc_hi[face][dimension]
 
-    /// This is a multifab-type object containing objects of type
-    /// Model::Solid::Elastic::Isotropic::Isotropic
-    /// (or some other model type). T is the template argument.
-    /// The models contain elastic constants and contain methods for converting strain to stress
+    /// \brief Multifab of elastic constant models (e.g. Model::Solid::Elastic::Isotropic::Isotropic)
     amrex::Vector<Set::Field<Set::Matrix4<AMREX_SPACEDIM,SYM>>> m_ddw_mf;
 
-    // This is a mask variable.
     amrex::Vector<Set::Field<Set::Scalar>> m_psi_mf;
     Set::Scalar m_psi_small = 1E-8;
     bool m_psi_set = false;
+    bool m_conservative_face_flux = false;
 
     virtual void averageDownCoeffs () override;
     void averageDownCoeffsDifferentAmrLevels (int fine_amrlev);
     
     /// \fn averageDownCoeffsSameAmrLevel
     /// \brief Update coarse-level AMR coefficients with data from fine level
-    ///
-    /// This function is called before the solve, and it updates the Matrix4 coefficients
-    /// on coarse levels with averaged versions on the fine levels.
-    /// Typically, this is not necessary, since the coefficients are computed on each level
-    /// already. 
-    /// However, there are some cases where this messes up the multigrid solver.
-    /// (Phase field fracture is the primary example.)
-    /// 
-    /// This is disabled by default. In order to enable, call
-    ///    
-    ///     elasticoperator.SetAverageDownCoeffs(true);
-    ///
+    /// Disabled by default; enable via SetAverageDownCoeffs(true).
     void averageDownCoeffsSameAmrLevel (int amrlev);
 
     void FillBoundaryCoeff (MultiTab& sigma, const amrex::Periodicity& p);

--- a/src/Operator/Elastic.cpp
+++ b/src/Operator/Elastic.cpp
@@ -1,9 +1,23 @@
-// TODO: Remove these 
-
 #include "Elastic.H"
+#include "AMReX_Loop.H"
 #include "Set/Set.H"
 
 #include "Numeric/Stencil.H"
+
+#ifdef ALAMO_GPU
+#define ALAMO_ELASTIC_OP_FOR amrex::ParallelFor
+#define ALAMO_ELASTIC_OP_CAPTURE [=]
+#define ALAMO_ELASTIC_OP_DEVICE AMREX_GPU_DEVICE
+#define ALAMO_ELASTIC_OP_BC_EVAL(bc, bc_type, u, gradu, sigma, i, j, k, bx) \
+    ::BC::Operator::Elastic::Elastic::eval(bc_type, u, gradu, sigma, i, j, k, bx)
+#else
+#define ALAMO_ELASTIC_OP_FOR amrex::LoopConcurrentOnCpu
+#define ALAMO_ELASTIC_OP_CAPTURE [=]
+#define ALAMO_ELASTIC_OP_DEVICE
+#define ALAMO_ELASTIC_OP_BC_EVAL(bc, bc_type, u, gradu, sigma, i, j, k, bx) \
+    (*(bc))(u, gradu, sigma, i, j, k, bx)
+#endif
+
 namespace Operator
 {
 template<int SYM>
@@ -45,7 +59,7 @@ Elastic<SYM>::define(const Vector<Geometry>& a_geom,
         {
             m_ddw_mf[amrlev][mglev].reset(new MultiTab(amrex::convert(m_grids[amrlev][mglev],
                 amrex::IntVect::TheNodeVector()),
-                m_dmap[amrlev][mglev], 1, model_nghost));
+                m_dmap[amrlev][mglev], AMREX_SPACEDIM + 1, model_nghost));
             m_psi_mf[amrlev][mglev].reset(new MultiFab(m_grids[amrlev][mglev],
                 m_dmap[amrlev][mglev], 1, model_nghost));
 
@@ -63,21 +77,36 @@ Elastic<SYM>::SetModel(MATRIX4& a_model)
         amrex::Box domain(m_geom[amrlev][0].Domain());
         domain.convert(amrex::IntVect::TheNodeVector());
 
+#ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+        Util::DeviceErrorFlag setmodel_error;
+        int* setmodel_error_flag = setmodel_error.dataPtr();
+#endif
+#endif
         for (MFIter mfi(*m_ddw_mf[amrlev][0], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             Box bx = mfi.grownnodaltilebox();
 
             amrex::Array4<MATRIX4> const& ddw = (*(m_ddw_mf[amrlev][0])).array(mfi);
 
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                ddw(i, j, k) = a_model;
+            ALAMO_ELASTIC_OP_FOR(bx, ALAMO_ELASTIC_OP_CAPTURE ALAMO_ELASTIC_OP_DEVICE (int i, int j, int k) {
+                for (int n = 0; n < AMREX_SPACEDIM + 1; ++n)
+                    ddw(i, j, k, n) = a_model;
 
 #ifdef AMREX_DEBUG
-                if (ddw(i, j, k).contains_nan()) Util::Abort(INFO, "model is nan at (", i, ",", j, ",", k, "), amrlev=", amrlev);
+#ifdef ALAMO_GPU
+                if (ddw(i, j, k, 0).contains_nan()) Util::SetDeviceError(setmodel_error_flag);
+#else
+                if (ddw(i, j, k, 0).contains_nan()) Util::Abort(INFO, "model is nan at (", i, ",", j, ",", k, "), amrlev=", amrlev);
+#endif
 #endif
             });
         }
-        
+#ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+        Util::AbortIfDeviceError(setmodel_error, INFO, "Operator::Elastic::SetModel() detected a NaN in the device coefficient field");
+#endif
+#endif
         (*(m_ddw_mf[amrlev][0])).setMultiGhost(true);
         (*(m_ddw_mf[amrlev][0])).FillBoundary( Geom(amrlev,0).periodicity());
     }
@@ -95,9 +124,13 @@ Elastic<SYM>::SetModel(int amrlev, const amrex::FabArray<amrex::BaseFab<MATRIX4>
 
     if (a_model.boxArray() != m_ddw_mf[amrlev][0]->boxArray()) Util::Abort(INFO, "Inconsistent box arrays\n", "a_model.boxArray()=\n", a_model.boxArray(), "\n but the current box array is \n", m_ddw_mf[amrlev][0]->boxArray());
     if (a_model.DistributionMap() != m_ddw_mf[amrlev][0]->DistributionMap()) Util::Abort(INFO, "Inconsistent distribution maps");
-    if (a_model.nComp() != m_ddw_mf[amrlev][0]->nComp()) Util::Abort(INFO, "Inconsistent # of components - should be ", m_ddw_mf[amrlev][0]->nComp());
+    if (a_model.nComp() != 1 &&
+        a_model.nComp() != m_ddw_mf[amrlev][0]->nComp())
+        Util::Abort(INFO, "Inconsistent # of coefficient components - should be 1 or ",
+            m_ddw_mf[amrlev][0]->nComp());
     if (a_model.nGrow() != m_ddw_mf[amrlev][0]->nGrow()) Util::Abort(INFO, "Inconsistent # of ghost nodes, should be ", m_ddw_mf[amrlev][0]->nGrow());
 
+    const bool nodal_only = a_model.nComp() == 1;
 
     for (MFIter mfi(a_model, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -107,7 +140,9 @@ Elastic<SYM>::SetModel(int amrlev, const amrex::FabArray<amrex::BaseFab<MATRIX4>
         amrex::Array4<const MATRIX4> const& a_C = a_model.array(mfi);
 
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            C(i, j, k) = a_C(i, j, k);
+            C(i, j, k, 0) = a_C(i, j, k, 0);
+            for (int n = 1; n < AMREX_SPACEDIM + 1; ++n)
+                C(i, j, k, n) = a_C(i, j, k, nodal_only ? 0 : n);
         });
     }
     m_ddw_mf[amrlev][0]->setMultiGhost(true);
@@ -148,7 +183,13 @@ Elastic<SYM>::Fapply(int amrlev, int mglev, MultiFab& a_f, const MultiFab& a_u) 
     amrex::Box stencilbox(m_geom[amrlev][mglev].growPeriodicDomain(2));
     stencilbox.convert(amrex::IntVect::TheNodeVector());
 
-    const Real* DX = m_geom[amrlev][mglev].CellSize();
+    Set::Vector DX(m_geom[amrlev][mglev].CellSize()); // device-safe cell size (copied into device closure)
+#ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+    Util::DeviceErrorFlag fapply_error;
+    int* fapply_error_flag = fapply_error.dataPtr();
+#endif
+#endif
 
     for (MFIter mfi(a_f, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -161,8 +202,17 @@ Elastic<SYM>::Fapply(int amrlev, int mglev, MultiFab& a_f, const MultiFab& a_u) 
         amrex::Array4<Set::Scalar> const& psi = m_psi_mf[amrlev][mglev]->array(mfi);
 
         const Dim3 lo = amrex::lbound(stencilbox), hi = amrex::ubound(stencilbox);
+        auto m_psi_set = this->m_psi_set;
+        auto m_psi_small = this->m_psi_small;
+        auto m_conservative_face_flux = this->m_conservative_face_flux;
+        auto m_uniform = this->m_uniform;
+#ifdef ALAMO_GPU
+        auto m_bc_type = this->m_bc->GetBcTypeArray();
+#else
+        auto m_bc = this->m_bc;
+#endif
 
-        amrex::ParallelFor(tilebox, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+        ALAMO_ELASTIC_OP_FOR(tilebox, ALAMO_ELASTIC_OP_CAPTURE ALAMO_ELASTIC_OP_DEVICE (int i, int j, int k) {
 
             Set::Vector f = Set::Vector::Zero();
 
@@ -173,92 +223,120 @@ Elastic<SYM>::Fapply(int amrlev, int mglev, MultiFab& a_f, const MultiFab& a_u) 
             bool AMREX_D_DECL(xmin = (i == lo.x), ymin = (j == lo.y), zmin = (k == lo.z)),
                 AMREX_D_DECL(xmax = (i == hi.x), ymax = (j == hi.y), zmax = (k == hi.z));
 
-            // Determine if a special stencil will be necessary for first derivatives
             std::array<Numeric::StencilType, AMREX_SPACEDIM>
                 sten = Numeric::GetStencil(i, j, k, stencilbox);
 
-            // The displacement gradient tensor
             Set::Matrix gradu; // gradu(i,j) = u_{i,j)
 
-            // Fill gradu
             for (int p = 0; p < AMREX_SPACEDIM; p++)
             {
-                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(U, i, j, k, p, DX, sten));,
-                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(U, i, j, k, p, DX, sten));,
-                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(U, i, j, k, p, DX, sten)););
+                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(U, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(U, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(U, i, j, k, p, DX.data(), sten)););
             }
 
             Set::Scalar psi_avg = 1.0;
             if (m_psi_set) psi_avg = (1.0 - m_psi_small) * Numeric::Interpolate::CellToNodeAverage(psi, i, j, k, 0) + m_psi_small;
 
-            // Stress tensor computed using the model fab
-            Set::Matrix sig = (DDW(i, j, k) * gradu) * psi_avg;
+            // ddw is reused below (sig, C(gradgradu), grad(psi) correction) - loaded once.
+            MATRIX4 const ddw = DDW(i, j, k);
 
-            // Boundary conditions
-            /// \todo Important: we need a way to handle corners and edges.
             amrex::IntVect m(AMREX_D_DECL(i, j, k));
             if (AMREX_D_TERM(xmax || xmin, || ymax || ymin, || zmax || zmin))
             {
-                f = (*m_bc)(u, gradu, sig, i, j, k, stencilbox);
+                // Only boundary rows consume the stress tensor.
+                Set::Matrix sig = (ddw * gradu) * psi_avg;
+                f = ALAMO_ELASTIC_OP_BC_EVAL(m_bc, m_bc_type, u, gradu, sig, i, j, k, stencilbox);
             }
             else
             {
+                if (m_conservative_face_flux)
+                {
+                    // Centered tangential endpoint averages avoid the checkerboard nullspace.
+                    for (int face = 0; face < AMREX_SPACEDIM; ++face)
+                    {
+                        const int im = i - (face == 0);
+                        const int jm = j - (face == 1);
+                        const int km = k - (face == 2);
+                        const Set::Matrix grad_hi = Numeric::FaceGradient(
+                            U, i, j, k, face, DX.data());
+                        const Set::Matrix grad_lo = Numeric::FaceGradient(
+                            U, im, jm, km, face, DX.data());
+                        const Set::Matrix flux_hi =
+                            DDW(i, j, k, face + 1) * grad_hi;
+                        const Set::Matrix flux_lo =
+                            DDW(im, jm, km, face + 1) * grad_lo;
+                        f += (flux_hi.col(face) - flux_lo.col(face)) / DX[face];
+                    }
+                }
+                else
+                {
 
-
-                // The gradient of the displacement gradient tensor
-                // TODO - replace with this call. But not for this PR
-                //Set::Matrix3 gradgradu = Numeric::Hessian(U,i,j,k,DX,sten); // gradgradu[k](l,j) = u_{k,lj}
+                /// \todo replace with Numeric::Hessian(U,i,j,k,DX,sten)
                 Set::Matrix3 gradgradu; // gradgradu[k](l,j) = u_{k,lj}
 
-                // Fill gradu and gradgradu
                 for (int p = 0; p < AMREX_SPACEDIM; p++)
                 {
-                    // Diagonal terms:
                     AMREX_D_TERM(
-                        gradgradu(p, 0, 0) = (Numeric::Stencil<Set::Scalar, 2, 0, 0>::D(U, i, j, k, p, DX));,
-                        gradgradu(p, 1, 1) = (Numeric::Stencil<Set::Scalar, 0, 2, 0>::D(U, i, j, k, p, DX));,
-                        gradgradu(p, 2, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 2>::D(U, i, j, k, p, DX)););
+                        gradgradu(p, 0, 0) = (Numeric::Stencil<Set::Scalar, 2, 0, 0>::D(U, i, j, k, p, DX.data()));,
+                        gradgradu(p, 1, 1) = (Numeric::Stencil<Set::Scalar, 0, 2, 0>::D(U, i, j, k, p, DX.data()));,
+                        gradgradu(p, 2, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 2>::D(U, i, j, k, p, DX.data())););
 
-                    // Off-diagonal terms:
                     AMREX_D_TERM(
-                        ,// 2D
-                        gradgradu(p, 0, 1) = (Numeric::Stencil<Set::Scalar, 1, 1, 0>::D(U, i, j, k, p, DX));
+                        ,
+                        gradgradu(p, 0, 1) = (Numeric::Stencil<Set::Scalar, 1, 1, 0>::D(U, i, j, k, p, DX.data()));
                         gradgradu(p, 1, 0) = gradgradu(p, 0, 1);
-                        ,// 3D
-                        gradgradu(p, 0, 2) = (Numeric::Stencil<Set::Scalar, 1, 0, 1>::D(U, i, j, k, p, DX));
-                        gradgradu(p, 1, 2) = (Numeric::Stencil<Set::Scalar, 0, 1, 1>::D(U, i, j, k, p, DX));
+                        ,
+                        gradgradu(p, 0, 2) = (Numeric::Stencil<Set::Scalar, 1, 0, 1>::D(U, i, j, k, p, DX.data()));
+                        gradgradu(p, 1, 2) = (Numeric::Stencil<Set::Scalar, 0, 1, 1>::D(U, i, j, k, p, DX.data()));
                         gradgradu(p, 2, 0) = gradgradu(p, 0, 2);
                         gradgradu(p, 2, 1) = gradgradu(p, 1, 2););
                 }
 
-                //
-                // Operator
-                //
-                // The return value is
-                //    f = C(grad grad u) + grad(C)*grad(u)
-                // In index notation
-                //    f_i = C_{ijkl,j} u_{k,l}  +  C_{ijkl}u_{k,lj}
-                //
-
-                f = (DDW(i, j, k) * gradgradu) * psi_avg;
+                // f = C(grad grad u) + grad(C)*grad(u)
+                f = (ddw * gradgradu) * psi_avg;
 
                 if (!m_uniform)
                 {
-                    MATRIX4
-                        AMREX_D_DECL(Cgrad1 = (Numeric::Stencil<MATRIX4, 1, 0, 0>::D(DDW, i, j, k, 0, DX, sten)),
-                            Cgrad2 = (Numeric::Stencil<MATRIX4, 0, 1, 0>::D(DDW, i, j, k, 0, DX, sten)),
-                            Cgrad3 = (Numeric::Stencil<MATRIX4, 0, 0, 1>::D(DDW, i, j, k, 0, DX, sten)));
-                    f += (AMREX_D_TERM((Cgrad1 * gradu).col(0),
-                        +(Cgrad2 * gradu).col(1),
-                        +(Cgrad3 * gradu).col(2))) * (psi_avg);
+                    // Accumulate grad(C):grad(u) one spatial direction at a time so
+                    // that only a single Matrix4 derivative temp is live at any
+                    // moment. Naming three temps (Cgrad1/2/3 = 135 live doubles in
+                    // 3D) whose scope spanned the whole expression was the dominant
+                    // Fapply register-spill source (255 regs/thread -> ~12.5%
+                    // occupancy, PHASE_A_FINDINGS.md sec.4).
+                    //
+                    // MulCol(a,b,c) is bit-identical to (a*b).col(c), computed
+                    // directly, and the summation order is unchanged, so f stays
+                    // bit-identical to both prior forms.
+                    Set::Vector graddc = Set::Vector::Zero();
+                    graddc += Set::MulCol(Numeric::Stencil<MATRIX4, 1, 0, 0>::D(DDW, i, j, k, 0, DX.data(), sten), gradu, 0);
+#if AMREX_SPACEDIM > 1
+                    graddc += Set::MulCol(Numeric::Stencil<MATRIX4, 0, 1, 0>::D(DDW, i, j, k, 0, DX.data(), sten), gradu, 1);
+#endif
+#if AMREX_SPACEDIM > 2
+                    graddc += Set::MulCol(Numeric::Stencil<MATRIX4, 0, 0, 1>::D(DDW, i, j, k, 0, DX.data(), sten), gradu, 2);
+#endif
+                    f += graddc * psi_avg;
                 }
                 if (m_psi_set)
                 {
-                    Set::Vector gradpsi = Numeric::CellGradientOnNode(psi, i, j, k, 0, DX);
+                    Set::Vector gradpsi = Numeric::CellGradientOnNode(psi, i, j, k, 0, DX.data());
                     gradpsi *= (1.0 - m_psi_small);
-                    f += (DDW(i, j, k) * gradu) * gradpsi;
+                    f += (ddw * gradu) * gradpsi;
+                }
                 }
 
+#ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+                if (std::isnan(f(0)) || std::isnan(f(1))
+#if AMREX_SPACEDIM == 3
+                    || std::isnan(f(2))
+#endif
+                )
+                {
+                    Util::SetDeviceError(fapply_error_flag);
+                }
+#else
                 if (std::isnan(f(0)) || std::isnan(f(1)))
                 {
                     Util::Message(INFO,"  =================  ");
@@ -282,13 +360,20 @@ Elastic<SYM>::Fapply(int amrlev, int mglev, MultiFab& a_f, const MultiFab& a_u) 
                     Util::Message(INFO,"psi_av: ",psi_avg);
                     Util::Message(INFO,"psi_set: ",m_psi_set);
                     Util::Message(INFO,"  =================  ");
-                        Util::Abort(INFO);
+                    Util::Abort(INFO);
                 }
-
+#endif
+#endif
             }
             AMREX_D_TERM(F(i, j, k, 0) = f[0];, F(i, j, k, 1) = f[1];, F(i, j, k, 2) = f[2];);
         });
+#ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+        Util::AbortIfDeviceError(fapply_error, INFO, "Operator::Elastic::Fapply() detected an invalid value on device");
+#endif
+#endif
     }
+
 }
 
 
@@ -299,17 +384,25 @@ Elastic<SYM>::Diagonal(int amrlev, int mglev, MultiFab& a_diag)
 {
     BL_PROFILE("Operator::Elastic::Diagonal()");
 
-    amrex::Box domain(m_geom[amrlev][mglev].growPeriodicDomain(1));
+    const amrex::IntVect diagonal_nghost = a_diag.nGrowVect();
+    amrex::Box domain(m_geom[amrlev][mglev].growPeriodicDomain(
+        diagonal_nghost.max()));
     domain.convert(amrex::IntVect::TheNodeVector());
 
     amrex::Box stencilbox(m_geom[amrlev][mglev].growPeriodicDomain(2));
     stencilbox.convert(amrex::IntVect::TheNodeVector());
 
-    const Real* DX = m_geom[amrlev][mglev].CellSize();
+    Set::Vector DX(m_geom[amrlev][mglev].CellSize()); // device-safe cell size (copied into device closure)
+#ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+    Util::DeviceErrorFlag diagonal_error;
+    int* diagonal_error_flag = diagonal_error.dataPtr();
+#endif
+#endif
 
     for (MFIter mfi(a_diag, false); mfi.isValid(); ++mfi)
     {
-        Box bx = mfi.validbox().grow(1) & domain;
+        Box bx = mfi.validbox().grow(diagonal_nghost) & domain;
         amrex::Box tilebox = mfi.grownnodaltilebox() & bx;
 
         amrex::Array4<MATRIX4> const& DDW = (*(m_ddw_mf[amrlev][mglev])).array(mfi);
@@ -317,31 +410,38 @@ Elastic<SYM>::Diagonal(int amrlev, int mglev, MultiFab& a_diag)
         amrex::Array4<Set::Scalar> const& psi = m_psi_mf[amrlev][mglev]->array(mfi);
 
         const Dim3 lo = amrex::lbound(stencilbox), hi = amrex::ubound(stencilbox);
+        auto m_psi_set = this->m_psi_set;
+        auto m_psi_small = this->m_psi_small;
+        auto m_conservative_face_flux = this->m_conservative_face_flux;
+#ifdef ALAMO_GPU
+        auto m_bc_type = this->m_bc->GetBcTypeArray();
+#else
+        auto m_bc = this->m_bc;
+#endif
 
-        amrex::ParallelFor(tilebox, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
+        amrex::ParallelFor(tilebox, [=] AMREX_GPU_DEVICE(int i, int j, int k)
         {
 
-            // Determine if a special stencil will be necessary for first derivatives
             std::array<Numeric::StencilType, AMREX_SPACEDIM>
                 sten = Numeric::GetStencil(i, j, k, stencilbox);
 
             // gradu(i,j) = u_{i,j)
-            std::array<Set::Matrix,AMREX_SPACEDIM> gradu = Numeric::Gradient_Diagonal<Set::Matrix>(DX, sten);  
+            std::array<Set::Matrix,AMREX_SPACEDIM> gradu = Numeric::Gradient_Diagonal<Set::Matrix>(DX.data(), sten);
 
             // gradgradu[k](l,j) = u_{k,lj}
-            std::array<Set::Matrix3,AMREX_SPACEDIM>  gradgradu = Numeric::Gradient_Diagonal<Set::Matrix3>(DX); 
+            std::array<Set::Matrix3,AMREX_SPACEDIM>  gradgradu = Numeric::Gradient_Diagonal<Set::Matrix3>(DX.data());
 
 
             Set::Vector f = Set::Vector::Zero();
 
-            bool    
+            bool
                 AMREX_D_DECL(xmin = (i == lo.x), ymin = (j == lo.y), zmin = (k == lo.z)),
                 AMREX_D_DECL(xmax = (i == hi.x), ymax = (j == hi.y), zmax = (k == hi.z));
 
             Set::Scalar psi_avg = 1.0;
             if (m_psi_set) psi_avg = (1.0 - m_psi_small) * Numeric::Interpolate::CellToNodeAverage(psi, i, j, k, 0) + m_psi_small;
 
-
+            MATRIX4 const ddw = DDW(i, j, k);
 
             for (int p = 0; p < AMREX_SPACEDIM; p++)
             {
@@ -352,26 +452,52 @@ Elastic<SYM>::Diagonal(int amrlev, int mglev, MultiFab& a_diag)
                 amrex::IntVect m(AMREX_D_DECL(i, j, k));
                 if (AMREX_D_TERM(xmax || xmin, || ymax || ymin, || zmax || zmin))
                 {
-                    Set::Matrix sig = DDW(i, j, k) * gradu[p] * psi_avg;
+                    Set::Matrix sig = ddw * gradu[p] * psi_avg;
                     Set::Vector u = Set::Vector::Zero();
                     u(p) = 1.0;
-                    f = (*m_bc)(u, gradu[p], sig, i, j, k, stencilbox);
+                    f = ALAMO_ELASTIC_OP_BC_EVAL(m_bc, m_bc_type, u, gradu[p], sig, i, j, k, stencilbox);
                     diag(i, j, k, p) = f(p);
+                }
+                else if (m_conservative_face_flux)
+                {
+                    // Only the two normal face differences contribute to this diagonal entry.
+                    for (int face = 0; face < AMREX_SPACEDIM; ++face)
+                    {
+                        const int im = i - (face == 0);
+                        const int jm = j - (face == 1);
+                        const int km = k - (face == 2);
+                        diag(i, j, k, p) -=
+                            (DDW(i, j, k, face + 1)(p, face, p, face)
+                             + DDW(im, jm, km, face + 1)(p, face, p, face))
+                            / (DX[face] * DX[face]);
+                    }
                 }
                 else
                 {
-                    Set::Vector f = (DDW(i, j, k) * gradgradu[p]) * psi_avg;
+                    Set::Vector f = (ddw * gradgradu[p]) * psi_avg;
                     diag(i, j, k, p) += f(p);
                 }
 
 #ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+                if (std::isnan(diag(i, j, k, p)) || std::isinf(diag(i, j, k, p)) || diag(i, j, k, p) == 0)
+                {
+                    Util::SetDeviceError(diagonal_error_flag);
+                }
+#else
                 if (std::isnan(diag(i, j, k, p))) Util::Abort(INFO, "diagonal is nan at (", i, ",", j, ",", k, "), amrlev=", amrlev, ", mglev=", mglev);
                 if (std::isinf(diag(i, j, k, p))) Util::Abort(INFO, "diagonal is inf at (", i, ",", j, ",", k, "), amrlev=", amrlev, ", mglev=", mglev);
                 if (diag(i, j, k, p) == 0) Util::Abort(INFO, "diagonal is zero at (", i, ",", j, ",", k, "), amrlev=", amrlev, ", mglev=", mglev);
 #endif
+#endif
 
             }
         });
+#ifdef AMREX_DEBUG
+#ifdef ALAMO_GPU
+        Util::AbortIfDeviceError(diagonal_error, INFO, "Operator::Elastic::Diagonal() detected an invalid value on device");
+#endif
+#endif
     }
 
     a_diag.FillBoundaryAndSync(Geom(amrlev,mglev).periodicity());
@@ -417,9 +543,9 @@ Elastic<SYM>::FFlux(int /*amrlev*/, const MFIter& /*mfi*/,
     amrex::BaseFab<amrex::Real> AMREX_D_DECL(&fxfab = *sigmafab[0],
         &fyfab = *sigmafab[1],
         &fzfab = *sigmafab[2]);
-    AMREX_D_TERM(fxfab.setVal(0.0);,
-        fyfab.setVal(0.0);,
-        fzfab.setVal(0.0););
+    AMREX_D_TERM(fxfab.setVal<amrex::RunOn::Device>(0.0);,
+        fyfab.setVal<amrex::RunOn::Device>(0.0);,
+        fzfab.setVal<amrex::RunOn::Device>(0.0););
 
 }
 
@@ -432,7 +558,7 @@ Elastic<SYM>::Strain(int amrlev,
 {
     BL_PROFILE("Operator::Elastic::Strain()");
 
-    const amrex::Real* DX = m_geom[amrlev][0].CellSize();
+    Set::Vector DX(m_geom[amrlev][0].CellSize()); // device-safe cell size (copied into device closure)
     amrex::Box domain(m_geom[amrlev][0].Domain());
     domain.convert(amrex::IntVect::TheNodeVector());
 
@@ -449,12 +575,11 @@ Elastic<SYM>::Strain(int amrlev,
             std::array<Numeric::StencilType, AMREX_SPACEDIM> sten
                 = Numeric::GetStencil(i, j, k, domain);
 
-            // Fill gradu
             for (int p = 0; p < AMREX_SPACEDIM; p++)
             {
-                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX, sten));,
-                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX, sten));,
-                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX, sten)););
+                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX.data(), sten)););
             }
 
             Set::Matrix eps = 0.5 * (gradu + gradu.transpose());
@@ -494,7 +619,7 @@ Elastic<SYM>::Stress(int amrlev,
     BL_PROFILE("Operator::Elastic::Stress()");
     SetHomogeneous(a_homogeneous);
 
-    const amrex::Real* DX = m_geom[amrlev][0].CellSize();
+    Set::Vector DX(m_geom[amrlev][0].CellSize()); // device-safe cell size (copied into device closure)
     amrex::Box domain(m_geom[amrlev][0].Domain());
     domain.convert(amrex::IntVect::TheNodeVector());
 
@@ -505,19 +630,20 @@ Elastic<SYM>::Stress(int amrlev,
         amrex::Array4<amrex::Real> const& sigma = a_sigma.array(mfi);
         amrex::Array4<Set::Scalar> const& psi = m_psi_mf[amrlev][0]->array(mfi);
         amrex::Array4<const amrex::Real> const& u = a_u.array(mfi);
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+        auto m_psi_set = this->m_psi_set;
+        auto m_psi_small = this->m_psi_small;
+        ALAMO_ELASTIC_OP_FOR(bx, ALAMO_ELASTIC_OP_CAPTURE ALAMO_ELASTIC_OP_DEVICE (int i, int j, int k)
         {
             Set::Matrix gradu;
 
             std::array<Numeric::StencilType, AMREX_SPACEDIM> sten
                 = Numeric::GetStencil(i, j, k, domain);
 
-            // Fill gradu
             for (int p = 0; p < AMREX_SPACEDIM; p++)
             {
-                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX, sten));,
-                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX, sten));,
-                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX, sten)););
+                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX.data(), sten)););
             }
 
             Set::Scalar psi_avg = 1.0;
@@ -561,7 +687,7 @@ Elastic<SYM>::Energy(int amrlev,
     amrex::Box domain(m_geom[amrlev][0].Domain());
     domain.convert(amrex::IntVect::TheNodeVector());
 
-    const amrex::Real* DX = m_geom[amrlev][0].CellSize();
+    Set::Vector DX(m_geom[amrlev][0].CellSize()); // device-safe cell size (copied into device closure)
 
     for (MFIter mfi(a_u, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -576,21 +702,16 @@ Elastic<SYM>::Energy(int amrlev,
             std::array<Numeric::StencilType, AMREX_SPACEDIM> sten
                 = Numeric::GetStencil(i, j, k, domain);
 
-            // Fill gradu
             for (int p = 0; p < AMREX_SPACEDIM; p++)
             {
-                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX, sten));,
-                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX, sten));,
-                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX, sten)););
+                AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                    gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX.data(), sten)););
             }
 
             Set::Matrix eps = .5 * (gradu + gradu.transpose());
             Set::Matrix sig = DDW(i, j, k) * gradu;
 
-            // energy(i,j,k) = (gradu.transpose() * sig).trace();
-
-            //Util::Abort(INFO,"Fix this"); //
-            //energy(i,j,k) = C(i,j,k).W(gradu);
             for (int m = 0; m < AMREX_SPACEDIM; m++)
             {
                 for (int n = 0; n < AMREX_SPACEDIM; n++)
@@ -623,6 +744,7 @@ Elastic<SYM>::averageDownCoeffs()
             }
         }
     }
+
 }
 
 template<int SYM>
@@ -633,10 +755,9 @@ Elastic<SYM>::averageDownCoeffsDifferentAmrLevels(int fine_amrlev)
     Util::Assert(INFO, TEST(fine_amrlev > 0));
 
     const int crse_amrlev = fine_amrlev - 1;
-    const int ncomp = 1;
-
     MultiTab& crse_ddw = *m_ddw_mf[crse_amrlev][0];
     MultiTab& fine_ddw = *m_ddw_mf[fine_amrlev][0];
+    const int ncomp = crse_ddw.nComp();
 
     amrex::Box cdomain(m_geom[crse_amrlev][0].Domain());
     cdomain.convert(amrex::IntVect::TheNodeVector());
@@ -663,22 +784,29 @@ Elastic<SYM>::averageDownCoeffsDifferentAmrLevels(int fine_amrlev)
         const Box& bx = mfi.validbox();
 
         amrex::Array4<const int> const& nmask = nodemask.array(mfi);
-        //amrex::Array4<const int> const& cmask = cellmask.array(mfi);
 
         amrex::Array4<MATRIX4> const& cdata = fine_ddw_for_coarse.array(mfi);
         amrex::Array4<const MATRIX4> const& fdata = fine_ddw.array(mfi);
 
         const Dim3 lo = amrex::lbound(cdomain), hi = amrex::ubound(cdomain);
 
-        for (int n = 0; n < fine_ddw.nComp(); n++)
+        for (int n = 0; n < ncomp; n++)
         {
-            // I,J,K == coarse coordinates
-            // i,j,k == fine coordinates
+            // (I,J,K) = coarse, (i,j,k) = fine
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int I, int J, int K) {
                 int i = I * 2, j = J * 2, k = K * 2;
 
                 if (nmask(I, J, K) == fine_fine_node || nmask(I, J, K) == coarse_fine_node)
                 {
+                    if (n > 0)
+                    {
+                        const int face = n - 1;
+                        cdata(I, J, K, n) = 0.5 * (
+                            fdata(i, j, k, n)
+                            + fdata(i + (face == 0), j + (face == 1),
+                                k + (face == 2), n));
+                        return;
+                    }
                     if ((I == lo.x || I == hi.x) &&
                         (J == lo.y || J == hi.y) &&
                         (K == lo.z || K == hi.z)) // Corner
@@ -722,7 +850,9 @@ Elastic<SYM>::averageDownCoeffsDifferentAmrLevels(int fine_amrlev)
                         fdata(i, j, k, n) / 8.0;
 
 #ifdef AMREX_DEBUG
-                    if (cdata(I, J, K).contains_nan()) Util::Abort(INFO, "restricted model is nan at (", i, ",", j, ",", k, "), fine_amrlev=", fine_amrlev);
+#ifndef ALAMO_GPU
+                    if (cdata(I, J, K, n).contains_nan()) Util::Abort(INFO, "restricted model is nan at (", i, ",", j, ",", k, "), fine_amrlev=", fine_amrlev);
+#endif
 #endif
                 }
 
@@ -730,12 +860,7 @@ Elastic<SYM>::averageDownCoeffsDifferentAmrLevels(int fine_amrlev)
         }
     }
 
-    // Copy the fine residual restricted onto the coarse grid
-    // into the final residual.
-
     crse_ddw.ParallelCopy(fine_ddw_for_coarse, 0, 0, ncomp, 0, 0, cgeom.periodicity());
-    //const int mglev = 0;
-    //Util::RealFillBoundary(crse_ddw, m_geom[crse_amrlev][mglev]);
 
     FillBoundaryCoeff(crse_ddw,Geom(fine_amrlev,0).periodicity());
 
@@ -758,6 +883,7 @@ Elastic<SYM>::averageDownCoeffsSameAmrLevel(int amrlev)
 
         MultiTab& crse = *m_ddw_mf[amrlev][mglev];
         MultiTab& fine = *m_ddw_mf[amrlev][mglev - 1];
+        const int ncomp = crse.nComp();
 
         amrex::BoxArray crseba = crse.boxArray();
         amrex::BoxArray fineba = fine.boxArray();
@@ -765,73 +891,101 @@ Elastic<SYM>::averageDownCoeffsSameAmrLevel(int amrlev)
         BoxArray newba = crseba;
         newba.refine(2);
         MultiTab fine_on_crseba;
-        fine_on_crseba.define(newba, crse.DistributionMap(), 1, 4);
-        fine_on_crseba.ParallelCopy(fine, 0, 0, 1, 2, 4, m_geom[amrlev][mglev-1].periodicity());
-        /* ine_on_crseba.FillBoundaryAndSync(m_geom[amrlev][mglev-1].periodicity()); */
+        fine_on_crseba.define(newba, crse.DistributionMap(), ncomp, 2);
+        fine_on_crseba.ParallelCopy(fine, 0, 0, ncomp, 2, 2,
+            m_geom[amrlev][mglev-1].periodicity());
+        /* fine_on_crseba.FillBoundaryAndSync(m_geom[amrlev][mglev-1].periodicity()); */
 
         for (MFIter mfi(crse, false); mfi.isValid(); ++mfi)
         {
 
-            Box bx = mfi.grownnodaltilebox() & cdomain;
-            /*Box bx = mfi.grownnodaltilebox(-1,1) & cdomain;*/
+            // Restrict valid coarse nodes only; support ghosts extended below after restriction.
+            Box bx = mfi.nodaltilebox() & cdomain;
 
             amrex::Array4<const Set::Matrix4<AMREX_SPACEDIM, SYM>> const& fdata = fine_on_crseba.array(mfi);
             amrex::Array4<Set::Matrix4<AMREX_SPACEDIM, SYM>> const& cdata = crse.array(mfi);
 
-            const Dim3 lo = amrex::lbound(bx), hi = amrex::ubound(bx);
-            /*const Dim3 lo = amrex::lbound(cdomain), hi = amrex::ubound(cdomain);*/
+            const Dim3 lo = amrex::lbound(cdomain), hi = amrex::ubound(cdomain);
 
-            // I,J,K == coarse coordinates
-            // i,j,k == fine coordinates
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int I, int J, int K) {
+            // (I,J,K) = coarse, (i,j,k) = fine
+            amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE(int I, int J, int K, int n) {
                 int i = 2 * I, j = 2 * J, k = 2 * K;
+
+                if (n > 0)
+                {
+                    const int face = n - 1;
+                    cdata(I, J, K, n) = 0.5 * (
+                        fdata(i, j, k, n)
+                        + fdata(i + (face == 0), j + (face == 1),
+                            k + (face == 2), n));
+                    return;
+                }
 
                 if ((I == lo.x || I == hi.x) &&
                     (J == lo.y || J == hi.y) &&
                     (K == lo.z || K == hi.z)) // Corner
-                    cdata(I, J, K) = fdata(i, j, k);
+                    cdata(I, J, K, n) = fdata(i, j, k, n);
                 else if ((J == lo.y || J == hi.y) &&
                     (K == lo.z || K == hi.z)) // X edge
-                    cdata(I, J, K) = fdata(i - 1, j, k) * 0.25 + fdata(i, j, k) * 0.5 + fdata(i + 1, j, k) * 0.25;
+                    cdata(I, J, K, n) = fdata(i - 1, j, k, n) * 0.25 + fdata(i, j, k, n) * 0.5 + fdata(i + 1, j, k, n) * 0.25;
                 else if ((K == lo.z || K == hi.z) &&
                     (I == lo.x || I == hi.x)) // Y edge
-                    cdata(I, J, K) = fdata(i, j - 1, k) * 0.25 + fdata(i, j, k) * 0.5 + fdata(i, j + 1, k) * 0.25;
+                    cdata(I, J, K, n) = fdata(i, j - 1, k, n) * 0.25 + fdata(i, j, k, n) * 0.5 + fdata(i, j + 1, k, n) * 0.25;
                 else if ((I == lo.x || I == hi.x) &&
                     (J == lo.y || J == hi.y)) // Z edge
-                    cdata(I, J, K) = fdata(i, j, k - 1) * 0.25 + fdata(i, j, k) * 0.5 + fdata(i, j, k + 1) * 0.25;
+                    cdata(I, J, K, n) = fdata(i, j, k - 1, n) * 0.25 + fdata(i, j, k, n) * 0.5 + fdata(i, j, k + 1, n) * 0.25;
                 else if (I == lo.x || I == hi.x) // X face
-                    cdata(I, J, K) =
-                    (fdata(i, j - 1, k - 1) + fdata(i, j, k - 1) * 2.0 + fdata(i, j + 1, k - 1)
-                        + fdata(i, j - 1, k) * 2.0 + fdata(i, j, k) * 4.0 + fdata(i, j + 1, k) * 2.0
-                        + fdata(i, j - 1, k + 1) + fdata(i, j, k + 1) * 2.0 + fdata(i, j + 1, k + 1)) / 16.0;
+                    cdata(I, J, K, n) =
+                    (fdata(i, j - 1, k - 1, n) + fdata(i, j, k - 1, n) * 2.0 + fdata(i, j + 1, k - 1, n)
+                        + fdata(i, j - 1, k, n) * 2.0 + fdata(i, j, k, n) * 4.0 + fdata(i, j + 1, k, n) * 2.0
+                        + fdata(i, j - 1, k + 1, n) + fdata(i, j, k + 1, n) * 2.0 + fdata(i, j + 1, k + 1, n)) / 16.0;
                 else if (J == lo.y || J == hi.y) // Y face
-                    cdata(I, J, K) =
-                    (fdata(i - 1, j, k - 1) + fdata(i - 1, j, k) * 2.0 + fdata(i - 1, j, k + 1)
-                        + fdata(i, j, k - 1) * 2.0 + fdata(i, j, k) * 4.0 + fdata(i, j, k + 1) * 2.0
-                        + fdata(i + 1, j, k - 1) + fdata(i + 1, j, k) * 2.0 + fdata(i + 1, j, k + 1)) / 16.0;
+                    cdata(I, J, K, n) =
+                    (fdata(i - 1, j, k - 1, n) + fdata(i - 1, j, k, n) * 2.0 + fdata(i - 1, j, k + 1, n)
+                        + fdata(i, j, k - 1, n) * 2.0 + fdata(i, j, k, n) * 4.0 + fdata(i, j, k + 1, n) * 2.0
+                        + fdata(i + 1, j, k - 1, n) + fdata(i + 1, j, k, n) * 2.0 + fdata(i + 1, j, k + 1, n)) / 16.0;
                 else if (K == lo.z || K == hi.z) // Z face
-                    cdata(I, J, K) =
-                    (fdata(i - 1, j - 1, k) + fdata(i, j - 1, k) * 2.0 + fdata(i + 1, j - 1, k)
-                        + fdata(i - 1, j, k) * 2.0 + fdata(i, j, k) * 4.0 + fdata(i + 1, j, k) * 2.0
-                        + fdata(i - 1, j + 1, k) + fdata(i, j + 1, k) * 2.0 + fdata(i + 1, j + 1, k)) / 16.0;
+                    cdata(I, J, K, n) =
+                    (fdata(i - 1, j - 1, k, n) + fdata(i, j - 1, k, n) * 2.0 + fdata(i + 1, j - 1, k, n)
+                        + fdata(i - 1, j, k, n) * 2.0 + fdata(i, j, k, n) * 4.0 + fdata(i + 1, j, k, n) * 2.0
+                        + fdata(i - 1, j + 1, k, n) + fdata(i, j + 1, k, n) * 2.0 + fdata(i + 1, j + 1, k, n)) / 16.0;
                 else // Interior
-                    cdata(I, J, K) =
-                    (fdata(i - 1, j - 1, k - 1) + fdata(i - 1, j - 1, k + 1) + fdata(i - 1, j + 1, k - 1) + fdata(i - 1, j + 1, k + 1) +
-                        fdata(i + 1, j - 1, k - 1) + fdata(i + 1, j - 1, k + 1) + fdata(i + 1, j + 1, k - 1) + fdata(i + 1, j + 1, k + 1)) / 64.0
+                    cdata(I, J, K, n) =
+                    (fdata(i - 1, j - 1, k - 1, n) + fdata(i - 1, j - 1, k + 1, n) + fdata(i - 1, j + 1, k - 1, n) + fdata(i - 1, j + 1, k + 1, n) +
+                        fdata(i + 1, j - 1, k - 1, n) + fdata(i + 1, j - 1, k + 1, n) + fdata(i + 1, j + 1, k - 1, n) + fdata(i + 1, j + 1, k + 1, n)) / 64.0
                     +
-                    (fdata(i, j - 1, k - 1) + fdata(i, j - 1, k + 1) + fdata(i, j + 1, k - 1) + fdata(i, j + 1, k + 1) +
-                        fdata(i - 1, j, k - 1) + fdata(i + 1, j, k - 1) + fdata(i - 1, j, k + 1) + fdata(i + 1, j, k + 1) +
-                        fdata(i - 1, j - 1, k) + fdata(i - 1, j + 1, k) + fdata(i + 1, j - 1, k) + fdata(i + 1, j + 1, k)) / 32.0
+                    (fdata(i, j - 1, k - 1, n) + fdata(i, j - 1, k + 1, n) + fdata(i, j + 1, k - 1, n) + fdata(i, j + 1, k + 1, n) +
+                        fdata(i - 1, j, k - 1, n) + fdata(i + 1, j, k - 1, n) + fdata(i - 1, j, k + 1, n) + fdata(i + 1, j, k + 1, n) +
+                        fdata(i - 1, j - 1, k, n) + fdata(i - 1, j + 1, k, n) + fdata(i + 1, j - 1, k, n) + fdata(i + 1, j + 1, k, n)) / 32.0
                     +
-                    (fdata(i - 1, j, k) + fdata(i, j - 1, k) + fdata(i, j, k - 1) +
-                        fdata(i + 1, j, k) + fdata(i, j + 1, k) + fdata(i, j, k + 1)) / 16.0
+                    (fdata(i - 1, j, k, n) + fdata(i, j - 1, k, n) + fdata(i, j, k - 1, n) +
+                        fdata(i + 1, j, k, n) + fdata(i, j + 1, k, n) + fdata(i, j, k + 1, n)) / 16.0
                     +
-                    fdata(i, j, k) / 8.0;
+                    fdata(i, j, k, n) / 8.0;
 
 #ifdef AMREX_DEBUG
-                if (cdata(I, J, K).contains_nan()) Util::Abort(INFO, "restricted model is nan at crse coordinates (I=", I, ",J=", J, ",K=", k, "), amrlev=", amrlev, " interpolating from mglev", mglev - 1, " to ", mglev);
+#ifndef ALAMO_GPU
+                if (cdata(I, J, K, n).contains_nan()) Util::Abort(INFO, "restricted model is nan at crse coordinates (I=", I, ",J=", J, ",K=", k, "), amrlev=", amrlev, " interpolating from mglev", mglev - 1, " to ", mglev);
+#endif
 #endif
             });
+        }
+        // Extend valid coarse coefficients to smoother support ghosts; FillBoundaryCoeff overwrites with real data.
+        for (MFIter mfi(crse, false); mfi.isValid(); ++mfi)
+        {
+            const Box valid = mfi.validbox();
+            const Box grown = mfi.grownnodaltilebox() & cdomain;
+            const Dim3 vlo = amrex::lbound(valid), vhi = amrex::ubound(valid);
+            amrex::Array4<Set::Matrix4<AMREX_SPACEDIM, SYM>> const& cdata = crse.array(mfi);
+            amrex::ParallelFor(grown, ncomp,
+                [=] AMREX_GPU_DEVICE(int I, int J, int K, int n)
+                {
+                    if (valid.contains(I, J, K)) return;
+                    const int Ic = amrex::max(vlo.x, amrex::min(I, vhi.x));
+                    const int Jc = amrex::max(vlo.y, amrex::min(J, vhi.y));
+                    const int Kc = amrex::max(vlo.z, amrex::min(K, vhi.z));
+                    cdata(I, J, K, n) = cdata(Ic, Jc, Kc, n);
+                });
         }
         FillBoundaryCoeff(crse, Geom(amrlev,mglev).periodicity());
 
@@ -856,8 +1010,7 @@ Elastic<SYM>::averageDownCoeffsSameAmrLevel(int amrlev)
 
             const Dim3 lo = amrex::lbound(cdomain), hi = amrex::ubound(cdomain);
 
-            // I,J,K == coarse coordinates
-            // i,j,k == fine coordinates
+            // (I,J,K) = coarse, (i,j,k) = fine
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int I, int J, int K) {
                 int i = 2 * I, j = 2 * J, k = 2 * K;
 

--- a/src/Operator/Operator.H
+++ b/src/Operator/Operator.H
@@ -18,17 +18,9 @@ namespace Operator
 
 template <Grid G> class Operator;
 
-//
-//
-//  NODE-BASED OPERATOR
-//
-//
-
 template <>
 class Operator<Grid::Node> : public amrex::MLNodeLinOp
 {
-    //
-    // Public: Constructor/Destructor/Operators/defines
     //
 public :
     Operator () {}
@@ -47,6 +39,12 @@ public :
             const LPInfo& a_info = LPInfo(),
             const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
     const Geometry& Geom (int amr_lev, int mglev=0) const noexcept { return m_geom[amr_lev][mglev]; }
+    /// Infinity norm over the active AMR composite grid.  Coarse nodes covered
+    /// by a finer level are excluded using the same nodal mask as MLMG.
+    Set::Scalar CompositeNormInf(int amrlev, const MultiFab& mf) const
+    {
+        return normInf(amrlev, mf, false);
+    }
 
     void Reflux(int crse_amrlev,
             MultiFab& res, const MultiFab& crse_sol, const MultiFab& crse_rhs,
@@ -57,45 +55,38 @@ public :
     void SetOmega(Set::Scalar a_omega) {m_omega = a_omega;}
     virtual void SetAverageDownCoeffs(bool) {Util::Abort(INFO,"Not implemented!");}
     void SetNormalizeDDW(bool a_normalize_ddw) {m_normalize_ddw = a_normalize_ddw;}
-    
-    //
-    // Public Utilty functions
-    //
+    // Must run once per Newton relinearization; MLMG only auto-syncs on its first solve.
+    void SyncCoefficients() { averageDownCoeffs(); Diagonal(true); }
+
 public:
     void RegisterNewFab(amrex::Vector<amrex::MultiFab> &input);
     void RegisterNewFab(amrex::Vector<std::unique_ptr<amrex::MultiFab> > &input);
     const amrex::FArrayBox & GetFab(const int num, const int amrlev, const int mglev, const amrex::MFIter &mfi) const;
     virtual void SetHomogeneous (bool) {};
-    //
-    // Pure Virtual: you MUST override these functions
-    //
 protected:
     virtual void Fapply (int amrlev, int mglev,MultiFab& out,const MultiFab& in) const override =0;
     virtual void averageDownCoeffs () = 0;
-    //
-    // Virtual: you SHOULD override these functions
-    //
-protected:
+    virtual bool useQuadraticAmrInterpolation() const { return false; }
+    virtual bool retainCoarseFineResidualRow() const { return false; }
+    virtual bool relaxCoarseFineGhostRows() const { return true; }
+public:
     virtual void Diagonal (bool recompute=false);
     virtual void Diagonal (int amrlev, int mglev, amrex::MultiFab& diag);
-    //
-    // Virtual: you CAN override these functions (but probably don't need to)
-    //
     virtual void Fsmooth (int amrlev, int mglev, MultiFab& x,const MultiFab& b) const override;
     virtual void normalize (int amrlev, int mglev, MultiFab& mf) const override;
     virtual void reflux (int crse_amrlev, MultiFab& res, const MultiFab& crse_sol, const MultiFab& crse_rhs,
                 MultiFab& fine_res, MultiFab& fine_sol, const MultiFab& fine_rhs) const override;
-    //
-    // Virtual: you CAN'T override these functions (they take care of AMReX business) and you SHOULDN'T
-    //
-protected:
+public:
     virtual void restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& fine) const final;
     virtual void interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiFab& crse) const override final;
+    virtual void interpolationAmr (int famrlev, MultiFab& fine,
+        const MultiFab& crse, IntVect const& nghost) const override final;
     virtual void averageDownSolutionRHS (int camrlev, MultiFab& crse_sol, MultiFab& crse_rhs, const MultiFab& fine_sol, const MultiFab& fine_rhs) final;
     virtual void prepareForSolve () override;
     virtual bool isSingular (int amrlev) const final {return (amrlev == 0) ? m_is_bottom_singular : false; }
     virtual bool isBottomSingular () const final { return m_is_bottom_singular; }
     virtual void applyBC (int amrlev, int mglev, MultiFab& phi, BCMode bc_mode, amrex::MLLinOp::StateMode /**/, bool skip_fillboundary=false) const final;
+public:
     virtual void fixUpResidualMask (int amrlev, iMultiFab& resmsk) final;
 public:
     virtual int getNGrow(int /*alev*/=0,int /*mglev*/=0) const override final {return 2;}
@@ -126,13 +117,6 @@ protected:
 
 
 
-//
-//
-//  CELL-BASED OPERATOR
-//
-//
-
-
 template<>
 class Operator<Grid::Cell> : public amrex::MLCellLinOp
 {
@@ -156,8 +140,6 @@ public:
             const amrex::LPInfo& a_info = amrex::LPInfo(),
             const amrex::Vector<amrex::FabFactory<amrex::FArrayBox> const*>& a_factory = {});
 
-    // virtual void setLevelBC (int amrlev, const amrex::MultiFab* levelbcdata) override final;
-
 protected:
     
     BC::BC<Set::Scalar> *m_bc;
@@ -168,9 +150,7 @@ protected:
     amrex::Vector<std::unique_ptr<amrex::MLMGBndry> > m_bndry_cor;
     amrex::Vector<std::unique_ptr<amrex::BndryRegister> > m_crse_cor_br;
 
-    // In case of agglomeration, coarse MG grids on amr level 0 are
-    // not simply coarsened from fine MG grids.  So we need to build
-    // bcond and bcloc for each MG level.
+    // Agglomerated coarse MG grids aren't simply coarsened from fine grids, so bcond/bcloc are per-MG-level.
     using RealTuple = std::array<amrex::Real,2*BL_SPACEDIM>;
     using BCTuple   = std::array<amrex::BoundCond,2*BL_SPACEDIM>;
     class BndryCondLoc
@@ -207,9 +187,6 @@ protected:
     void updateCorBC (int amrlev, const amrex::MultiFab& crse_bcdata) const;
 
     virtual void prepareForSolve () override;
-
-
-    // PURE VIRTUAL METHODS
 
     virtual void Fapply (int amrlev, int mglev, amrex::MultiFab& out, const amrex::MultiFab& in) const override = 0;
     virtual void Fsmooth (int amrlev, int mglev, amrex::MultiFab& sol, const amrex::MultiFab& rsh, int redblack) const override = 0;

--- a/src/Operator/Operator.cpp
+++ b/src/Operator/Operator.cpp
@@ -3,14 +3,23 @@
 #include <AMReX_MLCellLinOp.H>
 #include <AMReX_MLNodeLap_K.H>
 #include <AMReX_MultiFabUtil.H>
+#include <AMReX_ParallelDescriptor.H>
 #include "Util/Color.H"
 #include "Set/Set.H"
 #include "Operator.H"
 
 using namespace amrex;
+
+#ifdef ALAMO_GPU
+#define ALAMO_OPERATOR_FOR amrex::ParallelFor
+#define ALAMO_OPERATOR_DEVICE AMREX_GPU_DEVICE
+#else
+#define ALAMO_OPERATOR_FOR amrex::LoopConcurrentOnCpu
+#define ALAMO_OPERATOR_DEVICE
+#endif
+
 namespace Operator {
 
-// constexpr amrex::IntVect AMREX_D_DECL(Operator<Grid::Node>::dx,Operator<Grid::Node>::dy,Operator<Grid::Node>::dz);
 constexpr amrex::IntVect AMREX_D_DECL(Operator<Grid::Cell>::dx, Operator<Grid::Cell>::dy, Operator<Grid::Cell>::dz);
 
 void Operator<Grid::Node>::Diagonal(bool recompute)
@@ -31,7 +40,6 @@ void Operator<Grid::Node>::Diagonal(bool recompute)
 void Operator<Grid::Node>::Diagonal(int amrlev, int mglev, amrex::MultiFab& diag)
 {
     BL_PROFILE("Operator::Diagonal()");
-    //Util::Message(INFO);
 
     int ncomp = diag.nComp();
     int nghost = 0;
@@ -50,16 +58,15 @@ void Operator<Grid::Node>::Diagonal(int amrlev, int mglev, amrex::MultiFab& diag
         amrex::FArrayBox& xfab = x[mfi];
         amrex::FArrayBox& Axfab = Ax[mfi];
 
-        diagfab.setVal(0.0);
+        diagfab.setVal<amrex::RunOn::Device>(0.0);
 
         for (int i = 0; i < num; i++)
         {
             for (int n = 0; n < ncomp; n++)
             {
-                xfab.setVal(0.0);
-                Axfab.setVal(0.0);
+                xfab.setVal<amrex::RunOn::Device>(0.0);
+                Axfab.setVal<amrex::RunOn::Device>(0.0);
 
-                //BL_PROFILE_VAR("Operator::Part1", part1); 
                 AMREX_D_TERM(for (int m1 = bx.loVect()[0]; m1 <= bx.hiVect()[0]; m1++),
                     for (int m2 = bx.loVect()[1]; m2 <= bx.hiVect()[1]; m2++),
                         for (int m3 = bx.loVect()[2]; m3 <= bx.hiVect()[2]; m3++))
@@ -69,17 +76,14 @@ void Operator<Grid::Node>::Diagonal(int amrlev, int mglev, amrex::MultiFab& diag
                     if (m1 % sep == i / sep && m2 % sep == i % sep) xfab(m, n) = 1.0;
                     else xfab(m, n) = 0.0;
                 }
-                //BL_PROFILE_VAR_STOP(part1);
 
                 BL_PROFILE_VAR("Operator::Part2", part2);
                 Util::Message(INFO, "Calling fapply...", cntr++);
                 Fapply(amrlev, mglev, Ax, x);
                 BL_PROFILE_VAR_STOP(part2);
 
-                //BL_PROFILE_VAR("Operator::Part3", part3); 
-                Axfab.mult(xfab, n, n, 1);
-                diagfab.plus(Axfab, n, n, 1);
-                //BL_PROFILE_VAR_STOP(part3);
+                Axfab.mult<amrex::RunOn::Device>(xfab, n, n, 1);
+                diagfab.plus<amrex::RunOn::Device>(Axfab, n, n, 1);
             }
         }
     }
@@ -93,7 +97,8 @@ void Operator<Grid::Node>::Fsmooth(int amrlev, int mglev, amrex::MultiFab& x, co
     domain.convert(amrex::IntVect::TheNodeVector());
 
     int ncomp = b.nComp();
-    int nghost = 2; //b.nGrow();
+    const bool relax_ghost_rows = relaxCoarseFineGhostRows();
+    int nghost = relax_ghost_rows ? 2 : 0;
 
 
     amrex::MultiFab Ax(x.boxArray(), x.DistributionMap(), ncomp, nghost);
@@ -102,8 +107,7 @@ void Operator<Grid::Node>::Fsmooth(int amrlev, int mglev, amrex::MultiFab& x, co
 
     if (!m_diagonal_computed) Util::Abort(INFO, "Operator::Diagonal() must be called before using Fsmooth");
 
-    // This is a JACOBI iteration, not Gauss-Seidel.
-    // So we need to do twice the number of iterations to get the same behavior as GS.
+    // Jacobi, not Gauss-Seidel: run twice to match GS behavior.
     for (int ctr = 0; ctr < 2; ctr++)
     {
         Fapply(amrlev, mglev, Ax, x); // find Ax
@@ -116,35 +120,34 @@ void Operator<Grid::Node>::Fsmooth(int amrlev, int mglev, amrex::MultiFab& x, co
 
         for (MFIter mfi(x, false); mfi.isValid(); ++mfi)
         {
-            Box bx = mfi.grownnodaltilebox();
+            // relax_ghost_rows: conservative rows treat C/F ghosts as prescribed interpolation data.
+            Box bx = relax_ghost_rows ? mfi.grownnodaltilebox()
+                                      : (mfi.nodaltilebox() & domain);
             
-            amrex::Array4<amrex::Real> const& xfab = x.array(mfi);
-            amrex::Array4<const amrex::Real> const& bfab = b.array(mfi);
-            amrex::Array4<const amrex::Real> const& Rxfab = Rx.array(mfi);
-            amrex::Array4<const amrex::Real> const& diagfab = (*m_diag[amrlev][mglev]).array(mfi);
+            auto xfab = x.array(mfi);
+            auto bfab = b.const_array(mfi);
+            auto Rxfab = Rx.const_array(mfi);
+            auto diagfab = (*m_diag[amrlev][mglev]).const_array(mfi);
 
-
-            for (int n = 0; n < ncomp; n++)
+            auto m_omega = this->m_omega;
+            amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n)
             {
-                amrex::ParallelFor(bx, [&] AMREX_GPU_DEVICE(int i, int j, int k) 
-                {
 
-                    // Skip ghost cells outside problem domain
-                    if (!domain.contains(i,j,k))
-                    {
-                        //continue;
-                    }
-                    else if ( !bx.strictly_contains(i,j,k))
-                    {
-                        xfab(i, j, k, n) = 0.0;
-                        //continue;
-                    }
-                    else
-                    {
-                        xfab(i,j,k,n) = (1. - m_omega) * xfab(i,j,k, n) + m_omega * (bfab(i,j,k, n) - Rxfab(i,j,k, n)) / diagfab(i,j,k,n);
-                    }
-                });
-            }
+                if (relax_ghost_rows && !domain.contains(i,j,k))
+                {
+                    // Physical ghosts are supplied by the boundary condition.
+                }
+                else if (relax_ghost_rows && !bx.strictly_contains(i,j,k))
+                {
+                    xfab(i, j, k, n) = 0.0;
+                }
+                else
+                {
+                    xfab(i,j,k,n) = (1. - m_omega) * xfab(i,j,k, n)
+                        + m_omega * (bfab(i,j,k, n) - Rxfab(i,j,k, n))
+                        / diagfab(i,j,k,n);
+                }
+            });
         }
         amrex::Geometry geom = m_geom[amrlev][mglev];
         x.setMultiGhost(true);
@@ -158,7 +161,8 @@ void Operator<Grid::Node>::normalize(int amrlev, int mglev, MultiFab& a_x) const
     if (!m_diagonal_computed)
         Util::Abort(INFO, "Operator::Diagonal() must be called before using normalize");
 
-    a_x.divide(*m_diag[amrlev][mglev],0,getNComp(),2);
+    a_x.divide(*m_diag[amrlev][mglev], 0, getNComp(),
+        relaxCoarseFineGhostRows() ? 2 : 0);
 
     a_x.setMultiGhost(true);
     a_x.FillBoundaryAndSync(Geom(amrlev,mglev).periodicity());
@@ -220,9 +224,7 @@ void Operator<Grid::Node>::define(const Vector<Geometry>& a_geom,
         }
     }
 
-    // We need to instantiate the m_lobc objects.
-    // WE DO NOT USE THEM - our BCs are implemented differently.
-    // But they need to be the right size or the code will segfault.
+    // m_lobc/m_hibc unused (BCs implemented differently) but must be sized to avoid segfault.
     m_lobc.resize(getNComp(), { {AMREX_D_DECL(BCType::bogus,BCType::bogus,BCType::bogus)} });
     m_hibc.resize(getNComp(), { {AMREX_D_DECL(BCType::bogus,BCType::bogus,BCType::bogus)} });
 }
@@ -289,11 +291,31 @@ void Operator<Grid::Node>::restriction(int amrlev, int cmglev, MultiFab& crse, M
 
         for (int n = 0; n < crse.nComp(); n++)
         {
-            // I,J,K == coarse coordinates
-            // i,j,k == fine coordinates
+            // (I,J,K) = coarse, (i,j,k) = fine
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int I, int J, int K) {
                 int i = 2 * I, j = 2 * J, k = 2 * K;
 
+#if AMREX_SPACEDIM == 2
+                if ((I == lo.x || I == hi.x) && (J == lo.y || J == hi.y)) // Corner
+                {
+                    cdata(I, J, K, n) = fdata(i, j, k, n);
+                }
+                else if (J == lo.y || J == hi.y) // Y boundary
+                {
+                    cdata(I, J, K, n) = 0.25 * fdata(i - 1, j, k, n) + 0.5 * fdata(i, j, k, n) + 0.25 * fdata(i + 1, j, k, n);
+                }
+                else if (I == lo.x || I == hi.x) // X boundary
+                {
+                    cdata(I, J, K, n) = 0.25 * fdata(i, j - 1, k, n) + 0.5 * fdata(i, j, k, n) + 0.25 * fdata(i, j + 1, k, n);
+                }
+                else // Interior
+                {
+                    cdata(I, J, K, n) =
+                        (+fdata(i - 1, j - 1, k, n) + 2.0 * fdata(i, j - 1, k, n) + fdata(i + 1, j - 1, k, n)
+                            + 2.0 * fdata(i - 1, j, k, n) + 4.0 * fdata(i, j, k, n) + 2.0 * fdata(i + 1, j, k, n)
+                            + fdata(i - 1, j + 1, k, n) + 2.0 * fdata(i, j + 1, k, n) + fdata(i + 1, j + 1, k, n)) / 16.0;
+                }
+#else
                 if ((I == lo.x || I == hi.x) &&
                     (J == lo.y || J == hi.y) &&
                     (K == lo.z || K == hi.z)) // Corner
@@ -349,6 +371,7 @@ void Operator<Grid::Node>::restriction(int amrlev, int cmglev, MultiFab& crse, M
                         fdata(i + 1, j, k, n) + fdata(i, j + 1, k, n) + fdata(i, j, k + 1, n)) / 16.0
                     +
                     fdata(i, j, k, n) / 8.0;
+#endif
             });
         }
     }
@@ -386,7 +409,10 @@ void Operator<Grid::Node>::interpolation(int amrlev, int fmglev, MultiFab& fine,
         const Box& tmpbx = amrex::refine(course_bx, 2);
         FArrayBox tmpfab;
         tmpfab.resize(tmpbx, fine.nComp());
-        tmpfab.setVal(0.0);
+        // Elixir required: without it this per-box temp can be freed/reused by a different CUDA stream
+        // mid-flight, causing a nondeterministic cross-stream race (GPU multi-box MLMG divergence).
+        amrex::Gpu::Elixir tmpfab_eli = tmpfab.elixir();
+        tmpfab.setVal<amrex::RunOn::Device>(0.0);
         const amrex::FArrayBox& crsefab = (*cmf)[mfi];
 
         amrex::Array4<const amrex::Real> const& cdata = crsefab.const_array();
@@ -394,12 +420,22 @@ void Operator<Grid::Node>::interpolation(int amrlev, int fmglev, MultiFab& fine,
 
         for (int n = 0; n < crse.nComp(); n++)
         {
-            // I,J,K == coarse coordinates
-            // i,j,k == fine coordinates
-            amrex::ParallelFor(fine_bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            // (I,J,K) = coarse, (i,j,k) = fine
+            ALAMO_OPERATOR_FOR(fine_bx, [=] ALAMO_OPERATOR_DEVICE (int i, int j, int k) {
 
                 int I = i / 2, J = j / 2, K = k / 2;
 
+#if AMREX_SPACEDIM == 2
+                if (i % 2 == 0 && j % 2 == 0) // Coincident
+                    fdata(i, j, k, n) = cdata(I, J, K, n);
+                else if (j % 2 == 0) // X edge
+                    fdata(i, j, k, n) = 0.5 * (cdata(I, J, K, n) + cdata(I + 1, J, K, n));
+                else if (i % 2 == 0) // Y edge
+                    fdata(i, j, k, n) = 0.5 * (cdata(I, J, K, n) + cdata(I, J + 1, K, n));
+                else // Center
+                    fdata(i, j, k, n) = 0.25 * (cdata(I, J, K, n) + cdata(I + 1, J, K, n) +
+                        cdata(I, J + 1, K, n) + cdata(I + 1, J + 1, K, n));
+#else
                 if (i % 2 == 0 && j % 2 == 0 && k % 2 == 0) // Coincident
                     fdata(i, j, k, n) = cdata(I, J, K, n);
                 else if (j % 2 == 0 && k % 2 == 0) // X Edge
@@ -422,15 +458,17 @@ void Operator<Grid::Node>::interpolation(int amrlev, int fmglev, MultiFab& fine,
                         cdata(I + 1, J, K, n) + cdata(I, J + 1, K, n) + cdata(I, J, K + 1, n) +
                         cdata(I, J + 1, K + 1, n) + cdata(I + 1, J, K + 1, n) + cdata(I + 1, J + 1, K, n) +
                         cdata(I + 1, J + 1, K + 1, n));
+#endif
 
             });
         }
-        fine[mfi].plus(tmpfab, fine_bx, fine_bx, 0, 0, fine.nComp());
+        fine[mfi].plus<amrex::RunOn::Device>(tmpfab, fine_bx, fine_bx, 0, 0, fine.nComp());
     }
 
     fine.setMultiGhost(true);
     fine.FillBoundary(Geom(amrlev,fmglev).periodicity());
     nodalSync(amrlev, fmglev, fine);
+
 }
 
 void Operator<Grid::Node>::averageDownSolutionRHS(int camrlev, MultiFab& crse_sol, MultiFab& /*crse_rhs*/,
@@ -447,6 +485,78 @@ void Operator<Grid::Node>::averageDownSolutionRHS(int camrlev, MultiFab& crse_so
 
 }
 
+void Operator<Grid::Node>::interpolationAmr(int famrlev, MultiFab& fine,
+    const MultiFab& crse, IntVect const& nghost) const
+{
+    BL_PROFILE("Operator::interpolationAmr()");
+    if (!useQuadraticAmrInterpolation())
+    {
+        amrex::MLNodeLinOp::interpolationAmr(famrlev, fine, crse, nghost);
+        return;
+    }
+    Util::Assert(INFO, TEST(AMRRefRatio(famrlev - 1) == 2));
+    const int ncomp = getNComp();
+
+    for (MFIter mfi(fine, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box fbx = mfi.tilebox();
+        const Box valid = mfi.validbox();
+        fbx.grow(nghost);
+        const Dim3 vlo = amrex::lbound(valid), vhi = amrex::ubound(valid);
+        Array4<Real> const& ffab = fine.array(mfi);
+        Array4<Real const> const& cfab = crse.const_array(mfi);
+
+        ALAMO_OPERATOR_FOR(fbx, ncomp,
+            [=] ALAMO_OPERATOR_DEVICE(int i, int j, int k, int n)
+        {
+            int ci[3][3] = {};
+            Real cw[3][3] = {};
+            int nc[3] = {1, 1, 1};
+            cw[0][0] = cw[1][0] = cw[2][0] = 1.0;
+
+            const int fi[3] = {i, j, k};
+            const int flo[3] = {vlo.x, vlo.y, vlo.z};
+            const int fhi[3] = {vhi.x, vhi.y, vhi.z};
+            for (int d = 0; d < AMREX_SPACEDIM; ++d)
+            {
+                const int q = fi[d] >= 0 ? fi[d] / 2 : (fi[d] - 1) / 2;
+                if (fi[d] % 2 == 0)
+                {
+                    ci[d][0] = q;
+                }
+                else if (fi[d] < flo[d])
+                {
+                    nc[d] = 3;
+                    ci[d][0] = q;     cw[d][0] =  3.0 / 8.0;
+                    ci[d][1] = q + 1; cw[d][1] =  3.0 / 4.0;
+                    ci[d][2] = q + 2; cw[d][2] = -1.0 / 8.0;
+                }
+                else if (fi[d] > fhi[d])
+                {
+                    nc[d] = 3;
+                    ci[d][0] = q - 1; cw[d][0] = -1.0 / 8.0;
+                    ci[d][1] = q;     cw[d][1] =  3.0 / 4.0;
+                    ci[d][2] = q + 1; cw[d][2] =  3.0 / 8.0;
+                }
+                else
+                {
+                    nc[d] = 2;
+                    ci[d][0] = q;     cw[d][0] = 0.5;
+                    ci[d][1] = q + 1; cw[d][1] = 0.5;
+                }
+            }
+
+            Real value = 0.0;
+            for (int a = 0; a < nc[0]; ++a)
+                for (int b = 0; b < nc[1]; ++b)
+                    for (int c = 0; c < nc[2]; ++c)
+                        value += cw[0][a] * cw[1][b] * cw[2][c]
+                            * cfab(ci[0][a], ci[1][b], ci[2][c], n);
+            ffab(i, j, k, n) = value;
+        });
+    }
+}
+
 void Operator<Grid::Node>::realFillBoundary(MultiFab& phi, const Geometry& geom)
 {
     Util::RealFillBoundary(phi, geom);
@@ -460,8 +570,6 @@ void Operator<Grid::Node>::applyBC(int amrlev, int mglev, MultiFab& phi, BCMode/
     const Geometry& geom = m_geom[amrlev][mglev];
 
     if (!skip_fillboundary) {
-        //phi.FillBoundary(geom.periodicity());
-        //phi.setMultiGhost(true);
         phi.FillBoundaryAndSync(geom.periodicity());
     }
 }
@@ -548,6 +656,7 @@ void Operator<Grid::Node>::reflux(int crse_amrlev,
     // const int coarse_coarse_node = 0;
     const int coarse_fine_node = 1;
     const int fine_fine_node = 2;
+    const bool retain_coarse_fine = retainCoarseFineResidualRow();
 
     amrex::iMultiFab nodemask(amrex::coarsen(fba, 2), fdm, 1, 2);
     nodemask.ParallelCopy(*m_nd_fine_mask[crse_amrlev], 0, 0, 1, 0, 0, cgeom.periodicity());
@@ -557,7 +666,6 @@ void Operator<Grid::Node>::reflux(int crse_amrlev,
         const Box& bx = mfi.grownnodaltilebox(-1,1) & cdomain;
 
         amrex::Array4<const int> const& nmask = nodemask.array(mfi);
-        //amrex::Array4<const int> const& cmask = cellmask.array(mfi);
 
         amrex::Array4<amrex::Real> const& cdata = fine_res_for_coarse.array(mfi);
         amrex::Array4<const amrex::Real> const& fdata = fine_res.array(mfi);
@@ -566,12 +674,13 @@ void Operator<Grid::Node>::reflux(int crse_amrlev,
 
         for (int n = 0; n < fine_res.nComp(); n++)
         {
-            // I,J,K == coarse coordinates
-            // i,j,k == fine coordinates
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int I, int J, int K) {
+            // (I,J,K) = coarse, (i,j,k) = fine
+            ALAMO_OPERATOR_FOR(bx, [=] ALAMO_OPERATOR_DEVICE (int I, int J, int K) {
                 int i = I * 2, j = J * 2, k = K * 2;
 
-                if (nmask(I, J, K) == fine_fine_node || nmask(I, J, K) == coarse_fine_node)
+                // Only nodes fully covered by the fine level get its residual; shared C/F nodes keep this level's row.
+                if (nmask(I, J, K) == fine_fine_node ||
+                    (!retain_coarse_fine && nmask(I, J, K) == coarse_fine_node))
                 {
                     if ((I == lo.x || I == hi.x) &&
                         (J == lo.y || J == hi.y) &&
@@ -639,7 +748,7 @@ Operator<Grid::Node>::solutionResidual(int amrlev, MultiFab& resid, MultiFab& x,
     const int mglev = 0;
     const int ncomp = b.nComp();
     apply(amrlev, mglev, resid, x, BCMode::Inhomogeneous, StateMode::Solution);
-    MultiFab::Xpay(resid, -1.0, b, 0, 0, ncomp, 2);
+    MultiFab::Xpay(resid, -1.0, b, 0, 0, ncomp, resid.nGrow());
     resid.setMultiGhost(true);
     resid.FillBoundaryAndSync(Geom(amrlev).periodicity());
 }
@@ -650,8 +759,10 @@ Operator<Grid::Node>::correctionResidual(int amrlev, int mglev, MultiFab& resid,
 {
     resid.setVal(0.0);
     apply(amrlev, mglev, resid, x, BCMode::Homogeneous, StateMode::Correction);
+
     int ncomp = b.nComp();
     MultiFab::Xpay(resid, -1.0, b, 0, 0, ncomp, resid.nGrow());
+
     resid.setMultiGhost(true);
     resid.FillBoundaryAndSync(Geom(amrlev).periodicity());
 }

--- a/src/Set/Base.H
+++ b/src/Set/Base.H
@@ -25,6 +25,20 @@ using Matrix   = Eigen::Matrix<amrex::Real,AMREX_SPACEDIM,AMREX_SPACEDIM>;
 using Matrix3d = Eigen::Matrix3d;
 using iMatrix  = Eigen::Matrix<int,AMREX_SPACEDIM,AMREX_SPACEDIM>;
 
+
+template<class W, class DW>
+struct Jet {
+    W zero;     // or "grad"
+    DW first; // or "jacobian" or "hessian" depending on context
+
+    AMREX_GPU_HOST_DEVICE
+    Jet() = default;
+
+    AMREX_GPU_HOST_DEVICE
+    Jet(const W v, const DW d) : zero(v), first(d) {}
+};
+
+
 AMREX_FORCE_INLINE
 Set::Matrix reduce(const Set::Matrix3d &in)
 {
@@ -44,22 +58,28 @@ Set::Matrix3d expand(const Set::Matrix &in)
 class Quaternion : public Eigen::Quaterniond
 {
 public:
+    AMREX_GPU_HOST_DEVICE
     Quaternion()
         : Eigen::Quaterniond() {}
+    AMREX_GPU_HOST_DEVICE
     Quaternion(Set::Scalar w, Set::Scalar x, Set::Scalar y, Set::Scalar z)
         : Eigen::Quaterniond(w,x,y,z) {}
+    AMREX_GPU_HOST_DEVICE
     Quaternion(const Eigen::Matrix3d &R)
         : Eigen::Quaterniond(R) {}
+    AMREX_GPU_HOST_DEVICE
     Quaternion(Eigen::Quaterniond &q)
         : Eigen::Quaterniond(q.w(),q.x(),q.y(),q.z()) {}
 
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     void operator = (const Eigen::Quaterniond &rhs)
     {
         w() = rhs.w(); x() = rhs.x(); y() = rhs.y(); z() = rhs.z();
     }
 
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     void operator += (const Quaternion &rhs)
     {
         w() += rhs.w(); x() += rhs.x(); y() += rhs.y(); z() += rhs.z();
@@ -69,13 +89,14 @@ public:
     // {
     //     w += alpha; x *= alpha; y *= alpha; z *= alpha;
     // }
-    friend Quaternion operator * (const Set::Scalar alpha, const Quaternion b);
-    friend Quaternion operator * (const Quaternion b,const Set::Scalar alpha);
-    friend Quaternion operator + (const Quaternion a, const Quaternion b);
-    friend Quaternion operator - (const Quaternion a, const Quaternion b);
-    friend bool operator == (const Quaternion a, const Quaternion b);
+    friend AMREX_GPU_HOST_DEVICE Quaternion operator * (const Set::Scalar alpha, const Quaternion b);
+    friend AMREX_GPU_HOST_DEVICE Quaternion operator * (const Quaternion b,const Set::Scalar alpha);
+    friend AMREX_GPU_HOST_DEVICE Quaternion operator + (const Quaternion a, const Quaternion b);
+    friend AMREX_GPU_HOST_DEVICE Quaternion operator - (const Quaternion a, const Quaternion b);
+    friend AMREX_GPU_HOST_DEVICE bool operator == (const Quaternion a, const Quaternion b);
 };
 AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 Quaternion operator * (const Set::Scalar alpha, const Quaternion b)
 {
     Quaternion ret;
@@ -83,6 +104,7 @@ Quaternion operator * (const Set::Scalar alpha, const Quaternion b)
     return ret;
 }    
 AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 Quaternion operator * (const Quaternion b, const Set::Scalar alpha)
 {
     Quaternion ret;
@@ -90,6 +112,7 @@ Quaternion operator * (const Quaternion b, const Set::Scalar alpha)
     return ret;
 }    
 AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 Quaternion operator + (const Quaternion a, const Quaternion b)
 {
     Quaternion ret;
@@ -98,6 +121,7 @@ Quaternion operator + (const Quaternion a, const Quaternion b)
 }    
 
 AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 Quaternion operator - (const Quaternion a, const Quaternion b)
 {
     Quaternion ret;
@@ -106,6 +130,7 @@ Quaternion operator - (const Quaternion a, const Quaternion b)
 }    
 
 AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 bool operator == (const Quaternion a, const Quaternion b)
 {
     if (fabs((a.w() - b.w())/(a.w()+a.w())) > 1E-8) return false;
@@ -116,7 +141,22 @@ bool operator == (const Quaternion a, const Quaternion b)
 }
 
 
-[[maybe_unused]] static Scalar Garbage = NAN;
+#ifdef AMREX_DEVICE_COMPILE
+AMREX_GPU_DEVICE inline Scalar DeviceGarbage = NAN;
+#else
+AMREX_GPU_HOST inline Scalar HostGarbage = NAN;
+#endif
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Scalar& Garbage()
+{
+#ifdef AMREX_DEVICE_COMPILE
+    return DeviceGarbage;
+#else
+    return HostGarbage;
+#endif
+}
 
 AMREX_FORCE_INLINE
 Vector Position(const int &i, const int &j, const int &k, const amrex::Geometry &geom, const amrex::IndexType &ixType)
@@ -136,10 +176,38 @@ Vector Position(const int &i, const int &j, const int &k, const amrex::Geometry 
                 geom.ProbLo()[1] + ((amrex::Real)(j) + 0.5) * geom.CellSize()[1],
                 geom.ProbLo()[2] + ((amrex::Real)(k) + 0.5) * geom.CellSize()[2]));
     }
+    amrex::Abort("Set::Position: Unsupported index type");
+    return Set::Vector::Zero();
+}
+
+AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
+Vector Position(const int &i, const int &j, const int &k,
+                const Set::Vector &prob_lo,
+                const Set::Vector &cell_size,
+                const amrex::IndexType &ixType)
+{
+    (void)k;
+    if (ixType == amrex::IndexType::TheNodeType())
+    {
+        return Vector(AMREX_D_DECL(
+                prob_lo(0) + ((amrex::Real)(i)) * cell_size(0),
+                prob_lo(1) + ((amrex::Real)(j)) * cell_size(1),
+                prob_lo(2) + ((amrex::Real)(k)) * cell_size(2)));
+    }
+    else if (ixType == amrex::IndexType::TheCellType())
+    {
+        return Vector(AMREX_D_DECL(
+                prob_lo(0) + ((amrex::Real)(i) + 0.5) * cell_size(0),
+                prob_lo(1) + ((amrex::Real)(j) + 0.5) * cell_size(1),
+                prob_lo(2) + ((amrex::Real)(k) + 0.5) * cell_size(2)));
+    }
+    amrex::Abort("Set::Position: Unsupported index type");
     return Set::Vector::Zero(); 
 }
 
 AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
 Vector Normal(  AMREX_D_DECL(bool xmin,bool ymin, bool zmin),
                 AMREX_D_DECL(bool xmax,bool ymax, bool zmax))
 {
@@ -190,6 +258,7 @@ Vector Volume(const int &i, const int &j, const int &k, const amrex::Geometry &g
                 geom.ProbLo()[1] + ((amrex::Real)(j) + 0.5) * geom.CellSize()[1],
                 geom.ProbLo()[2] + ((amrex::Real)(k) + 0.5) * geom.CellSize()[2]));
     }
+    amrex::Abort("Set::Position: Unsupported index type");
     return Set::Vector::Zero(); 
 }
 

--- a/src/Set/Matrix3.H
+++ b/src/Set/Matrix3.H
@@ -25,7 +25,7 @@ public:
         return data[i];
     }
 
-    AMREX_FORCE_INLINE
+    AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE
     Set::Scalar norm()
     {
         Set::Scalar ret = 0.0;
@@ -39,12 +39,14 @@ public:
     AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE void operator *= (Set::Scalar alpha) {for (int i = 0; i < AMREX_SPACEDIM; i++) data[i] *= alpha;}
     AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE void operator /= (Set::Scalar alpha) {for (int i = 0; i < AMREX_SPACEDIM; i++) data[i] /= alpha;}
 
+    AMREX_GPU_HOST_DEVICE
     static Matrix3 Zero()
     {
         Matrix3 ret;
         for (int i = 0; i < AMREX_SPACEDIM; i++) ret.data[i] = Set::Matrix::Zero();
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     static Matrix3 Random()
     {
         Matrix3 ret;

--- a/src/Set/Matrix4_Diagonal.H
+++ b/src/Set/Matrix4_Diagonal.H
@@ -34,6 +34,7 @@ public:
 
     AMREX_GPU_HOST_DEVICE Matrix4() = default;
     //AMREX_GPU_HOST_DEVICE Matrix4(Set::Matrix a_A): A(a_A) {};
+    AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
         Scalar operator () (const int i, const int j, const int k, const int l) const
     {

--- a/src/Set/Matrix4_Isotropic.H
+++ b/src/Set/Matrix4_Isotropic.H
@@ -48,6 +48,7 @@ public:
     ///
     /// you will get a `lvalue required as left operand of assignment` compile error.
     /// You should probably consider using a lower symmetry operator.
+    AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
     Scalar operator () (const int i, const int j, const int k, const int l) const
     {

--- a/src/Set/Matrix4_Major.H
+++ b/src/Set/Matrix4_Major.H
@@ -9,7 +9,7 @@
 
 namespace Set
 {
-    
+
 template <>
 class Matrix4<2, Sym::Major>
 {
@@ -19,6 +19,40 @@ class Matrix4<2, Sym::Major>
 public:
     AMREX_GPU_HOST_DEVICE Matrix4(){};
 
+    #if AMREX_SPACEDIM == 2
+    AMREX_GPU_HOST_DEVICE
+    Matrix4(const Matrix4<2,Sym::Isotropic> &in)
+    {
+        // TODO: very inefficient, need to optimize
+        for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+        for (int k = 0; k < 2; k++)
+        for (int l = 0; l < 2; l++)
+            (*this)(i,j,k,l) = in(i,j,k,l);
+    }
+    AMREX_GPU_HOST_DEVICE
+    Matrix4(const Matrix4<2,Sym::Diagonal> &in)
+    {
+        // TODO: very inefficient, need to optimize
+        for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+        for (int k = 0; k < 2; k++)
+        for (int l = 0; l < 2; l++)
+            (*this)(i,j,k,l) = in(i,j,k,l);
+    }
+    AMREX_GPU_HOST_DEVICE
+    Matrix4(const Matrix4<2,Sym::MajorMinor> &in)
+    {
+        // TODO: very inefficient, need to optimize
+        for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+        for (int k = 0; k < 2; k++)
+        for (int l = 0; l < 2; l++)
+            (*this)(i,j,k,l) = in(i,j,k,l);
+    }
+    #endif
+
+    AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
     const Scalar &operator()(const int i, const int j, const int k, const int l) const
     {
@@ -35,9 +69,10 @@ public:
         else if (uid==15 )            return data[9]; // [1111] 
         else
             Util::Abort(INFO, "Index out of range");
-        return Set::Garbage;
+        return Set::Garbage();
     }
 
+    AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
     Scalar &operator()(const int i, const int j, const int k, const int l)
     {
@@ -54,40 +89,9 @@ public:
         else if (uid==15 )            return data[9]; // [1111] 
         else
             Util::Abort(INFO, "Index out of range");
-        return Set::Garbage;
+        return Set::Garbage();
     }
 
-
-    #if AMREX_SPACEDIM == 2
-    Matrix4(const Matrix4<2,Sym::Isotropic> &in)
-    {
-        // TODO: very inefficient, need to optimize
-        for (int i = 0; i < 2; i++)
-        for (int j = 0; j < 2; j++)
-        for (int k = 0; k < 2; k++)
-        for (int l = 0; l < 2; l++)
-            (*this)(i,j,k,l) = in(i,j,k,l);
-    }
-    Matrix4(const Matrix4<2,Sym::Diagonal> &in)
-    {
-        // TODO: very inefficient, need to optimize
-        for (int i = 0; i < 2; i++)
-        for (int j = 0; j < 2; j++)
-        for (int k = 0; k < 2; k++)
-        for (int l = 0; l < 2; l++)
-            (*this)(i,j,k,l) = in(i,j,k,l);
-    }
-    Matrix4(const Matrix4<2,Sym::MajorMinor> &in)
-    {
-        // TODO: very inefficient, need to optimize
-        for (int i = 0; i < 2; i++)
-        for (int j = 0; j < 2; j++)
-        for (int k = 0; k < 2; k++)
-        for (int l = 0; l < 2; l++)
-            (*this)(i,j,k,l) = in(i,j,k,l);
-    }
-    #endif
-    
     void Print(std::ostream &os)
     {
         os.precision(4);
@@ -132,6 +136,7 @@ public:
     AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE 
     void operator/=(const Set::Scalar &alpha)        { for (int i = 0; i < 10; i++) data[i] /= alpha; }
 
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<2, Sym::Major> Increment()
     {
         Matrix4<2, Sym::Major> ret;
@@ -148,18 +153,21 @@ public:
         ret.Randomize();
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<2, Sym::Major> Zero()
     {
         Matrix4<2, Sym::Major> ret;
         for (int i = 0; i < 10; i++) ret.data[i] = 0.0;
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     Set::Scalar Norm()
     {
         Set::Scalar normsq = 0.0;
         for (int i = 0; i < 10; i++) normsq += data[i]*data[i];
         return std::sqrt(normsq);
     }
+    AMREX_GPU_HOST_DEVICE
     bool contains_nan() const
     {
         if (std::isnan(data[ 0])) return true;
@@ -175,12 +183,14 @@ public:
         return false;
     }
 
-    friend Matrix4<2, Sym::Major> operator+(const Matrix4<2, Sym::Major> &a, const Matrix4<2, Sym::Major> &b);
-    friend Matrix4<2, Sym::Major> operator-(const Matrix4<2, Sym::Major> &a, const Matrix4<2, Sym::Major> &b);
-    friend Matrix4<2, Sym::Major> operator*(const Matrix4<2, Sym::Major> &a, const Set::Scalar &b);
-    friend Matrix4<2, Sym::Major> operator*(const Set::Scalar &b,const Matrix4<2, Sym::Major> &a);
-    friend Matrix4<2, Sym::Major> operator/(const Matrix4<2, Sym::Major> &a, const Set::Scalar &b);
-    friend Set::Matrix operator*(const Matrix4<2, Sym::Major> &a, const Set::Matrix &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2, Sym::Major> operator+(const Matrix4<2, Sym::Major> &a, const Matrix4<2, Sym::Major> &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2, Sym::Major> operator-(const Matrix4<2, Sym::Major> &a, const Matrix4<2, Sym::Major> &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2, Sym::Major> operator*(const Matrix4<2, Sym::Major> &a, const Set::Scalar &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2, Sym::Major> operator*(const Set::Scalar &b,const Matrix4<2, Sym::Major> &a);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2, Sym::Major> operator/(const Matrix4<2, Sym::Major> &a, const Set::Scalar &b);
+    friend AMREX_GPU_HOST_DEVICE Set::Matrix operator*(const Matrix4<2, Sym::Major> &a, const Set::Matrix &b);
+    friend AMREX_GPU_HOST_DEVICE Set::Vector operator*(const Matrix4<2, Sym::Major> &a, const Set::Matrix3 &b);
+    friend AMREX_GPU_HOST_DEVICE Set::Vector MulColMajor(const Matrix4<2, Sym::Major> &a, const Set::Matrix &b, const int col);
 };
 AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE 
 Matrix4<2, Sym::Major> operator+(const Matrix4<2, Sym::Major> &a, const Matrix4<2, Sym::Major> &b)
@@ -242,6 +252,7 @@ public:
     AMREX_GPU_HOST_DEVICE Matrix4(){};
     
     #if AMREX_SPACEDIM == 3
+    AMREX_GPU_HOST_DEVICE
     Matrix4(const Matrix4<3,Sym::Isotropic> &in)
     {
         // TODO: very inefficient, need to optimize
@@ -251,6 +262,7 @@ public:
         for (int l = 0; l < 3; l++)
             (*this)(i,j,k,l) = in(i,j,k,l);
     }
+    AMREX_GPU_HOST_DEVICE
     Matrix4(const Matrix4<3,Sym::Diagonal> &in)
     {
         // TODO: very inefficient, need to optimize
@@ -260,6 +272,7 @@ public:
         for (int l = 0; l < 3; l++)
             (*this)(i,j,k,l) = in(i,j,k,l);
     }
+    AMREX_GPU_HOST_DEVICE
     Matrix4(const Matrix4<3,Sym::MajorMinor> &in)
     {
         // TODO: very inefficient, need to optimize
@@ -271,6 +284,7 @@ public:
     }
     #endif
 
+    AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
     Scalar &operator()(const int i, const int j, const int k, const int l)
     {
@@ -323,10 +337,11 @@ public:
         else if (uid == 80)              return data[44]; // [2222]
         else
             Util::Abort(INFO, "Index out of range");
-        return Set::Garbage;
+        return Set::Garbage();
     }
     
 
+    AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
     const Scalar &operator()(const int i, const int j, const int k, const int l) const
     {
@@ -379,9 +394,10 @@ public:
         else if (uid == 80)              return data[44]; // [2222]
         else
             Util::Abort(INFO, "Index out of range");
-        return Set::Garbage;
+        return Set::Garbage();
     }
 
+    AMREX_GPU_HOST_DEVICE
     Set::Scalar Norm()
     {
         Set::Scalar retsq = 0;
@@ -437,6 +453,7 @@ public:
     AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE 
     void operator/=(const Set::Scalar &alpha)        { for (int i = 0; i < 45; i++) data[i] /= alpha; }
 
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<3, Sym::Major> Increment()
     {
         Matrix4<3, Sym::Major> ret;
@@ -453,18 +470,21 @@ public:
         ret.Randomize();
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<3, Sym::Major> Zero()
     {
         Matrix4<3, Sym::Major> ret;
         for (int i = 0; i < 45; i++) ret.data[i] = 0.0;
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     Set::Scalar norm()
     {
         Set::Scalar normsq = 0.0;
         for (int i = 0; i < 45; i++) normsq += data[i]*data[i];
         return std::sqrt(normsq);
     }
+    AMREX_GPU_HOST_DEVICE
     bool contains_nan() const
     {
         for (int i = 0; i < 45; i++)
@@ -472,12 +492,14 @@ public:
         return false;
     }
 
-    friend Matrix4<3, Sym::Major> operator-(const Matrix4<3, Sym::Major> &a, const Matrix4<3, Sym::Major> &b);
-    friend Matrix4<3, Sym::Major> operator+(const Matrix4<3, Sym::Major> &a, const Matrix4<3, Sym::Major> &b);
-    friend Set::Matrix operator*(const Matrix4<3, Sym::Major> &a, const Set::Matrix &b);
-    friend Matrix4<3, Sym::Major> operator*(const Matrix4<3, Sym::Major> &a, const Set::Scalar &b);
-    friend Matrix4<3, Sym::Major> operator*(const Set::Scalar &b,const Matrix4<3, Sym::Major> &a);
-    friend Matrix4<3, Sym::Major> operator/(const Matrix4<3, Sym::Major> &a, const Set::Scalar &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3, Sym::Major> operator-(const Matrix4<3, Sym::Major> &a, const Matrix4<3, Sym::Major> &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3, Sym::Major> operator+(const Matrix4<3, Sym::Major> &a, const Matrix4<3, Sym::Major> &b);
+    friend AMREX_GPU_HOST_DEVICE Set::Matrix operator*(const Matrix4<3, Sym::Major> &a, const Set::Matrix &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3, Sym::Major> operator*(const Matrix4<3, Sym::Major> &a, const Set::Scalar &b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3, Sym::Major> operator*(const Set::Scalar &b,const Matrix4<3, Sym::Major> &a);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3, Sym::Major> operator/(const Matrix4<3, Sym::Major> &a, const Set::Scalar &b);
+    friend AMREX_GPU_HOST_DEVICE Set::Vector operator*(const Matrix4<3, Sym::Major> &a, const Set::Matrix3 &b);
+    friend AMREX_GPU_HOST_DEVICE Set::Vector MulColMajor(const Matrix4<3, Sym::Major> &a, const Set::Matrix &b, const int col);
 };
 
 AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE 
@@ -531,20 +553,103 @@ Set::Matrix operator*(const Matrix4<3, Sym::Major> &a, const Set::Matrix &b)
     return ret;
 }
 
-AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE 
+// Hand-unrolled equivalent of the (i,J,k,L) accessor loop
+//     ret(i) += a(i,J,k,L) * b(k,L,J)   [loop order: J outer, k, L inner]
+// with the (i,J,k,L) -> data[] map taken directly from operator()(i,J,k,L)
+// above.  The accumulation order of each ret(i) is IDENTICAL to the original
+// loop (same terms, same left-to-right order), so this is bit-for-bit
+// equivalent to the previous implementation - not merely numerically close.
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE
 Set::Vector operator * (const Matrix4<AMREX_SPACEDIM,Sym::Major> &a, const Set::Matrix3 &b)
 {
-    // TODO: improve efficiency of this method
-    Set::Vector ret = Set::Vector::Zero();
-    for (int i = 0; i < AMREX_SPACEDIM; i++)
-    {
-        for (int J = 0; J < AMREX_SPACEDIM; J++)
-            for (int k = 0; k < AMREX_SPACEDIM; k++)
-                for (int L = 0; L < AMREX_SPACEDIM; L++)
-                    ret(i) += a(i,J,k,L) * b(k,L,J);
-    }    
+    Set::Vector ret;
+#if AMREX_SPACEDIM == 2
+    ret(0) = a.data[0]*b(0,0,0) + a.data[1]*b(0,1,0) + a.data[2]*b(1,0,0) + a.data[3]*b(1,1,0) + a.data[1]*b(0,0,1) + a.data[4]*b(0,1,1) + a.data[5]*b(1,0,1) + a.data[6]*b(1,1,1);
+    ret(1) = a.data[2]*b(0,0,0) + a.data[5]*b(0,1,0) + a.data[7]*b(1,0,0) + a.data[8]*b(1,1,0) + a.data[3]*b(0,0,1) + a.data[6]*b(0,1,1) + a.data[8]*b(1,0,1) + a.data[9]*b(1,1,1);
+#elif AMREX_SPACEDIM == 3
+    ret(0) = a.data[0]*b(0,0,0) + a.data[1]*b(0,1,0) + a.data[2]*b(0,2,0) + a.data[3]*b(1,0,0) + a.data[4]*b(1,1,0) + a.data[5]*b(1,2,0) + a.data[6]*b(2,0,0) + a.data[7]*b(2,1,0) + a.data[8]*b(2,2,0) + a.data[1]*b(0,0,1) + a.data[9]*b(0,1,1) + a.data[10]*b(0,2,1) + a.data[11]*b(1,0,1) + a.data[12]*b(1,1,1) + a.data[13]*b(1,2,1) + a.data[14]*b(2,0,1) + a.data[15]*b(2,1,1) + a.data[16]*b(2,2,1) + a.data[2]*b(0,0,2) + a.data[10]*b(0,1,2) + a.data[17]*b(0,2,2) + a.data[18]*b(1,0,2) + a.data[19]*b(1,1,2) + a.data[20]*b(1,2,2) + a.data[21]*b(2,0,2) + a.data[22]*b(2,1,2) + a.data[23]*b(2,2,2);
+    ret(1) = a.data[3]*b(0,0,0) + a.data[11]*b(0,1,0) + a.data[18]*b(0,2,0) + a.data[24]*b(1,0,0) + a.data[25]*b(1,1,0) + a.data[26]*b(1,2,0) + a.data[27]*b(2,0,0) + a.data[28]*b(2,1,0) + a.data[29]*b(2,2,0) + a.data[4]*b(0,0,1) + a.data[12]*b(0,1,1) + a.data[19]*b(0,2,1) + a.data[25]*b(1,0,1) + a.data[30]*b(1,1,1) + a.data[31]*b(1,2,1) + a.data[32]*b(2,0,1) + a.data[33]*b(2,1,1) + a.data[34]*b(2,2,1) + a.data[5]*b(0,0,2) + a.data[13]*b(0,1,2) + a.data[20]*b(0,2,2) + a.data[26]*b(1,0,2) + a.data[31]*b(1,1,2) + a.data[35]*b(1,2,2) + a.data[36]*b(2,0,2) + a.data[37]*b(2,1,2) + a.data[38]*b(2,2,2);
+    ret(2) = a.data[6]*b(0,0,0) + a.data[14]*b(0,1,0) + a.data[21]*b(0,2,0) + a.data[27]*b(1,0,0) + a.data[32]*b(1,1,0) + a.data[36]*b(1,2,0) + a.data[39]*b(2,0,0) + a.data[40]*b(2,1,0) + a.data[41]*b(2,2,0) + a.data[7]*b(0,0,1) + a.data[15]*b(0,1,1) + a.data[22]*b(0,2,1) + a.data[28]*b(1,0,1) + a.data[33]*b(1,1,1) + a.data[37]*b(1,2,1) + a.data[40]*b(2,0,1) + a.data[42]*b(2,1,1) + a.data[43]*b(2,2,1) + a.data[8]*b(0,0,2) + a.data[16]*b(0,1,2) + a.data[23]*b(0,2,2) + a.data[29]*b(1,0,2) + a.data[34]*b(1,1,2) + a.data[38]*b(1,2,2) + a.data[41]*b(2,0,2) + a.data[43]*b(2,1,2) + a.data[44]*b(2,2,2);
+#endif
     return ret;
 }
 
-} 
+// Column-restricted Matrix4 * Set::Matrix.  MulCol(a, b, c) computes ONLY
+// column c of (a * b), i.e. the Set::Vector whose entry i equals (a*b)(i,c).
+// For Sym::Major each returned entry uses the EXACT summation of the
+// corresponding row of operator*(Matrix4, Set::Matrix) above, so it is
+// bit-for-bit equal to operator*(a,b).col(c) - it just skips computing the
+// unused columns.  For every other symmetry class it defers to that class's
+// own operator* and extracts the column, preserving its accumulation order.
+//
+// The Major fast paths are separate helpers (MulColMajor) reached only through
+// the `if constexpr` in the MulCol template below.  Keeping them out of the
+// MulCol overload set is deliberate: a non-template MulCol(Matrix4<D,Major>)
+// overload would otherwise be a viable candidate for a Matrix4<D,OtherSym>
+// argument via the implicit Sym-converting constructor, which forces
+// instantiation of a host-only conversion in device code.
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE
+Set::Vector MulColMajor(const Matrix4<2, Sym::Major> &a, const Set::Matrix &b, const int col)
+{
+    Set::Vector ret;
+    switch (col)
+    {
+    case 0:
+        ret(0) = a.data[0]*b(0,0) + a.data[1]*b(0,1) + a.data[2]*b(1,0) + a.data[3]*b(1,1);
+        ret(1) = a.data[2]*b(0,0) + a.data[5]*b(0,1) + a.data[7]*b(1,0) + a.data[8]*b(1,1);
+        break;
+    case 1:
+        ret(0) = a.data[1]*b(0,0) + a.data[4]*b(0,1) + a.data[5]*b(1,0) + a.data[6]*b(1,1);
+        ret(1) = a.data[3]*b(0,0) + a.data[6]*b(0,1) + a.data[8]*b(1,0) + a.data[9]*b(1,1);
+        break;
+    default:
+        ret = (a * b).col(col);
+        break;
+    }
+    return ret;
+}
+
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE
+Set::Vector MulColMajor(const Matrix4<3, Sym::Major> &a, const Set::Matrix &b, const int col)
+{
+    Set::Vector ret;
+    switch (col)
+    {
+    case 0:
+        ret(0) = a.data[ 0]*b(0,0) + a.data[ 1]*b(0,1) + a.data[ 2]*b(0,2) + a.data[ 3]*b(1,0) + a.data[ 4]*b(1,1) + a.data[ 5]*b(1,2) + a.data[ 6]*b(2,0) + a.data[ 7]*b(2,1) + a.data[ 8]*b(2,2);
+        ret(1) = a.data[ 3]*b(0,0) + a.data[11]*b(0,1) + a.data[18]*b(0,2) + a.data[24]*b(1,0) + a.data[25]*b(1,1) + a.data[26]*b(1,2) + a.data[27]*b(2,0) + a.data[28]*b(2,1) + a.data[29]*b(2,2);
+        ret(2) = a.data[ 6]*b(0,0) + a.data[14]*b(0,1) + a.data[21]*b(0,2) + a.data[27]*b(1,0) + a.data[32]*b(1,1) + a.data[36]*b(1,2) + a.data[39]*b(2,0) + a.data[40]*b(2,1) + a.data[41]*b(2,2);
+        break;
+    case 1:
+        ret(0) = a.data[ 1]*b(0,0) + a.data[ 9]*b(0,1) + a.data[10]*b(0,2) + a.data[11]*b(1,0) + a.data[12]*b(1,1) + a.data[13]*b(1,2) + a.data[14]*b(2,0) + a.data[15]*b(2,1) + a.data[16]*b(2,2);
+        ret(1) = a.data[ 4]*b(0,0) + a.data[12]*b(0,1) + a.data[19]*b(0,2) + a.data[25]*b(1,0) + a.data[30]*b(1,1) + a.data[31]*b(1,2) + a.data[32]*b(2,0) + a.data[33]*b(2,1) + a.data[34]*b(2,2);
+        ret(2) = a.data[ 7]*b(0,0) + a.data[15]*b(0,1) + a.data[22]*b(0,2) + a.data[28]*b(1,0) + a.data[33]*b(1,1) + a.data[37]*b(1,2) + a.data[40]*b(2,0) + a.data[42]*b(2,1) + a.data[43]*b(2,2);
+        break;
+    case 2:
+        ret(0) = a.data[ 2]*b(0,0) + a.data[10]*b(0,1) + a.data[17]*b(0,2) + a.data[18]*b(1,0) + a.data[19]*b(1,1) + a.data[20]*b(1,2) + a.data[21]*b(2,0) + a.data[22]*b(2,1) + a.data[23]*b(2,2);
+        ret(1) = a.data[ 5]*b(0,0) + a.data[13]*b(0,1) + a.data[20]*b(0,2) + a.data[26]*b(1,0) + a.data[31]*b(1,1) + a.data[35]*b(1,2) + a.data[36]*b(2,0) + a.data[37]*b(2,1) + a.data[38]*b(2,2);
+        ret(2) = a.data[ 8]*b(0,0) + a.data[16]*b(0,1) + a.data[23]*b(0,2) + a.data[29]*b(1,0) + a.data[34]*b(1,1) + a.data[38]*b(1,2) + a.data[41]*b(2,0) + a.data[43]*b(2,1) + a.data[44]*b(2,2);
+        break;
+    default:
+        ret = (a * b).col(col);
+        break;
+    }
+    return ret;
+}
+
+// Public entry point: single overload template so a call MulCol(Matrix4<D,S>,..)
+// binds by exact type with no Sym-converting-constructor candidates.  The Major
+// fast path is selected at compile time; all other Sym classes use their own
+// operator*.
+template <int D, int S>
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE
+Set::Vector MulCol(const Matrix4<D,S> &a, const Set::Matrix &b, const int col)
+{
+    if constexpr (S == Sym::Major)
+        return MulColMajor(a, b, col);
+    else
+        return (a * b).col(col);
+}
+
+}
 #endif

--- a/src/Set/Matrix4_MajorMinor.H
+++ b/src/Set/Matrix4_MajorMinor.H
@@ -25,6 +25,7 @@ public:
     //    for (int i = 0; i < 6; i++) data[i] =  in.data[i];
     //}
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     const Scalar & operator () (const int i, const int j, const int k, const int l) const
     {
         int uid = i + 2*j + 4*k + 8*l;
@@ -35,9 +36,10 @@ public:
         else if (uid==14 || uid==13 || uid==11 || uid==7 ) return data[4]; // [0111] [1011] [1101] [1110]
         else if (uid==15 )                                 return data[5]; // [1111]
         else Util::Abort(INFO,"Index out of range");
-        return Set::Garbage;
+        return Set::Garbage();
     }
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     Scalar & operator () (const int i, const int j, const int k, const int l)
     {
         int uid = i + 2*j + 4*k + 8*l;
@@ -48,7 +50,7 @@ public:
         else if (uid==14 || uid==13 || uid==11 || uid==7 ) return data[4]; // [0111] [1011] [1101] [1110]
         else if (uid==15 )                                 return data[5]; // [1111]
         else Util::Abort(INFO,"Index out of range");
-        return Set::Garbage; 
+        return Set::Garbage();
     }
     void Print (std::ostream& os)
     {
@@ -116,12 +118,14 @@ public:
         ret.Randomize();
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<2,Sym::MajorMinor> Zero()
     {
         Matrix4<2,Sym::MajorMinor> ret;
         for (int i = 0 ; i < 6; i++) ret.data[i] = 0.0;
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<2,Sym::MajorMinor> Cubic(Set::Scalar C11, Set::Scalar C12, Set::Scalar C44, 
                                             Eigen::Matrix3d R = Eigen::Matrix3d::Identity())
     {
@@ -152,6 +156,7 @@ public:
                     }                
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<2,Sym::MajorMinor> Cubic(Set::Scalar C11, Set::Scalar C12, Set::Scalar C44, 
                                             Set::Scalar phi1, Set::Scalar Phi, Set::Scalar phi2)
     {
@@ -161,6 +166,8 @@ public:
             Eigen::AngleAxisd(phi1, Eigen::Vector3d::UnitX());
         return Matrix4<2,Sym::MajorMinor>::Cubic(C11,C12,C44,R);
     }
+
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<2,Sym::MajorMinor> Cubic(Set::Scalar C11, Set::Scalar C12, Set::Scalar C44, 
                                             Set::Quaternion q)
     {
@@ -233,14 +240,14 @@ public:
     }
 
 
-    friend Eigen::Matrix<Set::Scalar,2,2> operator * (Matrix4<2,Sym::MajorMinor> a, Eigen::Matrix<Set::Scalar,2,2> b);
-    friend bool operator == (Matrix4<2,Sym::MajorMinor> a, Matrix4<2,Sym::MajorMinor> b);
-    friend Matrix4<2,Sym::MajorMinor> operator + (Matrix4<2,Sym::MajorMinor> a, Matrix4<2,Sym::MajorMinor> b);
-    friend Matrix4<2,Sym::MajorMinor> operator - (Matrix4<2,Sym::MajorMinor> a, Matrix4<2,Sym::MajorMinor> b);
-    friend Matrix4<2,Sym::MajorMinor> operator * (Matrix4<2,Sym::MajorMinor> a, Set::Scalar b);
-    friend Matrix4<2,Sym::MajorMinor> operator * (Set::Scalar b, Matrix4<2,Sym::MajorMinor> a);
-    friend Matrix4<2,Sym::MajorMinor> operator / (Matrix4<2,Sym::MajorMinor> a, Set::Scalar b);
-    friend Set::Vector operator * (Matrix4<2,Sym::MajorMinor> a, Set::Matrix3 b);
+    friend AMREX_GPU_HOST_DEVICE Eigen::Matrix<Set::Scalar,2,2> operator * (Matrix4<2,Sym::MajorMinor> a, Eigen::Matrix<Set::Scalar,2,2> b);
+    friend AMREX_GPU_HOST_DEVICE bool operator == (Matrix4<2,Sym::MajorMinor> a, Matrix4<2,Sym::MajorMinor> b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2,Sym::MajorMinor> operator + (Matrix4<2,Sym::MajorMinor> a, Matrix4<2,Sym::MajorMinor> b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2,Sym::MajorMinor> operator - (Matrix4<2,Sym::MajorMinor> a, Matrix4<2,Sym::MajorMinor> b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2,Sym::MajorMinor> operator * (Matrix4<2,Sym::MajorMinor> a, Set::Scalar b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2,Sym::MajorMinor> operator * (Set::Scalar b, Matrix4<2,Sym::MajorMinor> a);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<2,Sym::MajorMinor> operator / (Matrix4<2,Sym::MajorMinor> a, Set::Scalar b);
+    friend AMREX_GPU_HOST_DEVICE Set::Vector operator * (Matrix4<2,Sym::MajorMinor> a, Set::Matrix3 b);
 };
 AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE 
 bool operator == (Matrix4<2,Sym::MajorMinor> a, Matrix4<2,Sym::MajorMinor> b)
@@ -325,6 +332,7 @@ class Matrix4<3,Sym::MajorMinor>
 public:
     AMREX_GPU_HOST_DEVICE Matrix4() {};
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     const Scalar & operator () (const int i, const int j, const int k, const int l) const
     {
         int uid = i + 3*j + 9*k + 27*l;
@@ -371,9 +379,10 @@ public:
         // [2222]
         else if (uid==80 ) return data[20];
         else Util::Abort(INFO,"Index out of range");
-        return Set::Garbage; 
+        return Set::Garbage();
     }
     AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE
     Scalar & operator () (const int i, const int j, const int k, const int l)
     {
         int uid = i + 3*j + 9*k + 27*l;
@@ -420,7 +429,7 @@ public:
         // [2222]
         else if (uid==80 ) return data[20];
         else Util::Abort(INFO,"Index out of range");
-        return Set::Garbage; 
+        return Set::Garbage();
     }
     void Print (std::ostream& os)
     {
@@ -509,12 +518,15 @@ public:
         ret.Randomize();
         return ret;
     }
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<3,Sym::MajorMinor> Zero()
     {
         Matrix4<3,Sym::MajorMinor> ret;
         for (int i = 0 ; i < 21; i++) ret.data[i] = 0.0;
         return ret;
     }
+
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<3,Sym::MajorMinor> Cubic(Set::Scalar C11, Set::Scalar C12, Set::Scalar C44, 
                                             Eigen::Matrix3d R = Eigen::Matrix3d::Identity())
     {
@@ -545,6 +557,8 @@ public:
                     }                
         return ret;
     }
+
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<3,Sym::MajorMinor> Cubic(Set::Scalar C11, Set::Scalar C12, Set::Scalar C44, 
                                             Set::Scalar phi1, Set::Scalar Phi, Set::Scalar phi2)
     {
@@ -554,6 +568,8 @@ public:
             Eigen::AngleAxisd(phi1, Eigen::Vector3d::UnitX());
         return Matrix4<3,Sym::MajorMinor>::Cubic(C11,C12,C44,R);
     }
+
+    AMREX_GPU_HOST_DEVICE
     static Matrix4<3,Sym::MajorMinor> Cubic(Set::Scalar C11, Set::Scalar C12, Set::Scalar C44, 
                                             Set::Quaternion q)
     {
@@ -624,14 +640,14 @@ public:
         return Transverse(C11,C12,C13,C33,C44,R);
     }
 
-    friend bool operator == (Matrix4<3,Sym::MajorMinor> a, Matrix4<3,Sym::MajorMinor> b);
-    friend Matrix4<3,Sym::MajorMinor> operator + (Matrix4<3,Sym::MajorMinor> a, Matrix4<3,Sym::MajorMinor> b);
-    friend Matrix4<3,Sym::MajorMinor> operator - (Matrix4<3,Sym::MajorMinor> a, Matrix4<3,Sym::MajorMinor> b);
-    friend Matrix4<3,Sym::MajorMinor> operator * (Matrix4<3,Sym::MajorMinor> a, Set::Scalar b);
-    friend Matrix4<3,Sym::MajorMinor> operator * (Set::Scalar b, Matrix4<3,Sym::MajorMinor> a);
-    friend Matrix4<3,Sym::MajorMinor> operator / (Matrix4<3,Sym::MajorMinor> a, Set::Scalar b);
-    friend Set::Vector operator * (Matrix4<3,Sym::MajorMinor> a, Set::Matrix3 b);
-    friend Eigen::Matrix<amrex::Real,3,3> operator * (Matrix4<3,Sym::MajorMinor> a, Eigen::Matrix<amrex::Real,3,3> b);
+    friend AMREX_GPU_HOST_DEVICE bool operator == (Matrix4<3,Sym::MajorMinor> a, Matrix4<3,Sym::MajorMinor> b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3,Sym::MajorMinor> operator + (Matrix4<3,Sym::MajorMinor> a, Matrix4<3,Sym::MajorMinor> b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3,Sym::MajorMinor> operator - (Matrix4<3,Sym::MajorMinor> a, Matrix4<3,Sym::MajorMinor> b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3,Sym::MajorMinor> operator * (Matrix4<3,Sym::MajorMinor> a, Set::Scalar b);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3,Sym::MajorMinor> operator * (Set::Scalar b, Matrix4<3,Sym::MajorMinor> a);
+    friend AMREX_GPU_HOST_DEVICE Matrix4<3,Sym::MajorMinor> operator / (Matrix4<3,Sym::MajorMinor> a, Set::Scalar b);
+    friend AMREX_GPU_HOST_DEVICE Set::Vector operator * (Matrix4<3,Sym::MajorMinor> a, Set::Matrix3 b);
+    friend AMREX_GPU_HOST_DEVICE Eigen::Matrix<amrex::Real,3,3> operator * (Matrix4<3,Sym::MajorMinor> a, Eigen::Matrix<amrex::Real,3,3> b);
 };
 AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE 
 bool operator == (Matrix4<3,Sym::MajorMinor> a, Matrix4<3,Sym::MajorMinor> b)

--- a/src/Set/Set.H
+++ b/src/Set/Set.H
@@ -206,6 +206,26 @@ void Field<Set::Matrix>::Copy(int a_lev, amrex::MultiFab &a_dst, int a_dstcomp, 
     }    
 }
 template<>
+ALAMO_SINGLE_DEFINITION
+void Field<Set::Matrix>::CopyFrom(int a_lev, amrex::MultiFab &a_src, int a_srccomp, int a_nghost) const
+{
+    for (amrex::MFIter mfi(a_src, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& bx = mfi.growntilebox(amrex::IntVect(a_nghost));
+        if (bx.ok())
+        {
+            amrex::Array4<Set::Matrix> const & dst = ((*this)[a_lev])->array(mfi);
+            amrex::Array4<const Set::Scalar> const & src = a_src.array(mfi);
+            for (int n = 0; n < AMREX_SPACEDIM*AMREX_SPACEDIM; n++)
+            {
+                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    dst(i,j,k)(n/AMREX_SPACEDIM,n%AMREX_SPACEDIM) = src(i,j,k,a_srccomp + n);
+                });
+            }
+        }
+    }
+}
+template<>
 ALAMO_SINGLE_DEFINITION int Field<Set::Matrix>::NComp() const {return AMREX_SPACEDIM*AMREX_SPACEDIM;} 
 template<> ALAMO_SINGLE_DEFINITION std::string Field<Set::Matrix>::Name(int i) const
 {

--- a/src/Solver/Nonlocal/Newton.H
+++ b/src/Solver/Nonlocal/Newton.H
@@ -1,16 +1,341 @@
 #ifndef SOLVER_NONLOCAL_NEWTON
 #define SOLVER_NONLOCAL_NEWTON
 
+#include <cmath>
+#include <sstream>
+#include <string>
+#include <AMReX_Math.H>
+#include <AMReX_ParallelContext.H>
+#include <AMReX_ParallelReduce.H>
+#include <AMReX_Reduce.H>
 #include "Set/Set.H"
 #include "Operator/Elastic.H"
 #include "Solver/Nonlocal/Linear.H"
 #include "IO/ParmParse.H"
 #include "Numeric/Stencil.H"
 
+#ifdef ALAMO_GPU
+#define ALAMO_NEWTON_FOR amrex::ParallelFor
+#define ALAMO_NEWTON_DEVICE AMREX_GPU_DEVICE
+#define ALAMO_NEWTON_BC_EVAL(elastic, bc_type, u, gradu, sigma, i, j, k, bx) \
+    ::BC::Operator::Elastic::Elastic::eval(bc_type, u, gradu, sigma, i, j, k, bx)
+#else
+#define ALAMO_NEWTON_FOR amrex::LoopConcurrentOnCpu
+#define ALAMO_NEWTON_DEVICE
+#define ALAMO_NEWTON_BC_EVAL(elastic, bc_type, u, gradu, sigma, i, j, k, bx) \
+    (elastic)->GetBC()(u, gradu, sigma, i, j, k, bx)
+#endif
+
 namespace Solver
 {
 namespace Nonlocal
 {
+namespace Detail
+{
+inline bool
+AcceptLineSearchResidual(Set::Scalar initial, Set::Scalar trial,
+                         Set::Scalar relative_tolerance = 1.0e-4)
+{
+    if (!std::isfinite(initial) || !std::isfinite(trial) ||
+        !std::isfinite(relative_tolerance) || initial < 0.0 || trial < 0.0 ||
+        relative_tolerance < 0.0)
+        return false;
+    if (initial == 0.0) return trial == 0.0;
+    return trial / initial <= 1.0 + relative_tolerance;
+}
+
+enum class NRTermination
+{
+    Continue,
+    Converged,
+    FixedIterationsComplete,
+    InvalidMetric,
+    Exhausted
+};
+
+inline NRTermination
+DecideNRTermination(Set::Scalar metric, Set::Scalar tolerance,
+                    bool final_iteration)
+{
+    if (!std::isfinite(metric) || !std::isfinite(tolerance) || metric < 0.0 ||
+        tolerance < 0.0)
+        return NRTermination::InvalidMetric;
+    if (tolerance == 0.0)
+        return final_iteration
+            ? NRTermination::FixedIterationsComplete
+            : NRTermination::Continue;
+    if (metric < tolerance) return NRTermination::Converged;
+    return final_iteration ? NRTermination::Exhausted : NRTermination::Continue;
+}
+
+inline Set::Scalar
+AcceptedUpdateMetric(Set::Scalar full_step_metric, Set::Scalar alpha)
+{
+    return alpha * full_step_metric;
+}
+
+template <typename T>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+T
+FaceModel(const amrex::Array4<const T>& model,
+          const int i, const int j, const int k, const int face)
+{
+    const int ip = i + (face == 0);
+    const int jp = j + (face == 1);
+    const int kp = k + (face == 2);
+    return 0.5 * (model(i, j, k) + model(ip, jp, kp));
+}
+
+template <typename T, typename U>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+FaceKinematicVariable(const amrex::Array4<const T>& model,
+                      const U& u,
+                      const int i, const int j, const int k, const int face,
+                      const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    const T face_model = FaceModel(model, i, j, k, face);
+    Set::Matrix gradu = Numeric::FaceGradient(u, i, j, k, face, dx);
+    if (face_model.kinvar == Model::Solid::KinematicVariable::gradu)
+        return gradu;
+    if (face_model.kinvar == Model::Solid::KinematicVariable::epsilon)
+        return 0.5 * (gradu + gradu.transpose());
+    if (face_model.kinvar == Model::Solid::KinematicVariable::F)
+        return gradu + Set::Matrix::Identity();
+    return Set::Matrix::Zero();
+}
+
+template <typename T, typename U>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+FaceStress(const amrex::Array4<const T>& model,
+           const U& u,
+           const int i, const int j, const int k, const int face,
+           const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    const T face_model = FaceModel(model, i, j, k, face);
+    return face_model.DW(
+        FaceKinematicVariable(model, u, i, j, k, face, dx));
+}
+
+/// Reconstruct a nodal stress tensor from the conservative face tractions.
+/// Each tensor column is the average of the matching low/high face-traction
+/// columns, so its divergence uses the same directional fluxes as the solve.
+template <typename T, typename U>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+NodalStressFromFaces(const amrex::Array4<const T>& model,
+                     const U& u,
+                     const int i, const int j, const int k,
+                     const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    Set::Matrix ret = Set::Matrix::Zero();
+    for (int face = 0; face < AMREX_SPACEDIM; ++face)
+    {
+        const int im = i - (face == 0);
+        const int jm = j - (face == 1);
+        const int km = k - (face == 2);
+        const Set::Matrix hi = FaceStress(model, u, i, j, k, face, dx);
+        const Set::Matrix lo = FaceStress(model, u, im, jm, km, face, dx);
+        ret.col(face) = 0.5 * (lo.col(face) + hi.col(face));
+    }
+    return ret;
+}
+
+/// Even extension of a material model through explicitly selected symmetry
+/// planes. Material parameters do not change sign under reflection.
+template <typename T>
+struct SymmetryModelExtension
+{
+    amrex::Array4<const T> model;
+    amrex::Dim3 lo, hi;
+    amrex::GpuArray<int, AMREX_SPACEDIM> symmetry_lo;
+    amrex::GpuArray<int, AMREX_SPACEDIM> symmetry_hi;
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    T operator()(int i, int j, int k) const
+    {
+        AMREX_D_TERM(
+            if (symmetry_lo[0] && i < lo.x) i = 2 * lo.x - i;
+            if (symmetry_hi[0] && i > hi.x) i = 2 * hi.x - i;,
+            if (symmetry_lo[1] && j < lo.y) j = 2 * lo.y - j;
+            if (symmetry_hi[1] && j > hi.y) j = 2 * hi.y - j;,
+            if (symmetry_lo[2] && k < lo.z) k = 2 * lo.z - k;
+            if (symmetry_hi[2] && k > hi.z) k = 2 * hi.z - k;);
+        return model(i, j, k);
+    }
+};
+
+/// Symmetry extension of displacement: the component normal to each reflected
+/// plane is odd, while tangential components are even.
+struct SymmetryDisplacementExtension
+{
+    amrex::Array4<const Set::Vector> displacement;
+    amrex::Dim3 lo, hi;
+    amrex::GpuArray<int, AMREX_SPACEDIM> symmetry_lo;
+    amrex::GpuArray<int, AMREX_SPACEDIM> symmetry_hi;
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    Set::Vector operator()(int i, int j, int k) const
+    {
+        amrex::GpuArray<int, AMREX_SPACEDIM> reflected{};
+        AMREX_D_TERM(
+            if (symmetry_lo[0] && i < lo.x) { i = 2 * lo.x - i; reflected[0] = 1; }
+            if (symmetry_hi[0] && i > hi.x) { i = 2 * hi.x - i; reflected[0] = 1; },
+            if (symmetry_lo[1] && j < lo.y) { j = 2 * lo.y - j; reflected[1] = 1; }
+            if (symmetry_hi[1] && j > hi.y) { j = 2 * hi.y - j; reflected[1] = 1; },
+            if (symmetry_lo[2] && k < lo.z) { k = 2 * lo.z - k; reflected[2] = 1; }
+            if (symmetry_hi[2] && k > hi.z) { k = 2 * hi.z - k; reflected[2] = 1; });
+        Set::Vector ret = displacement(i, j, k);
+        for (int d = 0; d < AMREX_SPACEDIM; ++d)
+            if (reflected[d]) ret(d) = -ret(d);
+        return ret;
+    }
+};
+
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+SymmetryFaceGradient(const SymmetryDisplacementExtension& displacement,
+                     const int i, const int j, const int k, const int face,
+                     const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    Set::Matrix ret = Set::Matrix::Zero();
+    const int ip = i + (face == 0);
+    const int jp = j + (face == 1);
+    const int kp = k + (face == 2);
+    ret.col(face) =
+        (displacement(ip, jp, kp) - displacement(i, j, k)) / dx[face];
+#if AMREX_SPACEDIM > 1
+    if (face != 0)
+        ret.col(0) = (displacement(i + 1, j, k) - displacement(i - 1, j, k)
+                    + displacement(ip + 1, jp, kp) - displacement(ip - 1, jp, kp))
+                   / (4.0 * dx[0]);
+    if (face != 1)
+        ret.col(1) = (displacement(i, j + 1, k) - displacement(i, j - 1, k)
+                    + displacement(ip, jp + 1, kp) - displacement(ip, jp - 1, kp))
+                   / (4.0 * dx[1]);
+#endif
+#if AMREX_SPACEDIM > 2
+    if (face != 2)
+        ret.col(2) = (displacement(i, j, k + 1) - displacement(i, j, k - 1)
+                    + displacement(ip, jp, kp + 1) - displacement(ip, jp, kp - 1))
+                   / (4.0 * dx[2]);
+#endif
+    return ret;
+}
+
+template <typename T>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+SymmetryFaceStress(const SymmetryModelExtension<T>& model,
+                   const SymmetryDisplacementExtension& displacement,
+                   const int i, const int j, const int k, const int face,
+                   const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    const int ip = i + (face == 0);
+    const int jp = j + (face == 1);
+    const int kp = k + (face == 2);
+    const T face_model = 0.5 * (model(i, j, k) + model(ip, jp, kp));
+    const Set::Matrix gradu =
+        SymmetryFaceGradient(displacement, i, j, k, face, dx);
+    if (face_model.kinvar == Model::Solid::KinematicVariable::gradu)
+        return face_model.DW(gradu);
+    if (face_model.kinvar == Model::Solid::KinematicVariable::epsilon)
+        return face_model.DW(0.5 * (gradu + gradu.transpose()));
+    if (face_model.kinvar == Model::Solid::KinematicVariable::F)
+        return face_model.DW(gradu + Set::Matrix::Identity());
+    return Set::Matrix::Zero();
+}
+
+/// Reconstruct stress on a physical symmetry plane by reflecting model and
+/// displacement, then applying the identical centered face reconstruction
+/// used in the domain interior.
+template <typename T>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix
+NodalStressFromSymmetryFaces(
+    const amrex::Array4<const T>& model,
+    const amrex::Array4<const Set::Vector>& displacement,
+    const int i, const int j, const int k,
+    const Set::Scalar dx[AMREX_SPACEDIM],
+    const amrex::Dim3 lo, const amrex::Dim3 hi,
+    const amrex::GpuArray<int, AMREX_SPACEDIM>& symmetry_lo,
+    const amrex::GpuArray<int, AMREX_SPACEDIM>& symmetry_hi)
+{
+    const SymmetryModelExtension<T> extended_model{
+        model, lo, hi, symmetry_lo, symmetry_hi};
+    const SymmetryDisplacementExtension extended_displacement{
+        displacement, lo, hi, symmetry_lo, symmetry_hi};
+    Set::Matrix ret = Set::Matrix::Zero();
+    for (int face = 0; face < AMREX_SPACEDIM; ++face)
+    {
+        const int im = i - (face == 0);
+        const int jm = j - (face == 1);
+        const int km = k - (face == 2);
+        const Set::Matrix hi_stress = SymmetryFaceStress(
+            extended_model, extended_displacement, i, j, k, face, dx);
+        const Set::Matrix lo_stress = SymmetryFaceStress(
+            extended_model, extended_displacement, im, jm, km, face, dx);
+        ret.col(face) = 0.5 * (lo_stress.col(face) + hi_stress.col(face));
+    }
+    return ret;
+}
+
+template <typename T, typename U>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Matrix4<AMREX_SPACEDIM, T::sym>
+FaceTangent(const amrex::Array4<const T>& model,
+            const U& u,
+            const int i, const int j, const int k, const int face,
+            const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    const T face_model = FaceModel(model, i, j, k, face);
+    return face_model.DDW(
+        FaceKinematicVariable(model, u, i, j, k, face, dx));
+}
+
+template <typename T, typename U>
+[[nodiscard]]
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+Set::Vector
+FaceStressDivergence(const amrex::Array4<const T>& model,
+                     const U& u,
+                     const int i, const int j, const int k,
+                     const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    Set::Vector ret = Set::Vector::Zero();
+    for (int face = 0; face < AMREX_SPACEDIM; ++face)
+    {
+        const int im = i - (face == 0);
+        const int jm = j - (face == 1);
+        const int km = k - (face == 2);
+        const Set::Matrix hi = FaceStress(model, u, i, j, k, face, dx);
+        const Set::Matrix lo = FaceStress(model, u, im, jm, km, face, dx);
+        ret += (hi.col(face) - lo.col(face)) / dx[face];
+    }
+    return ret;
+}
+} // namespace Detail
+
 template <typename T>
 class Newton: public Linear
 {
@@ -31,13 +356,12 @@ public:
     {
         Linear::Define(a_op);
         m_elastic = dynamic_cast<Operator::Elastic<T::sym> *>(linop);
-        //m_bc = &m_elastic->GetBC();
+        m_elastic->SetConservativeFaceFlux(m_conservative_face_flux);
     }
     void Clear()
     {
         Linear::Clear();
         m_elastic = nullptr;
-        //m_bc = nullptr;
     }
 
 
@@ -48,7 +372,17 @@ public:
         m_psi = &a_psi;
     }
 
-private:
+    void setConservativeFaceFlux(bool a_enabled)
+    {
+        m_conservative_face_flux = a_enabled;
+        if (m_elastic) m_elastic->SetConservativeFaceFlux(a_enabled);
+    }
+
+    [[nodiscard]] bool usesConservativeFaceFlux() const
+    {
+        return m_conservative_face_flux && m_psi == nullptr;
+    }
+
     void prepareForSolve(const Set::Field<Set::Scalar>& a_u_mf,
         const Set::Field<Set::Scalar>& a_b_mf,
         Set::Field<Set::Scalar>& a_rhs_mf,
@@ -60,8 +394,12 @@ private:
         {
             amrex::Box domain(linop->Geom(lev).growPeriodicDomain(1));
             domain.convert(amrex::IntVect::TheNodeVector());
-            const Set::Scalar* dx = linop->Geom(lev).CellSize();
+            // Device-safe cell size (see note on the Set::Vector overload below).
             Set::Vector DX(linop->Geom(lev).CellSize());
+#ifdef ALAMO_GPU
+            Util::DeviceErrorFlag prepare_error;
+            int* prepare_error_flag = prepare_error.dataPtr();
+#endif
             for (MFIter mfi(*a_model_mf[lev], false); mfi.isValid(); ++mfi)
             {
                 amrex::Box bx = mfi.grownnodaltilebox();
@@ -73,10 +411,10 @@ private:
                 amrex::Array4<Set::Matrix4<AMREX_SPACEDIM, T::sym>>  const& ddw = a_ddw_mf[lev]->array(mfi);
 
                 // Set model internal dw and ddw.
-                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                ALAMO_NEWTON_FOR(bx, [=] ALAMO_NEWTON_DEVICE (int i, int j, int k) {
                     auto sten = Numeric::GetStencil(i, j, k, bx);
 
-                    Set::Matrix gradu = Numeric::Gradient(u, i, j, k, dx, sten);
+                    Set::Matrix gradu = Numeric::Gradient(u, i, j, k, DX.data(), sten);
 
                     if (model(i, j, k).kinvar == Model::Solid::KinematicVariable::gradu)
                     {
@@ -95,8 +433,18 @@ private:
                         dw(i, j, k) = model(i, j, k).DW(F);
                         ddw(i, j, k) = model(i, j, k).DDW(F);
                     }
+#ifdef ALAMO_GPU
+                    else
+                    {
+                        Util::SetDeviceError(prepare_error_flag);
+                    }
+#endif
                 });
             }
+#ifdef ALAMO_GPU
+            Util::AbortIfDeviceError(prepare_error, INFO,
+                "Solver::Nonlocal::Newton::prepareForSolve() detected an invalid scalar model state on device");
+#endif
 
             Util::RealFillBoundary(*a_dw_mf[lev], m_elastic->Geom(lev));
             Util::RealFillBoundary(*a_ddw_mf[lev], m_elastic->Geom(lev));
@@ -108,7 +456,8 @@ private:
         {
             amrex::Box domain(linop->Geom(lev).growPeriodicDomain(1));
             domain.convert(amrex::IntVect::TheNodeVector());
-            const Set::Scalar* dx = linop->Geom(lev).CellSize();
+            // Device-safe cell size (see note on the Set::Vector overload below).
+            Set::Vector DX(linop->Geom(lev).CellSize());
             const amrex::Dim3 lo = amrex::lbound(domain), hi = amrex::ubound(domain);
             for (MFIter mfi(*a_model_mf[lev], false); mfi.isValid(); ++mfi)
             {
@@ -118,20 +467,23 @@ private:
                 amrex::Array4<const Set::Scalar>  const& b = a_b_mf[lev]->array(mfi);
                 amrex::Array4<const Set::Matrix>  const& dw = a_dw_mf[lev]->array(mfi);
                 amrex::Array4<Set::Scalar>        const& rhs = a_rhs_mf[lev]->array(mfi);
-                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+#ifdef ALAMO_GPU
+                auto m_bc_type = m_elastic->GetBC().GetBcTypeArray();
+#endif
+                ALAMO_NEWTON_FOR(bx, [=] ALAMO_NEWTON_DEVICE (int i, int j, int k)
                 {
                     auto sten = Numeric::GetStencil(i, j, k, bx);
                     // Do this if on the domain boundary
                     if (AMREX_D_TERM(i == lo.x || i == hi.x, || j == lo.y || j == hi.y, || k == lo.z || k == hi.z))
                     {
-                        Set::Matrix gradu = Numeric::Gradient(u, i, j, k, dx, sten);
+                        Set::Matrix gradu = Numeric::Gradient(u, i, j, k, DX.data(), sten);
                         Set::Vector U(AMREX_D_DECL(u(i, j, k, 0), u(i, j, k, 1), u(i, j, k, 2)));
-                        Set::Vector ret = m_elastic->GetBC()(U, gradu, dw(i, j, k), i, j, k, bx);
+                        Set::Vector ret = ALAMO_NEWTON_BC_EVAL(m_elastic, m_bc_type, U, gradu, dw(i, j, k), i, j, k, bx);
                         for (int d = 0; d < AMREX_SPACEDIM; d++) rhs(i, j, k, d) = b(i, j, k, d) - ret(d);
                     }
                     else
                     {
-                        Set::Vector divdw = Numeric::Divergence(dw, i, j, k, dx);
+                        Set::Vector divdw = Numeric::Divergence(dw, i, j, k, DX.data());
                         for (int p = 0; p < AMREX_SPACEDIM; p++) rhs(i, j, k, p) = b(i, j, k, p) - divdw(p);
                     }
                 });
@@ -148,16 +500,24 @@ private:
         Set::Field<Set::Matrix4<AMREX_SPACEDIM, T::sym>>& a_ddw_mf,
         Set::Field<T>& a_model_mf)
     {
+        const bool conservative_solve = m_conservative_face_flux && m_psi == nullptr;
         for (int lev = 0; lev <= a_b_mf.finest_level; ++lev)
         {
             amrex::Box domain(linop->Geom(lev).growPeriodicDomain(2));
             domain.convert(amrex::IntVect::TheNodeVector());
-            const Set::Scalar* dx = linop->Geom(lev).CellSize();
-            Set::Vector DX(linop->Geom(lev).CellSize());
+            amrex::Box row_domain(linop->Geom(lev).growPeriodicDomain(1));
+            row_domain.convert(amrex::IntVect::TheNodeVector());
+            Set::Vector DX(linop->Geom(lev).CellSize()); // device-safe: captured by value, DX.data() valid on device
+            const amrex::Dim3 hi = amrex::ubound(domain);
+#ifdef ALAMO_GPU
+            Util::DeviceErrorFlag prepare_error;
+            int* prepare_error_flag = prepare_error.dataPtr();
+#endif
             for (MFIter mfi(*a_model_mf[lev], false); mfi.isValid(); ++mfi)
             {
-                amrex::Box bx = mfi.grownnodaltilebox();
-                bx = bx & domain;
+                amrex::Box bx = conservative_solve
+                    ? (mfi.grownnodaltilebox(-1, 1) & row_domain)
+                    : (mfi.grownnodaltilebox() & domain);
 
                 amrex::Array4<const T>           const& model = a_model_mf[lev]->array(mfi);
                 amrex::Array4<const Set::Vector> const& u = a_u_mf[lev]->array(mfi);
@@ -165,11 +525,11 @@ private:
                 amrex::Array4<Set::Matrix4<AMREX_SPACEDIM, T::sym>>  const& ddw = a_ddw_mf[lev]->array(mfi);
 
                 // Set model internal dw and ddw.
-                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                amrex::ParallelFor (bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     auto sten = Numeric::GetStencil(i, j, k, bx);
 
-                    Set::Matrix gradu = Numeric::Gradient(u, i, j, k, dx, sten);
+                    Set::Matrix gradu = Numeric::Gradient(u, i, j, k, DX.data(), sten);
                     Set::Matrix kinvar;
                     if (model(i, j, k).kinvar == Model::Solid::KinematicVariable::gradu)
                         kinvar = gradu; // gradu
@@ -177,12 +537,44 @@ private:
                         kinvar = 0.5 * (gradu + gradu.transpose()); // epsilon
                     else if (model(i, j, k).kinvar == Model::Solid::KinematicVariable::F)
                         kinvar = gradu + Set::Matrix::Identity(); // F
+#ifdef ALAMO_GPU
+                    else
+                    {
+                        kinvar = Set::Matrix::Zero();
+                        Util::SetDeviceError(prepare_error_flag);
+                    }
+#endif
 
                     dw(i, j, k) = model(i, j, k).DW(kinvar);
-                    ddw(i, j, k) = model(i, j, k).DDW(kinvar);
+                    ddw(i, j, k, 0) = model(i, j, k).DDW(kinvar);
+
+                    if (!conservative_solve)
+                    {
+                        // Extra components unused by legacy masked operator; init deterministically without reading past support ghost.
+                        for (int face = 0; face < AMREX_SPACEDIM; ++face)
+                            ddw(i, j, k, face + 1) = ddw(i, j, k, 0);
+                    }
+                    else
+                    {
+                        for (int face = 0; face < AMREX_SPACEDIM; ++face)
+                        {
+                            const int ip = i + (face == 0);
+                            const int jp = j + (face == 1);
+                            [[maybe_unused]] const int kp = k + (face == 2);
+                            if (AMREX_D_TERM(ip <= hi.x, && jp <= hi.y, && kp <= hi.z))
+                                ddw(i, j, k, face + 1) = Detail::FaceTangent(
+                                    model, u, i, j, k, face, DX.data());
+                            else
+                                ddw(i, j, k, face + 1) = ddw(i, j, k, 0);
+                        }
+                    }
 
                 });
             }
+#ifdef ALAMO_GPU
+            Util::AbortIfDeviceError(prepare_error, INFO,
+                "Solver::Nonlocal::Newton::prepareForSolve() detected an invalid vector model state on device");
+#endif
 
             a_dw_mf[lev]->setMultiGhost(true);
             a_dw_mf[lev]->FillBoundaryAndSync(m_elastic->Geom(lev).periodicity());
@@ -200,65 +592,73 @@ private:
         {
             amrex::Box domain(linop->Geom(lev).growPeriodicDomain(2));
             domain.convert(amrex::IntVect::TheNodeVector());
-            const Set::Scalar* dx = linop->Geom(lev).CellSize();
+            amrex::Box row_domain(linop->Geom(lev).growPeriodicDomain(1));
+            row_domain.convert(amrex::IntVect::TheNodeVector());
+            Set::Vector DX(linop->Geom(lev).CellSize()); // device-safe cell size
             const amrex::Dim3 lo = amrex::lbound(domain), hi = amrex::ubound(domain);
             for (MFIter mfi(*a_model_mf[lev], false); mfi.isValid(); ++mfi)
             {
-                amrex::Box bx = mfi.grownnodaltilebox() & domain;
+                amrex::Box bx = conservative_solve
+                    ? (mfi.grownnodaltilebox(-1, 1) & row_domain)
+                    : (mfi.grownnodaltilebox() & domain);
+                amrex::Array4<const T>            const& model = a_model_mf[lev]->array(mfi);
                 amrex::Array4<const Set::Vector>  const& u = a_u_mf[lev]->array(mfi);
                 amrex::Array4<const Set::Vector>  const& b = a_b_mf[lev]->array(mfi);
                 amrex::Array4<const Set::Matrix>  const& dw = a_dw_mf[lev]->array(mfi);
                 amrex::Array4<Set::Scalar>        const& rhs = a_rhs_mf[lev]->array(mfi);
+#ifdef ALAMO_GPU
+                auto m_bc_type = m_elastic->GetBC().GetBcTypeArray();
+#endif
 
-                // This is for if psi is not being used and has not been set
-                if (m_psi == nullptr)
+                if (conservative_solve)
                 {
-                    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                    ALAMO_NEWTON_FOR (bx, [=] ALAMO_NEWTON_DEVICE (int i, int j, int k)
                     {
                         auto sten = Numeric::GetStencil(i, j, k, bx);
                         // Do this if on the domain boundary
                         if (AMREX_D_TERM(i == lo.x || i == hi.x, || j == lo.y || j == hi.y, || k == lo.z || k == hi.z))
                         {
-                            Set::Matrix gradu = Numeric::Gradient(u, i, j, k, dx, sten);
-                            Set::Vector ret = m_elastic->GetBC()(u(i, j, k), gradu, dw(i, j, k), i, j, k, bx);
+                            Set::Matrix gradu = Numeric::Gradient(u, i, j, k, DX.data(), sten);
+                            Set::Vector ret = ALAMO_NEWTON_BC_EVAL(m_elastic, m_bc_type, u(i, j, k), gradu, dw(i, j, k), i, j, k, bx);
                             for (int d = 0; d < AMREX_SPACEDIM; d++) rhs(i, j, k, d) = b(i, j, k)(d) - ret(d);
                         }
                         else
                         {
-                            Set::Vector divdw = Numeric::Divergence(dw, i, j, k, dx, sten);
+                            Set::Vector divdw = Detail::FaceStressDivergence(
+                                model, u, i, j, k, DX.data());
                             for (int d = 0; d < AMREX_SPACEDIM; d++) rhs(i, j, k, d) = b(i, j, k)(d) - divdw(d);
                         }
                     });
                 }
-                // This is EXACTLY THE SAME AS THE ABOVE, excpet that we are now accounting
-                // for psi terms. The reason we do this is because there's no good way (yet) to 
-                // initialize patches if psi = nullptr
                 else
                 {
                     const amrex::Dim3 boxlo = amrex::lbound(bx), boxhi = amrex::ubound(bx);
-                    amrex::Array4<const Set::Scalar>  const& psi = (*m_psi)[lev]->array(mfi);
-                    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                    amrex::Array4<const Set::Scalar> const psi = m_psi
+                        ? (*m_psi)[lev]->array(mfi)
+                        : amrex::Array4<const Set::Scalar>();
+                    const bool use_psi = m_psi != nullptr;
+                    ALAMO_NEWTON_FOR(bx, [=] ALAMO_NEWTON_DEVICE (int i, int j, int k)
                     {
                         auto sten = Numeric::GetStencil(i, j, k, bx);
                         // Do this if on the domain boundary
                         if (AMREX_D_TERM(i == lo.x || i == hi.x, || j == lo.y || j == hi.y, || k == lo.z || k == hi.z))
                         {
-                            Set::Matrix gradu = Numeric::Gradient(u, i, j, k, dx, sten);
+                            Set::Matrix gradu = Numeric::Gradient(u, i, j, k, DX.data(), sten);
                             Set::Scalar psiavg = 1.0;
-                            if (AMREX_D_TERM(i > boxlo.x && i<boxhi.x, && j>boxlo.y && j<boxhi.y, && k>boxlo.z && k < boxhi.z))
+                            if (use_psi && AMREX_D_TERM(i > boxlo.x && i<boxhi.x, && j>boxlo.y && j<boxhi.y, && k>boxlo.z && k < boxhi.z))
                             {
                                 psiavg = Numeric::Interpolate::CellToNodeAverage(psi, i, j, k, 0);
                             }
-                            Set::Vector ret = m_elastic->GetBC()(u(i, j, k), gradu, dw(i, j, k) * psiavg, i, j, k, bx);
+                            Set::Vector ret = ALAMO_NEWTON_BC_EVAL(m_elastic, m_bc_type, u(i, j, k), gradu, dw(i, j, k) * psiavg, i, j, k, bx);
                             for (int d = 0; d < AMREX_SPACEDIM; d++) rhs(i, j, k, d) = b(i, j, k)(d) - ret(d);
                         }
                         else
                         {
-                            Set::Vector divdw = Numeric::Divergence(dw, i, j, k, dx, sten);
-                            if (AMREX_D_TERM(i > boxlo.x && i<boxhi.x, && j>boxlo.y && j<boxhi.y, && k>boxlo.z && k < boxhi.z))
+                            Set::Vector divdw = Numeric::Divergence(dw, i, j, k, DX.data(), sten);
+                            if (use_psi && AMREX_D_TERM(i > boxlo.x && i<boxhi.x, && j>boxlo.y && j<boxhi.y, && k>boxlo.z && k < boxhi.z))
                             {
                                 divdw *= Numeric::Interpolate::CellToNodeAverage(psi, i, j, k, 0);
-                                Set::Vector gradpsi = Numeric::CellGradientOnNode(psi, i, j, k, 0, dx);
+                                Set::Vector gradpsi = Numeric::CellGradientOnNode(psi, i, j, k, 0, DX.data());
                                 divdw += dw(i, j, k) * gradpsi;
                             }
                             for (int d = 0; d < AMREX_SPACEDIM; d++) rhs(i, j, k, d) = b(i, j, k)(d) - divdw(d);
@@ -275,13 +675,12 @@ private:
     }
 
 
-public:
     Set::Scalar solve(const Set::Field<Set::Vector>& a_u_mf,
         const Set::Field<Set::Vector>& a_b_mf,
         Set::Field<T>& a_model_mf,
         Real a_tol_rel, Real a_tol_abs, const char* checkpoint_file = nullptr)
     {
-        Set::Field<Set::Scalar> dsol_mf, rhs_mf;
+        Set::Field<Set::Scalar> dsol_mf, rhs_mf, u0_mf, utrial_mf;
         Set::Field<Set::Matrix> dw_mf;
         Set::Field<Set::Matrix4<AMREX_SPACEDIM, T::sym>> ddw_mf;
 
@@ -289,6 +688,8 @@ public:
         dw_mf.resize(a_u_mf.finest_level + 1); dw_mf.finest_level = a_u_mf.finest_level;
         ddw_mf.resize(a_u_mf.finest_level + 1); ddw_mf.finest_level = a_u_mf.finest_level;
         rhs_mf.resize(a_u_mf.finest_level + 1); rhs_mf.finest_level = a_u_mf.finest_level;
+        u0_mf.resize(a_u_mf.finest_level + 1); u0_mf.finest_level = a_u_mf.finest_level;
+        utrial_mf.resize(a_u_mf.finest_level + 1); utrial_mf.finest_level = a_u_mf.finest_level;
         for (int lev = 0; lev <= a_u_mf.finest_level; lev++)
         {
             dsol_mf.Define(lev, a_u_mf[lev]->boxArray(),
@@ -301,31 +702,58 @@ public:
                 a_b_mf[lev]->nGrow());
             ddw_mf.Define(lev, a_b_mf[lev]->boxArray(),
                 a_b_mf[lev]->DistributionMap(),
-                1,
+                AMREX_SPACEDIM + 1,
                 a_b_mf[lev]->nGrow());
             rhs_mf.Define(lev, a_b_mf[lev]->boxArray(),
                 a_b_mf[lev]->DistributionMap(),
                 a_b_mf.NComp(),
                 a_b_mf[lev]->nGrow());
+            u0_mf.Define(lev, a_u_mf[lev]->boxArray(),
+                a_u_mf[lev]->DistributionMap(),
+                a_u_mf.NComp(),
+                a_u_mf[lev]->nGrow());
+            utrial_mf.Define(lev, a_u_mf[lev]->boxArray(),
+                a_u_mf[lev]->DistributionMap(),
+                a_u_mf.NComp(),
+                a_u_mf[lev]->nGrow());
 
             dsol_mf[lev]->setVal(0.0);
             dw_mf[lev]->setVal(Set::Matrix::Zero());
             ddw_mf[lev]->setVal(Set::Matrix4<AMREX_SPACEDIM, T::sym>::Zero());
 
             a_b_mf.Copy(lev, *rhs_mf[lev], 0, 2);
-            //amrex::MultiFab::Copy(*rhs_mf[lev], *a_b_mf[lev], 0, 0, AMREX_SPACEDIM, 2);
         }
 
+        Set::Scalar initial_resnorm = -1.0;
+        Set::Scalar last_nr_metric = -1.0;
         for (int nriter = 0; nriter < m_nriters; nriter++)
         {
             if (verbose > 0 && nriter < m_nriters) Util::Message(INFO, "Newton Iteration ", nriter + 1, " of ", m_nriters);
 
             prepareForSolve(a_u_mf, a_b_mf, rhs_mf, dw_mf, ddw_mf, a_model_mf);
+            AbortIfNonFinite(rhs_mf, "Newton residual");
 
+            // Re-derive coarse MG coefficients on relinearization; a stale hierarchy can detonate at high modulus contrast.
+            if (m_resync_coeffs && nriter > 0) m_elastic->SyncCoefficients();
 
             if (nriter == m_nriters) break;
 
+            const bool need_residual_norm = m_line_search || m_nr_diagnostics;
+            const bool need_weighted_update = m_nr_diagnostics || UsesPsiUpdateConvergence();
+
+            Set::Scalar resnorm0 = -1.0;
+            if (need_residual_norm)
+            {
+                resnorm0 = FieldNorm0(rhs_mf);
+                if (nriter == 0) initial_resnorm = resnorm0;
+            }
+
+            // Zero the correction each iteration; reusing the prior one skews MLMG's resid/resid0 denominator.
+            for (int lev = 0; lev < dsol_mf.size(); ++lev)
+                dsol_mf[lev]->setVal(0.0);
             Solver::Nonlocal::Linear::solve(dsol_mf, rhs_mf, a_tol_rel, a_tol_abs, checkpoint_file);
+            ProjectInvariantPeriodicDirections(dsol_mf);
+            AbortIfNonFinite(dsol_mf, "Newton correction", true);
 
             Set::Scalar cornorm = 0, solnorm = 0;
             for (int lev = 0; lev < dsol_mf.size(); ++lev)
@@ -334,26 +762,166 @@ public:
                 {
                     Set::Scalar tmpcornorm = dsol_mf[lev]->norm0(comp, 0);
                     if (tmpcornorm > cornorm) cornorm = tmpcornorm;
-
-                    //Set::Scalar tmpsolnorm = a_u_mf[lev]->norm0(comp,0);
-                    //if (tmpsolnorm > solnorm) solnorm = tmpsolnorm;
                 }
 
             }
+            NRUpdateNorms update_norms;
+            if (need_weighted_update) update_norms = ComputeWeightedUpdateNorms(dsol_mf);
+
+            Set::Scalar alpha = 1.0;
+            Set::Scalar resnorm = resnorm0;
+            if (m_line_search)
+            {
+                for (int lev = 0; lev <= a_u_mf.finest_level; lev++)
+                    a_u_mf.Copy(lev, *u0_mf[lev], 0, 2);
+                AbortIfNonFinite(u0_mf, "Newton line-search baseline", true);
+
+                auto restore_baseline = [&]()
+                {
+                    for (int lev = 0; lev <= a_u_mf.finest_level; lev++)
+                        a_u_mf.CopyFrom(lev, *u0_mf[lev], 0, 2);
+                    amrex::Gpu::streamSynchronizeAll();
+                };
+                auto restore_and_abort = [&](const std::string& reason)
+                {
+                    restore_baseline();
+                    prepareForSolve(a_u_mf, a_b_mf, rhs_mf, dw_mf, ddw_mf, a_model_mf);
+                    AbortIfNonFinite(rhs_mf, "restored Newton residual");
+                    Util::Abort(INFO, reason);
+                };
+                auto restore_baseline_state = [&]()
+                {
+                    restore_baseline();
+                    prepareForSolve(a_u_mf, a_b_mf, rhs_mf, dw_mf, ddw_mf, a_model_mf);
+                    AbortIfNonFinite(rhs_mf, "restored Newton residual");
+                };
+
+                constexpr int max_backtrack = 8;
+                bool accepted = false;
+                for (int bt = 0; bt <= max_backtrack; bt++)
+                {
+                    try
+                    {
+                        for (int lev = 0; lev <= a_u_mf.finest_level; lev++)
+                        {
+                            amrex::MultiFab::Copy(*utrial_mf[lev], *u0_mf[lev],
+                                0, 0, AMREX_SPACEDIM, 2);
+                            amrex::MultiFab::Saxpy(*utrial_mf[lev], alpha,
+                                *dsol_mf[lev], 0, 0, AMREX_SPACEDIM, 2);
+                        }
+                        if (HasNonFinite(utrial_mf, true))
+                            restore_and_abort("Newton line-search trial contains a non-finite value");
+                        for (int lev = 0; lev <= a_u_mf.finest_level; lev++)
+                            a_u_mf.CopyFrom(lev, *utrial_mf[lev], 0, 2);
+
+                        prepareForSolve(a_u_mf, a_b_mf, rhs_mf, dw_mf, ddw_mf, a_model_mf);
+                    }
+                    catch (...)
+                    {
+                        restore_baseline_state();
+                        throw;
+                    }
+                    if (HasNonFinite(rhs_mf))
+                        restore_and_abort("Newton line-search residual contains a non-finite value");
+
+                    resnorm = 0;
+                    resnorm = FieldNorm0(rhs_mf);
+
+                    if (Detail::AcceptLineSearchResidual(resnorm0, resnorm))
+                    {
+                        accepted = true;
+                        break;
+                    }
+
+                    alpha *= 0.5;
+                }
+                if (!accepted)
+                {
+                    std::ostringstream reason;
+                    reason << "Newton line search failed after " << max_backtrack
+                           << " backtracks: initial residual=" << resnorm0
+                           << ", final trial residual=" << resnorm;
+                    restore_and_abort(reason.str());
+                }
+            }
+            else
+            {
+                for (int lev = 0; lev < dsol_mf.size(); ++lev)
+                    a_u_mf.AddFrom(lev, *dsol_mf[lev], 0, 2);
+                for (int lev = 0; lev <= a_u_mf.finest_level; ++lev)
+                {
+                    a_u_mf.Copy(lev, *u0_mf[lev], 0, 2);
+                }
+                AbortIfNonFinite(u0_mf, "accepted Newton solution", true);
+
+                if (need_residual_norm)
+                {
+                    prepareForSolve(a_u_mf, a_b_mf, rhs_mf, dw_mf, ddw_mf, a_model_mf);
+                    AbortIfNonFinite(rhs_mf, "accepted Newton residual");
+                    resnorm = FieldNorm0(rhs_mf);
+                }
+            }
+
+            // Sync before dsol_mf is overwritten/destroyed: an async kernel above may still be reading it (UAF).
+            amrex::Gpu::streamSynchronizeAll();
+
             Set::Scalar relnorm;
             if (solnorm == 0) relnorm = cornorm;
             else relnorm = cornorm / solnorm;
-            if (verbose > 0) Util::Message(INFO, "NR iteration ", nriter + 1, ", relative norm(ddisp) = ", relnorm);
+            if (!std::isfinite(cornorm) || !std::isfinite(relnorm))
+                Util::Abort(INFO, "Newton update norm is non-finite");
+            if (verbose > 0) Util::Message(INFO, "NR iteration ", nriter + 1,
+                ", alpha = ", alpha, ", max norm(ddisp) = ", relnorm);
 
-            for (int lev = 0; lev < dsol_mf.size(); ++lev)
-                a_u_mf.AddFrom(lev, *dsol_mf[lev], 0, 2);
-            //amrex::MultiFab::Add(*a_u_mf[lev], *dsol_mf[lev], 0, 0, AMREX_SPACEDIM, 2);
+            const Set::Scalar accepted_relnorm =
+                Detail::AcceptedUpdateMetric(relnorm, alpha);
+            const Set::Scalar psi_relnorm =
+                Detail::AcceptedUpdateMetric(update_norms.psi_update, alpha);
+            const Set::Scalar solid_relnorm =
+                Detail::AcceptedUpdateMetric(update_norms.solid_update, alpha);
+            if (!std::isfinite(psi_relnorm) || !std::isfinite(solid_relnorm))
+                Util::Abort(INFO, "Newton weighted update norm is non-finite");
+            Set::Scalar resid_rel = -1.0;
+            if (need_residual_norm)
+            {
+                if (initial_resnorm > 0.0) resid_rel = resnorm / initial_resnorm;
+                else resid_rel = resnorm;
+            }
 
-            if (relnorm < m_nrtolerance)
-                return relnorm;
+            last_nr_metric = SelectedNRMetric(accepted_relnorm, psi_relnorm);
+            const Detail::NRTermination termination = Detail::DecideNRTermination(
+                last_nr_metric, m_nrtolerance, nriter + 1 == m_nriters);
+            if (termination == Detail::NRTermination::InvalidMetric)
+                Util::Abort(INFO, "Newton convergence metric is invalid");
+            const bool converged = termination == Detail::NRTermination::Converged;
+            if (m_nr_diagnostics || CustomNRConvergence())
+                Util::Message(INFO, "NR convergence metrics: mode=", m_nr_convergence,
+                    ", max_update=", cornorm,
+                    ", accepted_max_update=", alpha * cornorm,
+                    ", accepted_relative_update=", accepted_relnorm,
+                    ", psi_update=", psi_relnorm,
+                    ", solid_update=", solid_relnorm,
+                    ", nonlinear_resid=", resnorm,
+                    ", nonlinear_resid_rel=", resid_rel,
+                    ", converged=", converged);
+
+            if (converged)
+                return CustomNRConvergence()
+                    ? SelectedNRMetric(accepted_relnorm, psi_relnorm)
+                    : accepted_relnorm;
+            if (termination == Detail::NRTermination::Exhausted)
+                Util::Abort(INFO, "Newton solver failed to converge in ", m_nriters,
+                    " iterations: mode=", m_nr_convergence,
+                    ", final metric=", last_nr_metric,
+                    ", tolerance=", m_nrtolerance);
 
         }
 
+        if (m_nrtolerance > 0.0)
+            Util::Abort(INFO, "Newton solver failed to converge in ", m_nriters,
+                " iterations: mode=", m_nr_convergence,
+                ", final metric=", last_nr_metric,
+                ", tolerance=", m_nrtolerance);
         return 0.0;
     }
 
@@ -396,16 +964,24 @@ public:
             amrex::MultiFab::Copy(*rhs_mf[lev], *a_b_mf[lev], 0, 0, AMREX_SPACEDIM, 2);
         }
 
+        Set::Scalar last_relnorm = -1.0;
         for (int nriter = 0; nriter < m_nriters; nriter++)
         {
             if (verbose > 0 && nriter < m_nriters) Util::Message(INFO, "Newton Iteration ", nriter + 1, " of ", m_nriters);
 
             prepareForSolve(a_u_mf, a_b_mf, rhs_mf, dw_mf, ddw_mf, a_model_mf);
+            AbortIfNonFinite(rhs_mf, "Newton residual");
 
+            // Re-derive coarse MG coefficients/diagonal after relinearization.
+            if (m_resync_coeffs && nriter > 0) m_elastic->SyncCoefficients();
 
             if (nriter == m_nriters) break;
 
+            for (int lev = 0; lev < dsol_mf.size(); ++lev)
+                dsol_mf[lev]->setVal(0.0);
             Solver::Nonlocal::Linear::solve(dsol_mf, rhs_mf, a_tol_rel, a_tol_abs, checkpoint_file);
+            ProjectInvariantPeriodicDirections(dsol_mf);
+            AbortIfNonFinite(dsol_mf, "Newton correction", true);
 
             Set::Scalar cornorm = 0, solnorm = 0;
             for (int lev = 0; lev < dsol_mf.size(); ++lev)
@@ -423,16 +999,33 @@ public:
             Set::Scalar relnorm;
             if (solnorm == 0) relnorm = cornorm;
             else relnorm = cornorm / solnorm;
+            if (!std::isfinite(cornorm) || !std::isfinite(relnorm))
+                Util::Abort(INFO, "Newton update norm is non-finite");
+            last_relnorm = relnorm;
+            const Detail::NRTermination termination = Detail::DecideNRTermination(
+                relnorm, m_nrtolerance, nriter + 1 == m_nriters);
+            if (termination == Detail::NRTermination::InvalidMetric)
+                Util::Abort(INFO, "Newton convergence metric is invalid");
             if (verbose > 0) Util::Message(INFO, "NR iteration ", nriter + 1, ", relative norm(ddisp) = ", relnorm);
 
             for (int lev = 0; lev < dsol_mf.size(); ++lev)
                 amrex::MultiFab::Add(*a_u_mf[lev], *dsol_mf[lev], 0, 0, AMREX_SPACEDIM, 2);
+            amrex::Gpu::streamSynchronizeAll();
+            AbortIfNonFinite(a_u_mf, "accepted Newton solution", true);
 
-            if (relnorm < m_nrtolerance)
+            if (termination == Detail::NRTermination::Converged)
                 return relnorm;
+            if (termination == Detail::NRTermination::Exhausted)
+                Util::Abort(INFO, "Newton solver failed to converge in ", m_nriters,
+                    " iterations: final relative update=", last_relnorm,
+                    ", tolerance=", m_nrtolerance);
 
         }
 
+        if (m_nrtolerance > 0.0)
+            Util::Abort(INFO, "Newton solver failed to converge in ", m_nriters,
+                " iterations: final relative update=", last_relnorm,
+                ", tolerance=", m_nrtolerance);
         return 0.0;
     }
     Set::Scalar solve(const Set::Field<Set::Scalar>& a_u_mf,
@@ -449,9 +1042,12 @@ public:
     {
         Set::Field<Set::Matrix> dw_mf;
         Set::Field<Set::Matrix4<AMREX_SPACEDIM, T::sym>> ddw_mf;
-        dw_mf.resize(a_u_mf.size());
-        ddw_mf.resize(a_u_mf.size());
-        for (int lev = 0; lev < a_u_mf.size(); lev++)
+        const int nlev = a_u_mf.finest_level + 1;
+        dw_mf.resize(nlev);
+        ddw_mf.resize(nlev);
+        dw_mf.finest_level = a_u_mf.finest_level;
+        ddw_mf.finest_level = a_u_mf.finest_level;
+        for (int lev = 0; lev < nlev; lev++)
         {
             dw_mf.Define(lev, a_b_mf[lev]->boxArray(),
                 a_b_mf[lev]->DistributionMap(),
@@ -472,18 +1068,22 @@ public:
     {
         Set::Field<Set::Matrix> dw_mf;
         Set::Field<Set::Matrix4<AMREX_SPACEDIM, T::sym>> ddw_mf;
-        Set::Field<Set::Scalar> res_mf(a_res_mf.size());
-        dw_mf.resize(a_u_mf.size());
-        ddw_mf.resize(a_u_mf.size());
-        res_mf.resize(a_u_mf.size());
-        for (int lev = 0; lev < a_u_mf.size(); lev++)
+        const int nlev = a_u_mf.finest_level + 1;
+        Set::Field<Set::Scalar> res_mf(nlev);
+        dw_mf.resize(nlev);
+        ddw_mf.resize(nlev);
+        res_mf.resize(nlev);
+        dw_mf.finest_level = a_u_mf.finest_level;
+        ddw_mf.finest_level = a_u_mf.finest_level;
+        res_mf.finest_level = a_u_mf.finest_level;
+        for (int lev = 0; lev < nlev; lev++)
         {
             dw_mf.Define(lev, a_b_mf[lev]->boxArray(),
                 a_b_mf[lev]->DistributionMap(),
                 1, a_b_mf[lev]->nGrow());
             ddw_mf.Define(lev, a_b_mf[lev]->boxArray(),
                 a_b_mf[lev]->DistributionMap(),
-                1, a_b_mf[lev]->nGrow());
+                AMREX_SPACEDIM + 1, a_b_mf[lev]->nGrow());
             res_mf.Define(lev, a_b_mf[lev]->boxArray(),
                 a_b_mf[lev]->DistributionMap(),
                 AMREX_SPACEDIM, a_b_mf[lev]->nGrow());
@@ -492,7 +1092,12 @@ public:
 
         prepareForSolve(a_u_mf, a_b_mf, res_mf, dw_mf, ddw_mf, a_model_mf);
 
-        for (int lev = 0; lev < a_res_mf.size(); ++lev)
+        // Reflux to match the composite residual MLMG solves and norms.
+        for (int lev = a_u_mf.finest_level - 1; lev >= 0; --lev)
+            m_elastic->Reflux(lev, *res_mf[lev], *res_mf[lev], *res_mf[lev],
+                *res_mf[lev + 1], *res_mf[lev + 1], *res_mf[lev + 1]);
+
+        for (int lev = 0; lev < nlev; ++lev)
         {
             Util::RealFillBoundary(*res_mf[lev], m_elastic->Geom(lev));
             a_res_mf.CopyFrom(lev, *res_mf[lev], 0, 2);
@@ -533,7 +1138,8 @@ public:
         {
             BL_PROFILE("Solver::Nonlocal::Newton::DW()");
 
-            const amrex::Real* DX = linop->Geom(lev).CellSize();
+            // Device-safe cell size: a Set::Vector copied into the device closure.
+            Set::Vector DX(linop->Geom(lev).CellSize());
             amrex::Box domain(linop->Geom(lev).Domain());
             domain.convert(amrex::IntVect::TheNodeVector());
 
@@ -552,9 +1158,9 @@ public:
                     // Fill gradu
                     for (int p = 0; p < AMREX_SPACEDIM; p++)
                     {
-                        AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX, sten));,
-                            gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX, sten));,
-                            gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX, sten)););
+                        AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                            gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                            gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX.data(), sten)););
                     }
 
                     if (C(i, j, k).kinvar == Model::Solid::KinematicVariable::gradu)
@@ -576,7 +1182,8 @@ public:
         {
             BL_PROFILE("Solver::Nonlocal::Newton::DW()");
 
-            const amrex::Real* DX = linop->Geom(lev).CellSize();
+            // Device-safe cell size: a Set::Vector copied into the device closure.
+            Set::Vector DX(linop->Geom(lev).CellSize());
             amrex::Box domain(linop->Geom(lev).Domain());
             domain.convert(amrex::IntVect::TheNodeVector());
 
@@ -595,9 +1202,9 @@ public:
                     // Fill gradu
                     for (int p = 0; p < AMREX_SPACEDIM; p++)
                     {
-                        AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX, sten));,
-                            gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX, sten));,
-                            gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX, sten)););
+                        AMREX_D_TERM(gradu(p, 0) = (Numeric::Stencil<Set::Scalar, 1, 0, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                            gradu(p, 1) = (Numeric::Stencil<Set::Scalar, 0, 1, 0>::D(u, i, j, k, p, DX.data(), sten));,
+                            gradu(p, 2) = (Numeric::Stencil<Set::Scalar, 0, 0, 1>::D(u, i, j, k, p, DX.data(), sten)););
                     }
 
                     Set::Matrix sig = Set::Matrix::Zero();
@@ -609,7 +1216,6 @@ public:
                     else if (C(i, j, k).kinvar == Model::Solid::KinematicVariable::F)
                         sig = C(i, j, k).DW(gradu + Set::Matrix::Identity());
 
-                    // = C(i,j,k)(gradu,m_homogeneous);
 
                     AMREX_D_PICK(dw(i, j, k, 0) = sig(0, 0);
                     ,
@@ -626,20 +1232,257 @@ public:
     }
 
 
-public:
     int m_nriters = 1;
     Set::Scalar m_nrtolerance = 0.0;
-    Operator::Elastic<T::sym>* m_elastic;
-    //BC::Operator::Elastic::Elastic *m_bc;
+    bool m_line_search = false;
+    bool m_resync_coeffs = false;
+    std::string m_nr_convergence = "update";
+    Set::Scalar m_nr_psi_weight_floor = 0.0;
+    Set::Scalar m_nr_psi_power = 1.0;
+    Set::Scalar m_nr_solid_psi = 0.5;
+    bool m_nr_diagnostics = false;
+    std::vector<int> m_invariant_periodic;
+    Operator::Elastic<T::sym>* m_elastic = nullptr;
 
     Set::Field<Set::Scalar>* m_psi = nullptr;
+    bool m_conservative_face_flux = false;
 
-public:
-    // These paramters control a standard Newton-Raphson solve.
-    // 
-    // **Note**: 
-    // This class inherits all of the linear solve paramters
-    // from its parent class, :ref:`Solver::Nonlocal::Linear`
+    struct NRUpdateNorms
+    {
+        Set::Scalar psi_update = 0.0;
+        Set::Scalar solid_update = 0.0;
+    };
+
+    void ProjectInvariantPeriodicDirections(Set::Field<Set::Scalar>& field) const
+    {
+        if (m_invariant_periodic.empty()) return;
+
+        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+        {
+            if (!m_invariant_periodic[dir]) continue;
+            for (int lev = 0; lev < field.size(); ++lev)
+            {
+                const amrex::Geometry& geom = m_elastic->Geom(lev);
+                if (!geom.isPeriodic(dir))
+                    Util::Abort(INFO, "solver.invariant_periodic direction ", dir,
+                        " is not periodic");
+
+                amrex::Box domain = geom.Domain();
+                domain.convert(amrex::IntVect::TheNodeVector());
+                const int source_index = domain.smallEnd(dir);
+                for (amrex::MFIter mfi(*field[lev], false); mfi.isValid(); ++mfi)
+                {
+                    // Include all ghosts or machine-scale noise can re-enter the residual via face gradients.
+                    const amrex::Box bx = mfi.grownnodaltilebox();
+                    const amrex::Box valid = mfi.validbox();
+                    if (valid.smallEnd(dir) != domain.smallEnd(dir) ||
+                        valid.bigEnd(dir) != domain.bigEnd(dir))
+                        Util::Abort(INFO,
+                            "solver.invariant_periodic requires every grid to span ",
+                            "the periodic direction; direction=", dir,
+                            ", level=", lev, ", grid=", valid,
+                            ", domain=", domain);
+
+                    amrex::Array4<amrex::Real> const& fab = field[lev]->array(mfi);
+                    const int ncomp = field[lev]->nComp();
+                    amrex::ParallelFor(bx, ncomp,
+                        [=] AMREX_GPU_DEVICE(int i, int j, int k, int n)
+                        {
+                            int is = i, js = j, ks = k;
+                            if (dir == 0) is = source_index;
+#if AMREX_SPACEDIM > 1
+                            if (dir == 1) js = source_index;
+#endif
+#if AMREX_SPACEDIM > 2
+                            if (dir == 2) ks = source_index;
+#endif
+                            fab(i, j, k, n) = fab(is, js, ks, n);
+                        });
+                }
+                field[lev]->setMultiGhost(true);
+                field[lev]->FillBoundaryAndSync(geom.periodicity());
+            }
+        }
+        amrex::Gpu::streamSynchronizeAll();
+    }
+
+    bool HasNonFinite(const Set::Field<Set::Scalar>& a_mf,
+                      bool include_ghosts = false) const
+    {
+        amrex::Gpu::streamSynchronizeAll();
+        if (!include_ghosts)
+        {
+            for (int lev = 0; lev < a_mf.size(); ++lev)
+                if (!a_mf[lev]->is_finite(0, a_mf[lev]->nComp(), 0)) return true;
+            return false;
+        }
+
+        bool nonfinite = false;
+        for (int lev = 0; lev < a_mf.size(); ++lev)
+        {
+            const int ncomp = a_mf[lev]->nComp();
+            amrex::Box active_domain = m_elastic->Geom(lev).growPeriodicDomain(
+                a_mf[lev]->nGrowVect().max());
+            active_domain.convert(amrex::IntVect::TheNodeVector());
+            for (amrex::MFIter mfi(*a_mf[lev], false); mfi.isValid(); ++mfi)
+            {
+                const amrex::Box bx = mfi.growntilebox(a_mf[lev]->nGrowVect()) &
+                    active_domain;
+                if (!bx.ok()) continue;
+
+                amrex::ReduceOps<amrex::ReduceOpLogicalOr> reduce_op;
+                amrex::ReduceData<int> reduce_data(reduce_op);
+                using ReduceTuple = typename decltype(reduce_data)::Type;
+                const auto field = a_mf[lev]->const_array(mfi);
+                reduce_op.eval(bx, reduce_data,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+                    {
+                        bool bad = false;
+                        for (int n = 0; n < ncomp; ++n)
+                            bad = bad || !amrex::Math::isfinite(field(i, j, k, n));
+                        return {static_cast<int>(bad)};
+                    });
+                nonfinite = nonfinite || (amrex::get<0>(reduce_data.value(reduce_op)) != 0);
+            }
+        }
+        amrex::ParallelAllReduce::Or(nonfinite,
+            amrex::ParallelContext::CommunicatorSub());
+        return nonfinite;
+    }
+
+    void AbortIfNonFinite(const Set::Field<Set::Scalar>& a_mf,
+                          const char* description,
+                          bool include_ghosts = false) const
+    {
+        if (HasNonFinite(a_mf, include_ghosts))
+            Util::Abort(INFO, description, " contains a non-finite value");
+    }
+
+    Set::Scalar FieldNorm0(const Set::Field<Set::Scalar>& a_mf) const
+    {
+        amrex::Vector<std::unique_ptr<amrex::MultiFab>> composite(a_mf.size());
+        for (int lev = 0; lev < a_mf.size(); ++lev)
+        {
+            composite[lev] = std::make_unique<amrex::MultiFab>(
+                a_mf[lev]->boxArray(), a_mf[lev]->DistributionMap(),
+                a_mf[lev]->nComp(), a_mf[lev]->nGrowVect());
+            amrex::MultiFab::Copy(*composite[lev], *a_mf[lev], 0, 0,
+                a_mf[lev]->nComp(), a_mf[lev]->nGrowVect());
+        }
+
+        // Reflux to match MLMG's C/F row replacement, or line search can reject a good Newton step.
+        for (int lev = static_cast<int>(composite.size()) - 2; lev >= 0; --lev)
+            m_elastic->Reflux(lev, *composite[lev], *composite[lev],
+                *composite[lev], *composite[lev + 1], *composite[lev + 1],
+                *composite[lev + 1]);
+
+        Set::Scalar norm = 0.0;
+        for (int lev = 0; lev < composite.size(); ++lev)
+        {
+            const Set::Scalar tmp = m_elastic->CompositeNormInf(
+                lev, *composite[lev]);
+            if (tmp > norm) norm = tmp;
+        }
+        return norm;
+    }
+
+    NRUpdateNorms ComputeWeightedUpdateNorms(const Set::Field<Set::Scalar>& a_dsol_mf) const
+    {
+        NRUpdateNorms norms;
+        if (!m_psi)
+        {
+            norms.psi_update = FieldNorm0(a_dsol_mf);
+            norms.solid_update = norms.psi_update;
+            return norms;
+        }
+
+        for (int lev = 0; lev < a_dsol_mf.size(); ++lev)
+        {
+            amrex::Box stencilbox(linop->Geom(lev).growPeriodicDomain(2));
+            stencilbox.convert(amrex::IntVect::TheNodeVector());
+
+            amrex::ReduceOps<amrex::ReduceOpMax, amrex::ReduceOpMax> reduce_op;
+            amrex::ReduceData<amrex::Real, amrex::Real> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+
+            const Set::Scalar psi_floor = m_nr_psi_weight_floor;
+            const Set::Scalar psi_power = m_nr_psi_power;
+            const Set::Scalar solid_psi = m_nr_solid_psi;
+
+            for (MFIter mfi(*a_dsol_mf[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const amrex::Box& bx = mfi.validbox();
+                amrex::Array4<const Set::Scalar> const& dsol = a_dsol_mf[lev]->const_array(mfi);
+                amrex::Array4<const Set::Scalar> const& psi = (*m_psi)[lev]->const_array(mfi);
+                const int ncomp = a_dsol_mf[lev]->nComp();
+
+                reduce_op.eval(bx, reduce_data,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+                    {
+                        const auto sten = Numeric::GetStencil(i, j, k, stencilbox);
+                        Set::Scalar psi_avg = Numeric::Interpolate::CellToNodeAverage(psi, i, j, k, 0, sten);
+                        psi_avg = amrex::max(Set::Scalar(0.0), psi_avg);
+
+                        Set::Scalar weight = amrex::max(psi_floor, psi_avg);
+                        if (psi_power != 1.0) weight = std::pow(weight, psi_power);
+
+                        Set::Scalar weighted_max = 0.0;
+                        Set::Scalar solid_max = 0.0;
+                        for (int n = 0; n < ncomp; ++n)
+                        {
+                            const Set::Scalar absdu = amrex::Math::abs(dsol(i, j, k, n));
+                            weighted_max = amrex::max(weighted_max, weight * absdu);
+                            if (psi_avg >= solid_psi) solid_max = amrex::max(solid_max, absdu);
+                        }
+                        return {weighted_max, solid_max};
+                    });
+            }
+
+            ReduceTuple hv = reduce_data.value(reduce_op);
+            Set::Scalar weighted = amrex::get<0>(hv);
+            Set::Scalar solid = amrex::get<1>(hv);
+            amrex::ParallelDescriptor::ReduceRealMax(weighted);
+            amrex::ParallelDescriptor::ReduceRealMax(solid);
+            if (weighted > norms.psi_update) norms.psi_update = weighted;
+            if (solid > norms.solid_update) norms.solid_update = solid;
+        }
+
+        return norms;
+    }
+
+    bool UsesPsiUpdateConvergence() const
+    {
+        return m_nr_convergence == "psi_update";
+    }
+
+    bool CustomNRConvergence() const
+    {
+        return m_nr_convergence != "update";
+    }
+
+    Set::Scalar SelectedNRMetric(Set::Scalar relnorm, Set::Scalar psi_relnorm) const
+    {
+        if (m_nr_convergence == "psi_update") return psi_relnorm;
+        return relnorm;
+    }
+
+    void ValidateNRConvergenceInputs() const
+    {
+        if (!std::isfinite(m_nrtolerance) || m_nrtolerance < 0.0)
+            Util::Abort(INFO, "solver.nrtolerance must be finite and nonnegative");
+        if (m_nr_convergence != "update" &&
+            m_nr_convergence != "psi_update")
+            Util::Abort(INFO, "Invalid solver.nr_convergence=", m_nr_convergence,
+                ". Valid values: update, psi_update");
+        if (!std::isfinite(m_nr_psi_weight_floor) || m_nr_psi_weight_floor < 0.0)
+            Util::Abort(INFO, "solver.nr_psi_weight_floor must be finite and nonnegative");
+        if (!std::isfinite(m_nr_psi_power) || m_nr_psi_power < 0.0)
+            Util::Abort(INFO, "solver.nr_psi_power must be finite and nonnegative");
+        if (!std::isfinite(m_nr_solid_psi) || m_nr_solid_psi < 0.0)
+            Util::Abort(INFO, "solver.nr_solid_psi must be finite and nonnegative");
+    }
+
+    // Also inherits linear solve parameters from Solver::Nonlocal::Linear.
     static void Parse(Newton<T>& value, amrex::ParmParse& pp)
     {
         Linear::Parse(value, pp);
@@ -648,7 +1491,32 @@ public:
         pp_query("nriters", value.m_nriters);
 
         // Tolerance to use for newton-raphson convergence
-        pp_query("nrtolerance", value.m_nrtolerance); 
+        pp_query("nrtolerance", value.m_nrtolerance);
+
+        // Enable backtracking line-search damping of the Newton step.
+        pp_query("line_search", value.m_line_search);
+
+        // Re-derive coarse MG-level coefficients and the smoother diagonal
+        // after each Newton relinearization (the persistent MLMG otherwise
+        // reuses the hierarchy prepared on the first linear solve). Off by
+        // default to preserve historical iteration trajectories exactly.
+        pp_query("resync_coeffs", value.m_resync_coeffs);
+
+        // Nonlinear convergence mode. Historical default "update" uses the max
+        // displacement correction over all DOFs. "psi_update" weights the max
+        // update by local psi so low-stiffness void displacement drift does not
+        // dominate convergence after the stress-bearing region has settled.
+        pp_query("nr_convergence", value.m_nr_convergence);
+        pp_query("nr_psi_weight_floor", value.m_nr_psi_weight_floor);
+        pp_query("nr_psi_power", value.m_nr_psi_power);
+        pp_query("nr_solid_psi", value.m_nr_solid_psi);
+        pp_query("nr_diagnostics", value.m_nr_diagnostics);
+        pp_queryarr("invariant_periodic", value.m_invariant_periodic);
+        if (!value.m_invariant_periodic.empty() &&
+            value.m_invariant_periodic.size() != AMREX_SPACEDIM)
+            Util::Abort(INFO, "solver.invariant_periodic must contain exactly ",
+                AMREX_SPACEDIM, " entries");
+        value.ValidateNRConvergenceInputs();
     }
 
 };

--- a/src/Test/BC/Constant.H
+++ b/src/Test/BC/Constant.H
@@ -1,0 +1,64 @@
+#ifndef TEST_BC_CONSTANT_H
+#define TEST_BC_CONSTANT_H
+
+#include <cmath>
+#include <limits>
+
+#include <AMReX_FArrayBox.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_Gpu.H>
+
+#include "BC/Constant.H"
+
+namespace Test
+{
+namespace BC
+{
+inline int
+ConstantNeumannSubcellSpacing()
+{
+    const amrex::Box domain(
+        amrex::IntVect(AMREX_D_DECL(0, 0, 0)),
+        amrex::IntVect(AMREX_D_DECL(3, 3, 3)));
+    const amrex::RealBox physical_domain(
+        AMREX_D_DECL(0.0, 0.0, 0.0),
+        AMREX_D_DECL(1.0, 1.0, 1.0));
+    const amrex::Array<int, AMREX_SPACEDIM> periodic{
+        AMREX_D_DECL(0, 0, 0)};
+    const amrex::Geometry geom(
+        domain, physical_domain, amrex::CoordSys::cartesian, periodic);
+
+    const amrex::Vector<std::string> types(AMREX_SPACEDIM, "neumann");
+    ::BC::Constant boundary(
+        1, types, types,
+        AMREX_D_DECL(amrex::Vector<amrex::Real>{2.0},
+                     amrex::Vector<amrex::Real>{0.0},
+                     amrex::Vector<amrex::Real>{0.0}),
+        AMREX_D_DECL(amrex::Vector<amrex::Real>{3.0},
+                     amrex::Vector<amrex::Real>{0.0},
+                     amrex::Vector<amrex::Real>{0.0}));
+    boundary.define(geom);
+
+    amrex::FArrayBox field(
+        amrex::grow(domain, 1), 1, amrex::The_Managed_Arena());
+    field.setVal(10.0);
+    boundary.FillBoundary(
+        field, domain, 1, 0, 1, 0.0, ::BC::Orientation::xlo);
+    boundary.FillBoundary(
+        field, domain, 1, 0, 1, 0.0, ::BC::Orientation::xhi);
+    amrex::Gpu::streamSynchronize();
+
+    const amrex::IntVect lower(AMREX_D_DECL(-1, 1, 1));
+    const amrex::IntVect upper(AMREX_D_DECL(4, 1, 1));
+    const amrex::Real tolerance =
+        32.0 * std::numeric_limits<amrex::Real>::epsilon();
+
+    int failed = 0;
+    failed += std::abs(field(lower, 0) - 9.5) > tolerance;
+    failed += std::abs(field(upper, 0) - 9.25) > tolerance;
+    return failed;
+}
+} // namespace BC
+} // namespace Test
+
+#endif

--- a/src/Test/Numeric/Stencil.H
+++ b/src/Test/Numeric/Stencil.H
@@ -134,6 +134,91 @@ private:
     Set::Field<Set::Scalar> DphiNumeric;
     amrex::Vector<std::string> varnames = {"phi","dphi_exact","dphi_numeric"};
 };
+
+inline Set::Matrix IsotropicFaceStress(const Set::Matrix& gradu,
+                                       Set::Scalar lambda,
+                                       Set::Scalar mu)
+{
+    return lambda * gradu.trace() * Set::Matrix::Identity()
+        + mu * (gradu + gradu.transpose());
+}
+
+inline Set::Vector FaceElasticOperator(const amrex::Array4<const Set::Scalar>& u,
+                                       int i, int j, int k,
+                                       const Set::Scalar dx[AMREX_SPACEDIM])
+{
+    constexpr Set::Scalar lambda = 2.0;
+    constexpr Set::Scalar mu = 1.0;
+    Set::Vector value = Set::Vector::Zero();
+    for (int face = 0; face < AMREX_SPACEDIM; ++face)
+    {
+        const int im = i - (face == 0);
+        const int jm = j - (face == 1);
+        const int km = k - (face == 2);
+        const Set::Matrix stress_hi = IsotropicFaceStress(
+            ::Numeric::FaceGradient(u, i, j, k, face, dx), lambda, mu);
+        const Set::Matrix stress_lo = IsotropicFaceStress(
+            ::Numeric::FaceGradient(u, im, jm, km, face, dx), lambda, mu);
+        value += (stress_hi.col(face) - stress_lo.col(face)) / dx[face];
+    }
+    return value;
+}
+
+inline int FaceElasticMixedPolynomial()
+{
+    const amrex::IntVect small(AMREX_D_DECL(-3, -3, -3));
+    const amrex::IntVect big(AMREX_D_DECL(5, 5, 5));
+    amrex::FArrayBox fab(amrex::Box(small, big), AMREX_SPACEDIM);
+    auto u = fab.array();
+    const amrex::Box box = fab.box();
+    amrex::LoopOnCpu(box, [=] (int i, int j, int k)
+    {
+        u(i, j, k, 0) = 0.0;
+        u(i, j, k, 1) = static_cast<Set::Scalar>(i * i * j);
+#if AMREX_SPACEDIM == 3
+        u(i, j, k, 2) = 0.0;
+#endif
+    });
+
+    const Set::Scalar dx[AMREX_SPACEDIM] = {AMREX_D_DECL(1.0, 1.0, 1.0)};
+    const int i = 2, j = 2, k = AMREX_D_PICK(0, 0, 2);
+    const Set::Vector actual = FaceElasticOperator(
+        fab.const_array(), i, j, k, dx);
+    Set::Vector exact = Set::Vector::Zero();
+    exact(0) = 6.0 * i;
+    exact(1) = 2.0 * j;
+    return (actual - exact).lpNorm<Eigen::Infinity>() < 1.0e-12 ? 0 : 1;
+}
+
+inline int FaceElasticNullspace()
+{
+    const amrex::IntVect small(AMREX_D_DECL(-3, -3, -3));
+    const amrex::IntVect big(AMREX_D_DECL(5, 5, 5));
+    amrex::FArrayBox fab(amrex::Box(small, big), AMREX_SPACEDIM);
+    auto u = fab.array();
+    const amrex::Box box = fab.box();
+    const Set::Scalar dx[AMREX_SPACEDIM] = {AMREX_D_DECL(1.0, 1.0, 1.0)};
+    const int i0 = 2, j0 = 2, k0 = AMREX_D_PICK(0, 0, 2);
+
+    amrex::LoopOnCpu(box, [=] (int i, int j, int k)
+    {
+        for (int n = 0; n < AMREX_SPACEDIM; ++n)
+            u(i, j, k, n) = static_cast<Set::Scalar>(n + 1);
+    });
+    const Set::Vector translation = FaceElasticOperator(
+        fab.const_array(), i0, j0, k0, dx);
+
+    amrex::LoopOnCpu(box, [=] (int i, int j, int k)
+    {
+        u(i, j, k, 0) = ((i + j + AMREX_D_PICK(0, 0, k)) & 1) ? -1.0 : 1.0;
+        for (int n = 1; n < AMREX_SPACEDIM; ++n) u(i, j, k, n) = 0.0;
+    });
+    const Set::Vector checkerboard = FaceElasticOperator(
+        fab.const_array(), i0, j0, k0, dx);
+
+    return translation.lpNorm<Eigen::Infinity>() < 1.0e-12
+        && checkerboard.lpNorm<Eigen::Infinity>() > 1.0 ? 0 : 1;
+}
 }
 }
 

--- a/src/Test/Solver/Nonlocal/Newton.H
+++ b/src/Test/Solver/Nonlocal/Newton.H
@@ -1,0 +1,201 @@
+#ifndef TEST_SOLVER_NONLOCAL_NEWTON_H
+#define TEST_SOLVER_NONLOCAL_NEWTON_H
+
+#include <limits>
+
+#include "Solver/Nonlocal/Newton.H"
+
+namespace Test
+{
+namespace Solver
+{
+namespace Nonlocal
+{
+struct FaceOutputTestModel
+{
+    static constexpr auto kinvar = ::Model::Solid::KinematicVariable::gradu;
+
+    ::Set::Scalar scale = 0.0;
+
+    AMREX_GPU_HOST_DEVICE FaceOutputTestModel operator+(const FaceOutputTestModel& rhs) const
+    {
+        FaceOutputTestModel ret;
+        ret.scale = scale + rhs.scale;
+        return ret;
+    }
+
+    AMREX_GPU_HOST_DEVICE friend FaceOutputTestModel operator*(
+        ::Set::Scalar lhs, const FaceOutputTestModel& rhs)
+    {
+        FaceOutputTestModel ret;
+        ret.scale = lhs * rhs.scale;
+        return ret;
+    }
+
+    AMREX_GPU_HOST_DEVICE ::Set::Matrix DW(const ::Set::Matrix& gradu) const
+    {
+        return scale * gradu;
+    }
+};
+
+inline int
+LineSearchResidualAcceptance()
+{
+    using ::Solver::Nonlocal::Detail::AcceptLineSearchResidual;
+
+    const ::Set::Scalar nan = std::numeric_limits<::Set::Scalar>::quiet_NaN();
+    const ::Set::Scalar inf = std::numeric_limits<::Set::Scalar>::infinity();
+    int failed = 0;
+
+    failed += !AcceptLineSearchResidual(10.0, 9.0);
+    failed += !AcceptLineSearchResidual(10.0, 10.0);
+    failed += !AcceptLineSearchResidual(10.0, 10.0005);
+    failed += !AcceptLineSearchResidual(1.0, 1.0001);
+    failed += !AcceptLineSearchResidual(0.0, 0.0);
+    failed += !AcceptLineSearchResidual(
+        std::numeric_limits<::Set::Scalar>::max(),
+        std::numeric_limits<::Set::Scalar>::max());
+
+    failed += AcceptLineSearchResidual(10.0, 10.01);
+    failed += AcceptLineSearchResidual(0.0, 1.0e-12);
+    failed += AcceptLineSearchResidual(-1.0, 0.0);
+    failed += AcceptLineSearchResidual(1.0, -1.0);
+    failed += AcceptLineSearchResidual(nan, 1.0);
+    failed += AcceptLineSearchResidual(1.0, nan);
+    failed += AcceptLineSearchResidual(inf, 1.0);
+    failed += AcceptLineSearchResidual(1.0, inf);
+    failed += AcceptLineSearchResidual(1.0, 1.0, -1.0);
+    failed += AcceptLineSearchResidual(1.0, 1.0, nan);
+    failed += AcceptLineSearchResidual(1.0, 1.0, inf);
+
+    return failed;
+}
+
+inline int
+NewtonTerminationDecision()
+{
+    using ::Solver::Nonlocal::Detail::DecideNRTermination;
+    using ::Solver::Nonlocal::Detail::NRTermination;
+
+    const ::Set::Scalar nan = std::numeric_limits<::Set::Scalar>::quiet_NaN();
+    int failed = 0;
+
+    failed += DecideNRTermination(1.0, 0.0, false) != NRTermination::Continue;
+    failed += DecideNRTermination(1.0, 0.0, true) != NRTermination::FixedIterationsComplete;
+    failed += DecideNRTermination(1.0e-6, 1.0e-5, false) != NRTermination::Converged;
+    failed += DecideNRTermination(1.0e-5, 1.0e-5, false) != NRTermination::Continue;
+    failed += DecideNRTermination(1.0e-5, 1.0e-5, true) != NRTermination::Exhausted;
+    failed += DecideNRTermination(-1.0, 1.0e-5, false) != NRTermination::InvalidMetric;
+    failed += DecideNRTermination(nan, 1.0e-5, false) != NRTermination::InvalidMetric;
+    failed += DecideNRTermination(1.0, nan, false) != NRTermination::InvalidMetric;
+    failed += DecideNRTermination(1.0, -1.0, false) != NRTermination::InvalidMetric;
+
+    const ::Set::Scalar accepted_metric =
+        ::Solver::Nonlocal::Detail::AcceptedUpdateMetric(2.0e-5, 0.25);
+    failed += accepted_metric != 5.0e-6;
+    failed += DecideNRTermination(accepted_metric, 1.0e-5, false) !=
+        NRTermination::Converged;
+
+    return failed;
+}
+
+inline int
+ConservativeNodalStressReconstruction()
+{
+    const amrex::IntVect small(AMREX_D_DECL(-3, -3, -3));
+    const amrex::IntVect big(AMREX_D_DECL(5, 5, 5));
+    const amrex::Box box(small, big);
+    amrex::BaseFab<FaceOutputTestModel> model(box, 1);
+    amrex::FArrayBox displacement(box, AMREX_SPACEDIM);
+    auto model_array = model.array();
+    auto u = displacement.array();
+    constexpr ::Set::Scalar scale = 2.5;
+    amrex::LoopOnCpu(box, [=] (int i, int j, int k)
+    {
+        model_array(i, j, k).scale = scale;
+        u(i, j, k, 0) = i * i + 2.0 * j;
+        u(i, j, k, 1) = 3.0 * i - j * j;
+#if AMREX_SPACEDIM == 3
+        u(i, j, k, 2) = i + 2.0 * j + k * k;
+#endif
+    });
+
+    const ::Set::Scalar dx[AMREX_SPACEDIM] = {AMREX_D_DECL(1.0, 1.0, 1.0)};
+    const int i = 2, j = 2, k = AMREX_D_PICK(0, 0, 2);
+    const ::Set::Matrix actual =
+        ::Solver::Nonlocal::Detail::NodalStressFromFaces(
+            model.const_array(), displacement.const_array(), i, j, k, dx);
+    ::Set::Matrix expected = ::Set::Matrix::Zero();
+    expected(0, 0) = 2.0 * i;
+    expected(0, 1) = 2.0;
+    expected(1, 0) = 3.0;
+    expected(1, 1) = -2.0 * j;
+#if AMREX_SPACEDIM == 3
+    expected(2, 0) = 1.0;
+    expected(2, 1) = 2.0;
+    expected(2, 2) = 2.0 * k;
+#endif
+    expected *= scale;
+    return (actual - expected).lpNorm<Eigen::Infinity>() < 1.0e-12 ? 0 : 1;
+}
+
+inline int
+SymmetryNodalStressReconstruction()
+{
+    const amrex::IntVect small(AMREX_D_DECL(0, 0, 0));
+    const amrex::IntVect big(AMREX_D_DECL(4, 4, 4));
+    const amrex::Box box(small, big);
+    amrex::BaseFab<FaceOutputTestModel> model(box, 1);
+    amrex::BaseFab<::Set::Vector> displacement(box, 1);
+    auto model_array = model.array();
+    auto u = displacement.array();
+    constexpr ::Set::Scalar scale = 2.5;
+    amrex::LoopOnCpu(box, [=] (int i, int j, int k)
+    {
+        model_array(i, j, k).scale = scale;
+        u(i, j, k) = ::Set::Vector::Zero();
+        // About y=0: u_x is even and u_y is odd.
+        u(i, j, k)(0) = i * i + j * j;
+        u(i, j, k)(1) = (3.0 * i + 1.0) * j;
+    });
+
+    const ::Set::Scalar dx[AMREX_SPACEDIM] = {AMREX_D_DECL(1.0, 1.0, 1.0)};
+    const amrex::Dim3 lo = amrex::lbound(box), hi = amrex::ubound(box);
+    amrex::GpuArray<int, AMREX_SPACEDIM> symmetry_lo{};
+    amrex::GpuArray<int, AMREX_SPACEDIM> symmetry_hi{};
+    symmetry_lo[1] = 1;
+    const int k = AMREX_D_PICK(0, 0, 2);
+    ::Set::Matrix actual = ::Solver::Nonlocal::Detail::NodalStressFromSymmetryFaces(
+        model.const_array(), displacement.const_array(), 2, 0, k, dx,
+        lo, hi, symmetry_lo, symmetry_hi);
+    ::Set::Matrix expected = ::Set::Matrix::Zero();
+    expected(0, 0) = 4.0;
+    expected(1, 1) = 7.0;
+    expected *= scale;
+    int failed = (actual - expected).lpNorm<Eigen::Infinity>() < 1.0e-12 ? 0 : 1;
+
+    amrex::LoopOnCpu(box, [=] (int i, int j, int k2)
+    {
+        const ::Set::Scalar q = i - hi.x;
+        u(i, j, k2) = ::Set::Vector::Zero();
+        // About x=hi.x: u_x is odd and u_y is even.
+        u(i, j, k2)(0) = (2.0 * j + 1.0) * q;
+        u(i, j, k2)(1) = q * q + j * j;
+    });
+    symmetry_lo[1] = 0;
+    symmetry_hi[0] = 1;
+    actual = ::Solver::Nonlocal::Detail::NodalStressFromSymmetryFaces(
+        model.const_array(), displacement.const_array(), hi.x, 2, k, dx,
+        lo, hi, symmetry_lo, symmetry_hi);
+    expected = ::Set::Matrix::Zero();
+    expected(0, 0) = 5.0;
+    expected(1, 1) = 4.0;
+    expected *= scale;
+    failed += (actual - expected).lpNorm<Eigen::Infinity>() < 1.0e-12 ? 0 : 1;
+    return failed;
+}
+} // namespace Nonlocal
+} // namespace Solver
+} // namespace Test
+
+#endif

--- a/src/Util/Util.H
+++ b/src/Util/Util.H
@@ -15,6 +15,8 @@
 #include "Util/String.H"
 
 #include "AMReX.H"
+#include <AMReX_GpuAtomic.H>
+#include <AMReX_GpuMemory.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_iMultiFab.H>
@@ -23,6 +25,15 @@
 #include "Color.H"
 #define INFO __FILE__, __func__, __LINE__
 #define TEST(x) #x, x
+
+#ifdef ALAMO_GPU
+#define ALAMO_GPU_UNSUPPORTED_HOST_LOOP(name) \
+    do { \
+        Util::Abort(INFO, name, " is not supported in CUDA builds because it writes device-arena fabs from a host LoopConcurrentOnCpu path."); \
+    } while (false)
+#else
+#define ALAMO_GPU_UNSUPPORTED_HOST_LOOP(name) do {} while (false)
+#endif
 
 
 #ifndef ALAMO_SINGLE_DEFINITION
@@ -35,7 +46,6 @@ namespace Util
 extern std::string globalprefix;
 extern bool initialized;
 extern bool finalized;
-
 
 std::string GetFileName();
 void CopyFileToOutputDir(std::string a_path, bool fullpath = true, std::string prefix = "");
@@ -51,12 +61,34 @@ void Finalize ();
 
 void Terminate(const char * msg, int signal, bool backtrace);
 
+AMREX_GPU_HOST_DEVICE
 void Abort (const char * msg);
 
-template<typename... Args>
-AMREX_FORCE_INLINE
-void Assert (std::string file, std::string func, int line, std::string smt, bool pass, Args const &... args)
+class DeviceErrorFlag
 {
+public:
+    DeviceErrorFlag() : m_flag(0) {}
+
+    [[nodiscard]] int* dataPtr() { return m_flag.dataPtr(); }
+    [[nodiscard]] int value() const { return m_flag.dataValue(); }
+
+private:
+    amrex::Gpu::DeviceScalar<int> m_flag;
+};
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void SetDeviceError(int* flag)
+{
+    if (flag == nullptr) return;
+    AMREX_IF_ON_DEVICE((amrex::Gpu::Atomic::AddNoRet(flag, 1);))
+    AMREX_IF_ON_HOST((*flag = 1;))
+}
+
+template<typename... Args>
+AMREX_GPU_HOST_DEVICE
+void Assert (const char * file, const char * func, int line, const char * smt, bool pass, Args const &... args)
+{
+#ifndef __CUDA_ARCH__
     if (pass) return;
 
     std::ostringstream infostream;
@@ -77,12 +109,17 @@ void Assert (std::string file, std::string func, int line, std::string smt, bool
     std::cout << info << message << std::endl;
 
     Abort("Fatal Error");
+#else
+    amrex::Abort();
+#endif
 }
 
 
 template<typename... Args>
-void Abort (std::string file, std::string func, int line, Args const &... args)
+AMREX_GPU_HOST_DEVICE
+void Abort (const char * file, const char * func, int line, Args const &... args)
 {
+#ifndef __CUDA_ARCH__
     if (amrex::ParallelDescriptor::IOProcessor())
     {
         std::ostringstream infostream;
@@ -101,12 +138,29 @@ void Abort (std::string file, std::string func, int line, Args const &... args)
         std::cout << info << message << std::endl;
     }
     Abort("Fatal Error");
+#else
+    amrex::Abort();
+#endif
 }
 
 template<typename... Args>
+void AbortIfDeviceError(const DeviceErrorFlag& flag, const char* file, const char* func, int line, Args const&... args)
+{
+    // flag.value() only syncs the *current* stream (DeviceScalar::dataValue()).
+    // SetDeviceError() writes from boxes processed on other streams in AMReX's
+    // per-MFIter stream pool may still be in flight, so a bare read here can
+    // silently miss a real device-side error (false negative, not corruption --
+    // but the masked error state then propagates downstream to code that isn't
+    // expecting it). Full sync before the read closes that window.
+    amrex::Gpu::streamSynchronizeAll();
+    if (flag.value() != 0) Util::Abort(file, func, line, args...);
+}
+
+template<typename... Args>
+AMREX_GPU_HOST_DEVICE
 void ParallelAbort (std::string file, std::string func, int line, Args const &... args)
 {
-
+#ifndef __CUDA_ARCH__
     std::ostringstream infostream;
     infostream << globalprefix;
     infostream << Color::Bold << Color::FG::Red << "ABORT("<< amrex::ParallelDescriptor::MyProc()<<")" << Color::Reset << ":   ";
@@ -123,11 +177,16 @@ void ParallelAbort (std::string file, std::string func, int line, Args const &..
     std::cout << info << message << std::endl;
 
     Abort("Fatal Error");
+#else
+    amrex::Abort();
+#endif
 }
 
 template<typename... Args>
-void Message (std::string file, std::string func, int line, Args const &... args)
+AMREX_GPU_HOST_DEVICE
+void Message (const char * file, const char * func, int line, Args const &... args)
 {
+#ifndef __CUDA_ARCH__
     if (amrex::ParallelDescriptor::IOProcessor())
     {
         std::ostringstream infostream;
@@ -146,6 +205,9 @@ void Message (std::string file, std::string func, int line, Args const &... args
 
         std::cout << info << message << std::endl;
     }
+#else
+    // Device-side messages are intentionally suppressed.
+#endif
 }
 
 #ifdef AMREX_DEBUG
@@ -182,8 +244,10 @@ void DebugMessage (std::string, std::string, int, Args const &... )
 
 
 template<typename... Args>
+AMREX_GPU_HOST_DEVICE
 void ParallelMessage (std::string file, std::string func, int line, Args const &... args)
 {
+#ifndef __CUDA_ARCH__
     std::ostringstream infostream;
     infostream << globalprefix;
     infostream << Color::Bold << Color::FG::Blue << "MESSAGE("<< amrex::ParallelDescriptor::MyProc()<<")" << Color::Reset << ": ";
@@ -196,11 +260,16 @@ void ParallelMessage (std::string file, std::string func, int line, Args const &
     std::string message = messagestream.str();//String::Wrap(messagestream.str(),150);
     Util::String::ReplaceAll(message,'\n',"\n"+info);
     std::cout << info << message << std::endl;
+#else
+    // Device-side messages are intentionally suppressed.
+#endif
 }
 
 template<typename... Args>
+AMREX_GPU_HOST_DEVICE
 void Warning (std::string file, std::string func, int line, Args const &... args)
 {
+#ifndef __CUDA_ARCH__
     if (amrex::ParallelDescriptor::IOProcessor())
     {
         std::ostringstream infostream;
@@ -219,12 +288,17 @@ void Warning (std::string file, std::string func, int line, Args const &... args
 
         std::cout << info << message << std::endl;
     }
+#else
+    // Device-side warnings are intentionally suppressed.
+#endif
 }
 
 
 template<typename... Args>
+AMREX_GPU_HOST_DEVICE
 void Exception (std::string file, std::string func, int line, Args const &... args)
 {
+#ifndef __CUDA_ARCH__
     if (amrex::ParallelDescriptor::IOProcessor())
     {
         std::ostringstream infostream;
@@ -247,14 +321,19 @@ void Exception (std::string file, std::string func, int line, Args const &... ar
 
         std::throw_with_nested(std::runtime_error("IO::Exception"));
     }
+#else
+    amrex::Abort();
+#endif
 }
 
 template<typename... Args>
+AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void AssertException (std::string file, std::string func, int line, std::string smt, bool pass, Args const &... args)
 {
     if (pass) return;
 
+#ifndef __CUDA_ARCH__
     if (amrex::ParallelDescriptor::IOProcessor())
     {
         std::ostringstream infostream;
@@ -276,6 +355,9 @@ void AssertException (std::string file, std::string func, int line, std::string 
 
         Exception(file,func,line,"Fatal Error");
     }
+#else
+    amrex::Abort();
+#endif
 }
 
 
@@ -334,6 +416,8 @@ int SubFinalMessage(int failed);
 // These two functions are not really necessary anymore.
 // TODO: remove RealFillBoundary and all references to them.
 //
+
+
 template<class T>
 AMREX_FORCE_INLINE
 void RealFillBoundary(amrex::FabArray<amrex::BaseFab<T>> &a_mf,const amrex::Geometry &/*a_geom*/, const int nghost=2)
@@ -355,7 +439,6 @@ void RealFillBoundary(amrex::MultiFab &a_mf, const amrex::Geometry &/*a_geom*/, 
 }
 
 void AverageCellcenterToNode(amrex::MultiFab& node_mf, const int &dcomp, const amrex::MultiFab &cell_mf, const int &scomp, const int &ncomp/*, const int ngrow=0*/);
-
 
 template <class T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/src/test.cc
+++ b/src/test.cc
@@ -4,7 +4,9 @@
 #include "Util/Util.H"
 
 #include "Test/Numeric/Stencil.H"
+#include "Test/BC/Constant.H"
 #include "Test/Set/Matrix4.H"
+#include "Test/Solver/Nonlocal/Newton.H"
 
 #include "Operator/Elastic.H"
 
@@ -98,6 +100,10 @@ int main (int argc, char* argv[])
         subfailed += Util::Test::SubMessage("2-2-0",test.Derivative<2,2,0>(0));
         subfailed += Util::Test::SubMessage("4-0-0",test.Derivative<4,0,0>(0));
         subfailed += Util::Test::SubMessage("0-4-0",test.Derivative<0,4,0>(0));
+        subfailed += Util::Test::SubMessage("face elastic mixed polynomial",
+            Test::Numeric::FaceElasticMixedPolynomial());
+        subfailed += Util::Test::SubMessage("face elastic nullspace",
+            Test::Numeric::FaceElasticNullspace());
 #if AMREX_SPACEDIM>2
         // first order
         subfailed += Util::Test::SubMessage("0-0-1",test.Derivative<0,0,1>(0));
@@ -117,6 +123,28 @@ int main (int argc, char* argv[])
         subfailed += Util::Test::SubMessage("1-2-1",test.Derivative<1,2,1>(0));
         subfailed += Util::Test::SubMessage("1-1-2",test.Derivative<1,1,2>(0));
 #endif
+        failed += Util::Test::SubFinalMessage(subfailed);
+    }
+
+    Util::Test::Message("Solver::Nonlocal::Newton test");
+    {
+        int subfailed = 0;
+        subfailed += Util::Test::SubMessage("Line-search residual acceptance",
+            Test::Solver::Nonlocal::LineSearchResidualAcceptance());
+        subfailed += Util::Test::SubMessage("Newton termination decision",
+            Test::Solver::Nonlocal::NewtonTerminationDecision());
+        subfailed += Util::Test::SubMessage("conservative nodal stress reconstruction",
+            Test::Solver::Nonlocal::ConservativeNodalStressReconstruction());
+        subfailed += Util::Test::SubMessage("symmetry nodal stress reconstruction",
+            Test::Solver::Nonlocal::SymmetryNodalStressReconstruction());
+        failed += Util::Test::SubFinalMessage(subfailed);
+    }
+
+    Util::Test::Message("BC::Constant test");
+    {
+        int subfailed = 0;
+        subfailed += Util::Test::SubMessage("Nonzero Neumann subcell spacing",
+            Test::BC::ConstantNeumannSubcellSpacing());
         failed += Util::Test::SubFinalMessage(subfailed);
     }
 

--- a/tests/ElasticSoftVoid/input
+++ b/tests/ElasticSoftVoid/input
@@ -1,0 +1,194 @@
+#@ [2d-serial]
+#@ exe = alamo
+#@ dim = 2
+#@ nprocs = 1
+#@ check = true
+#@ timeout = 120
+#@ args = amr.max_level=2 amr.n_cell=64 64 8 explicitmesh.lo1=32 32 0 explicitmesh.hi1=95 95 0 explicitmesh.lo2=72 72 0 explicitmesh.hi2=183 183 0 pf.eta.ic.expression.constant.w=0.002 model_void.kappa=0.2_MPa model_void.mu=0.2_MPa
+#@
+#@ [2d-parallel]
+#@ exe = alamo
+#@ dim = 2
+#@ nprocs = 2
+#@ check = true
+#@ timeout = 120
+#@ args = amr.max_level=2 amr.n_cell=64 64 8 amr.max_grid_size=32 explicitmesh.lo1=32 32 0 explicitmesh.hi1=95 95 0 explicitmesh.lo2=72 72 0 explicitmesh.hi2=183 183 0 pf.eta.ic.expression.constant.w=0.002 model_void.kappa=0.2_MPa model_void.mu=0.2_MPa
+#@
+#@ [3d-serial]
+#@ exe = alamo
+#@ dim = 3
+#@ nprocs = 1
+#@ check = true
+#@ timeout = 120
+#@ args = amr.n_cell=64 64 8 explicitmesh.lo1=32 32 0 explicitmesh.hi1=95 95 15 pf.eta.ic.expression.constant.w=0.002 model_void.kappa=0.2_MPa model_void.mu=0.2_MPa elastic.solver.invariant_periodic=0 0 1
+#@
+
+# Soft-void elastic regression.  The centered stiff rod and surrounding stiff
+# tube are connected through a diffuse, finite soft material.  This is
+# intentionally *not* an exact-zero psi mask: that formulation needs a
+# separate inactive-DOF/nullspace policy.
+alamo.program = flame
+plot_file = output
+max_step = 2
+
+system.length = m
+system.time = s
+
+# AMR: the 2-D sections use a second refined level; the smaller 3-D section
+# uses one refined level.  Explicit nested boxes end inside the soft annulus,
+# so both cases exercise heterogeneous coarse-fine coefficient/smoother
+# ghosts while keeping the sub-MPa serial regression practical.
+amr.plot_int = 1
+amr.thermo.int = 1
+amr.max_level = 1
+amr.nsubsteps = 2
+amr.blocking_factor = 8
+amr.max_grid_size = 128
+amr.base_regrid_int = 10
+amr.grid_eff = 0.7
+amr.node.all = 1
+amr.refinement_criterion = 0.1
+amr.refinement_criterion_temp = 15.0_K
+amr.phi_refinement_criterion = 0.2
+amr.n_cell = 32 32 8
+
+explicitmesh.on = 1
+# Per-section lo/hi overrides select centered boxes appropriate to each
+# dimension.  These defaults are replaced by every runner section.
+explicitmesh.lo1 = 16 16 0
+explicitmesh.hi1 = 47 47 15
+
+# The z direction is ignored in 2-D and is a periodic extrusion in 3-D.
+geometry.prob_lo = 0.0_m 0.0_m 0.0_m
+geometry.prob_hi = 0.1754_m 0.1754_m 0.0439_m
+geometry.is_periodic = 0 0 1
+
+timestep = 1.0e-4_s
+stop_time = 1.0_s
+
+# Centered rod / soft annulus / outer tube.  The runner sections use w=2 mm
+# and at least 1.5 cells per width on their finest explicit mesh.
+pf.eps = 5.0e-5_m
+pf.lambda = 0.001_J/m^2
+pf.kappa = 1.0_J/m^2
+pf.w1 = 1.0_1
+pf.w12 = 2.0_1
+pf.w0 = 0.0_1
+small = 1.0e-4
+
+pf.eta.ic.type = expression
+pf.eta.ic.expression.constant.xc = 0.0877
+pf.eta.ic.expression.constant.yc = 0.0877
+pf.eta.ic.expression.constant.r1 = 0.033
+pf.eta.ic.expression.constant.r2 = 0.046
+pf.eta.ic.expression.constant.w = 0.006
+pf.eta.ic.expression.region0 = "1.0 - 0.25*(1.0 + tanh((sqrt((x-xc)^2+(y-yc)^2) - r1)/w))*(1.0 + tanh((r2 - sqrt((x-xc)^2+(y-yc)^2))/w))"
+
+phi.ic.type = constant
+phi.ic.constant.value = 1.0
+
+pf.eta.bc.type = constant
+pf.eta.bc.constant.type.xlo = dirichlet
+pf.eta.bc.constant.type.xhi = dirichlet
+pf.eta.bc.constant.type.ylo = dirichlet
+pf.eta.bc.constant.type.yhi = dirichlet
+pf.eta.bc.constant.type.zlo = periodic
+pf.eta.bc.constant.type.zhi = periodic
+pf.eta.bc.constant.val.xlo = 1.0
+pf.eta.bc.constant.val.xhi = 1.0
+pf.eta.bc.constant.val.ylo = 1.0
+pf.eta.bc.constant.val.yhi = 1.0
+
+# Homogenized propellant supplies the material blend used by Flame.  Use the
+# development-branch schema here so this elastic regression does not require
+# the unrelated chamber propellant-model refactor.
+propellant.type = homogenize
+propellant.homogenize.dispersion1 = 0.025
+propellant.homogenize.dispersion2 = 1.2
+propellant.homogenize.dispersion3 = 1000
+propellant.homogenize.h1 = 1.5e6
+propellant.homogenize.h2 = 8.0e6
+propellant.homogenize.massfraction = 0.8
+propellant.homogenize.rho_ap = 1745
+propellant.homogenize.rho_htpb = 1745
+propellant.homogenize.k_ap = 1.5
+propellant.homogenize.k_htpb = 1.5
+propellant.homogenize.cp_ap = 1476
+propellant.homogenize.cp_htpb = 1476
+propellant.homogenize.mlocal_ap = 0.1
+propellant.homogenize.m_ap = 8000_cm/s
+propellant.homogenize.m_htpb = 8000_cm/s
+propellant.homogenize.E_ap = 0_J
+propellant.homogenize.E_htpb = 0_J
+propellant.homogenize.mob_ap = false
+propellant.homogenize.bound = 0
+
+thermal.on = 1
+thermal.Tref = 300
+thermal.Tfluid = 300
+thermal.Tcutoff = 1000_K
+thermal.end_initial_refine_time = 1_s
+thermal.temp.bc.type = constant
+thermal.temp.bc.constant.type.xlo = dirichlet
+thermal.temp.bc.constant.type.xhi = dirichlet
+thermal.temp.bc.constant.type.ylo = dirichlet
+thermal.temp.bc.constant.type.yhi = dirichlet
+thermal.temp.bc.constant.type.zlo = periodic
+thermal.temp.bc.constant.type.zhi = periodic
+thermal.temp.bc.constant.val.xlo = 300_K
+thermal.temp.bc.constant.val.xhi = 300_K
+thermal.temp.bc.constant.val.ylo = 300_K
+thermal.temp.bc.constant.val.yhi = 300_K
+temp.ic.type = constant
+temp.ic.constant.value = 300_K
+laser.ic.type = expression
+laser.ic.expression.region0 = "(t < 0.025) * (150000000)"
+thermal.hc = 1.0
+
+variable_pressure = 0
+chamber.pressure = 1.0_MPa
+
+elastic.on = 1
+elastic.type = static
+elastic.interval = 1
+elastic.tstart = 5.0e-5
+elastic.phirefinement = 100
+elastic.print_model = 1
+elastic.print_residual = 1
+elastic.traction = 1000000
+elastic.use_psi = 0
+elastic.zero_out_displacement = 1
+elastic.max_coarsening_level = 2
+elastic.tol_rel = 1.0e-5
+elastic.tol_abs = 1.0e-8
+
+elastic.solver.max_iter = 200
+elastic.solver.pre_smooth = 4
+elastic.solver.post_smooth = 4
+elastic.solver.nriters = 5
+elastic.solver.nrtolerance = 2.0e-5
+elastic.solver.bottom_solver = smoother
+elastic.solver.line_search = 1
+elastic.solver.resync_coeffs = 1
+elastic.solver.nr_convergence = update
+elastic.solver.nr_diagnostics = 1
+elastic.solver.verbose = 2
+
+# Every runner section overrides the void below with a 0.2 MPa finite
+# material.  This is a real constitutive phase, not a psi regularization.
+model_ap.kappa = 150_MPa
+model_ap.mu = 140_MPa
+model_void.kappa = 10_MPa
+model_void.mu = 10_MPa
+model_htpb.kappa = 150_MPa
+model_htpb.mu = 140_MPa
+
+elastic.bc.type = constant
+elastic.bc.constant.type.xlo = disp disp disp
+elastic.bc.constant.type.xhi = disp disp disp
+elastic.bc.constant.type.ylo = disp disp disp
+elastic.bc.constant.type.yhi = disp disp disp
+elastic.bc.constant.type.xloylo = disp disp disp
+elastic.bc.constant.type.xloyhi = disp disp disp
+elastic.bc.constant.type.xhiylo = disp disp disp
+elastic.bc.constant.type.xhiyhi = disp disp disp

--- a/tests/ElasticSoftVoid/test
+++ b/tests/ElasticSoftVoid/test
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Property oracle for conservative finite-soft-void elastic solves."""
+
+import math
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+import yt
+
+
+yt.set_log_level(50)
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
+
+def metadata(path):
+    values = {}
+    for line in path.read_text().splitlines():
+        if " = " not in line:
+            continue
+        key, value = line.split(" = ", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def field_values(container, name):
+    return np.asarray(container[("boxlib", name)], dtype=float)
+
+
+def grid_field_values(grid, name):
+    values = np.asarray(grid[("boxlib", name)], dtype=float)
+    if values.ndim == 2:
+        values = values[:, :, np.newaxis]
+    require(values.ndim == 3, f"unexpected {name} grid shape {values.shape}")
+    return values
+
+
+def mpa_value(value):
+    match = re.fullmatch(r"([+\-0-9.eE]+)_MPa", value)
+    require(match, f"cannot parse MPa value {value!r}")
+    return float(match.group(1)) * 1.0e6
+
+
+def level_bounds(grids):
+    left = np.min([np.asarray(grid.LeftEdge, dtype=float) for grid in grids], axis=0)
+    right = np.max([np.asarray(grid.RightEdge, dtype=float) for grid in grids], axis=0)
+    return left, right
+
+
+def require_rectangular_union(grids, dimension, level):
+    """Prove chopped same-level boxes tile their physical bounding box."""
+    left, right = level_bounds(grids)
+    axes = tuple(range(dimension))
+    bounding_measure = float(np.prod((right - left)[list(axes)]))
+    grid_measure = sum(
+        float(np.prod((np.asarray(grid.RightEdge, dtype=float) -
+                       np.asarray(grid.LeftEdge, dtype=float))[list(axes)]))
+        for grid in grids
+    )
+    require(math.isclose(grid_measure, bounding_measure,
+                         rel_tol=2.0e-12, abs_tol=1.0e-16),
+            f"AMR level {level} fine-grid union is not rectangular")
+    return left, right
+
+
+def assemble_level_field(grids, name, level):
+    """Assemble a nodal level field independent of its grid decomposition."""
+    left, right = level_bounds(grids)
+    spacing = np.asarray(grids[0].dds, dtype=float)
+    shape = np.rint((right - left) / spacing).astype(int) + 1
+    require(np.all(shape > 0), f"AMR level {level} has an invalid extent")
+
+    total = np.zeros(tuple(shape), dtype=float)
+    count = np.zeros(tuple(shape), dtype=np.int32)
+    for grid in grids:
+        grid_spacing = np.asarray(grid.dds, dtype=float)
+        require(np.allclose(grid_spacing, spacing, rtol=2.0e-12, atol=0.0),
+                f"AMR level {level} has inconsistent grid spacing")
+        values = grid_field_values(grid, name)
+        start = np.rint(
+            (np.asarray(grid.LeftEdge, dtype=float) - left) / spacing
+        ).astype(int)
+        stop = start + np.asarray(values.shape)
+        require(np.all(start >= 0) and np.all(stop <= shape),
+                f"{name} grid lies outside the AMR level {level} union")
+        slices = tuple(slice(int(lo), int(hi)) for lo, hi in zip(start, stop))
+        total[slices] += values
+        count[slices] += 1
+
+    require(np.all(count > 0),
+            f"AMR level {level} {name} field has holes in its rectangular union")
+    return total / count
+
+
+require(len(sys.argv) == 2, "usage: test OUTPUT_DIRECTORY")
+outdir = Path(sys.argv[1])
+stdout = (outdir / "stdout").read_text()
+require("ELASTIC SOLVE:" in stdout, "the case did not enter an elastic solve")
+require(not re.search(r"\b(?:abort|nan|inf(?:inity)?)\b", stdout, re.IGNORECASE),
+        "solver output contains an abort or non-finite value")
+require("MLMG failed" not in stdout and "Failed to converge" not in stdout and
+        "Failing to converge" not in stdout,
+        "the linear solver reported non-convergence")
+
+linear = re.findall(
+    r"MLMG: Final Iter\.\s+\d+\s+resid, resid/(?:bnorm|resid0)\s+=\s+([^,\s]+),\s+([^,\s]+)",
+    stdout,
+)
+require(linear, "no final MLMG residual was reported")
+for _, relative in linear:
+    value = float(relative)
+    require(math.isfinite(value) and value <= 1.2e-5,
+            f"linear residual {value:g} exceeds the 1e-5 solve target")
+
+solve_blocks = stdout.split("ELASTIC SOLVE:")[1:]
+require(solve_blocks, "no elastic solve block was reported")
+metric_pattern = re.compile(
+    r"NR convergence metrics:\s*mode=([^,\s]+),\s*"
+    r"max_update=([^,\s]+),\s*accepted_max_update=([^,\s]+),\s*"
+    r"accepted_relative_update=([^,\s]+),\s*psi_update=([^,\s]+),\s*"
+    r"solid_update=([^,\s]+),\s*nonlinear_resid=([^,\s]+),\s*"
+    r"nonlinear_resid_rel=([^,\s]+),\s*converged=([01])"
+)
+iteration_pattern = re.compile(
+    r"NR iteration\s+\d+,\s*alpha\s*=\s*([^,\s]+),\s*"
+    r"max norm\(ddisp\)\s*=\s*([^\s]+)"
+)
+for solve_number, block in enumerate(solve_blocks, start=1):
+    metrics = metric_pattern.findall(block)
+    iterations = iteration_pattern.findall(block)
+    require(metrics, f"elastic solve {solve_number} has no Newton convergence record")
+    require(len(metrics) == len(iterations),
+            f"elastic solve {solve_number} has mismatched iteration diagnostics")
+
+    previous_residual = None
+    for metric, iteration in zip(metrics, iterations):
+        mode, max_update, accepted_update, accepted_relative, psi_update, \
+            solid_update, nonlinear_residual, nonlinear_relative, converged = metric
+        alpha, reported_relative = iteration
+        values = list(map(float, (
+            max_update, accepted_update, accepted_relative, psi_update,
+            solid_update, nonlinear_residual, nonlinear_relative, alpha,
+            reported_relative,
+        )))
+        require(all(map(math.isfinite, values)),
+                f"elastic solve {solve_number} has a non-finite Newton metric")
+        max_update, accepted_update, accepted_relative, psi_update, \
+            solid_update, nonlinear_residual, nonlinear_relative, alpha, \
+            reported_relative = values
+        require(mode == "update", f"unexpected Newton convergence mode {mode}")
+        require(0.0 < alpha <= 1.0, f"invalid line-search alpha {alpha:g}")
+        require(math.isclose(accepted_update, alpha * max_update,
+                             rel_tol=2.0e-5, abs_tol=1.0e-14),
+                "accepted update is inconsistent with the line-search step")
+        require(math.isclose(reported_relative, max_update,
+                             rel_tol=2.0e-5, abs_tol=1.0e-14),
+                "reported update is inconsistent with the convergence metric")
+        if previous_residual is None:
+            require(nonlinear_relative <= 1.0001 + 1.0e-12,
+                    "the first accepted Newton step increased its residual")
+        else:
+            require(nonlinear_residual <= previous_residual * (1.0001 + 1.0e-12),
+                    "an accepted Newton step increased its residual")
+        previous_residual = nonlinear_residual
+
+    final_accepted_update = float(metrics[-1][2])
+    final_nonlinear_relative = float(metrics[-1][7])
+    require(metrics[-1][-1] == "1",
+            f"elastic solve {solve_number} did not report convergence")
+    require(final_accepted_update <= 2.0e-5,
+            f"elastic solve {solve_number} accepted update "
+            f"{final_accepted_update:g} exceeds tolerance")
+    require(final_nonlinear_relative < 0.05,
+            f"elastic solve {solve_number} nonlinear equilibrium ratio "
+            f"{final_nonlinear_relative:g} is not below 0.05")
+meta = metadata(outdir / "metadata")
+require(meta.get("Status", "").strip().lower() == "complete",
+        "simulation status is not exactly Complete")
+dimension_text = meta.get("Dimension", "")
+require(re.fullmatch(r"[23]", dimension_text) is not None,
+        f"invalid metadata Dimension {dimension_text!r}")
+dimension = int(dimension_text)
+require(int(meta["Number_of_processors"]) >= 1,
+        "metadata reports no active MPI processes")
+use_psi = float(meta["elastic.use_psi"])
+psi_floor = float(meta.get("elastic.psi_floor", "0"))
+require(use_psi == 0.0, "the physical regression must use the finite void model, not psi masking")
+require(psi_floor == 0.0, "the physical regression must not use a psi floor")
+require(meta.get("elastic.solver.nr_convergence") == "update",
+        "the regression must use the unscaled update convergence mode")
+require(float(meta.get("elastic.solver.line_search", "0")) == 1.0,
+        "the regression must exercise the line search")
+for key in ("model_void.kappa", "model_void.mu"):
+    require(math.isclose(mpa_value(meta[key]), 0.2e6,
+                         rel_tol=0.0, abs_tol=1.0e-8),
+            f"{key} is not the required 0.2 MPa")
+
+plots = sorted(outdir.glob("*node"))
+require(plots, "no nodal plotfile was written")
+ds = yt.load(str(plots[-1]))
+ad = ds.all_data()
+fields = {name for field_type, name in ds.field_list if field_type == "boxlib"}
+domain_dimensions = np.asarray(ds.domain_dimensions, dtype=int)
+require((dimension == 2 and domain_dimensions[2] == 1) or
+        (dimension == 3 and domain_dimensions[2] > 1),
+        "plotfile dimensionality disagrees with metadata Dimension")
+
+required_level = 2 if dimension == 2 else 1
+require(ds.index.max_level >= required_level,
+        f"expected AMR level {required_level}, found only {ds.index.max_level}")
+
+grids_by_level = {}
+for grid in ds.index.grids:
+    grids_by_level.setdefault(int(grid.Level), []).append(grid)
+for level in range(required_level + 1):
+    require(grids_by_level.get(level), f"AMR level {level} has no grids")
+    require_rectangular_union(grids_by_level[level], dimension, level)
+
+for prefix in ("disp_", "strain_", "stress_", "rhs_", "res_"):
+    names = sorted(name for name in fields if name.startswith(prefix))
+    require(names, f"plotfile has no {prefix} fields")
+    for name in names:
+        values = field_values(ad, name)
+        require(np.isfinite(values).all(), f"{name} contains a non-finite value")
+
+mu_name = "model_mu" if "model_mu" in fields else "_mu"
+kappa_name = "model_kappa" if "model_kappa" in fields else "_kappa"
+psi_name = "psi" if "psi" in fields else "eta"
+for name in (psi_name, mu_name, kappa_name):
+    require(name in fields, f"plotfile is missing {name}")
+    require(np.isfinite(field_values(ad, name)).all(), f"{name} contains a non-finite value")
+
+in_plane_disp_max = max(
+    float(np.max(np.abs(field_values(ad, name))))
+    for name in ("disp_x", "disp_y")
+)
+in_plane_stress_max = max(
+    float(np.max(np.abs(field_values(ad, name))))
+    for name in ("stress_xx", "stress_xy", "stress_yx", "stress_yy")
+)
+require(in_plane_disp_max > 1.0e-12, "in-plane elastic displacement is trivially zero")
+require(in_plane_stress_max > 0.1, "in-plane elastic stress is trivially zero")
+
+psi = field_values(ad, psi_name)
+psi_min = float(np.min(psi))
+psi_max = float(np.max(psi))
+require(psi_min < 0.3 and psi_max > 0.99,
+        "the diffuse rod/void/tube geometry was not realized")
+
+for level, grids in grids_by_level.items():
+    level_psi = np.concatenate([
+        grid_field_values(grid, psi_name).ravel() for grid in grids
+    ])
+    require(float(np.min(level_psi)) < 0.3 and float(np.max(level_psi)) > 0.99,
+            f"AMR level {level} does not contain both soft and solid material")
+    require(np.any((level_psi > 0.05) & (level_psi < 0.95)),
+            f"AMR level {level} does not resolve the diffuse interface")
+
+# The explicit fine regions are rectangular but may be chopped into many
+# same-level boxes.  Only faces on the exterior of each rectangular union are
+# coarse/fine interfaces; faces shared by chopped boxes are deliberately
+# excluded.
+domain_lo = np.asarray(ds.domain_left_edge, dtype=float)
+domain_hi = np.asarray(ds.domain_right_edge, dtype=float)
+for level in range(1, required_level + 1):
+    grids = grids_by_level[level]
+    union_lo, union_hi = level_bounds(grids)
+    spacing = np.asarray(grids[0].dds, dtype=float)
+    for axis in range(2):
+        require(union_lo[axis] > domain_lo[axis] + 0.5 * spacing[axis] and
+                union_hi[axis] < domain_hi[axis] - 0.5 * spacing[axis],
+                f"AMR level {level} fine-grid union is not internal in "
+                f"{'xy'[axis]}")
+
+    cf_transition_count = 0
+    for grid in grids:
+        values = grid_field_values(grid, psi_name)
+        left = np.asarray(grid.LeftEdge, dtype=float)
+        right = np.asarray(grid.RightEdge, dtype=float)
+        for axis in range(2):
+            edge_tolerance = 1.0e-8 * spacing[axis]
+            if math.isclose(left[axis], union_lo[axis],
+                            rel_tol=0.0, abs_tol=edge_tolerance):
+                face = np.take(values, 0, axis=axis)
+                cf_transition_count += int(np.count_nonzero(
+                    (face > 0.05) & (face < 0.95)
+                ))
+            if math.isclose(right[axis], union_hi[axis],
+                            rel_tol=0.0, abs_tol=edge_tolerance):
+                face = np.take(values, -1, axis=axis)
+                cf_transition_count += int(np.count_nonzero(
+                    (face > 0.05) & (face < 0.95)
+                ))
+    require(cf_transition_count > 0,
+            f"AMR level {level} outer coarse/fine boundary does not intersect "
+            "the diffuse material interface")
+
+for field_name, parameter in ((mu_name, "mu"), (kappa_name, "kappa")):
+    values = field_values(ad, field_name)
+    void_modulus = mpa_value(meta[f"model_void.{parameter}"])
+    propellant_modulus = mpa_value(meta[f"model_ap.{parameter}"])
+    casing_modulus = mpa_value(meta[f"model_htpb.{parameter}"])
+    require(math.isclose(propellant_modulus, casing_modulus),
+            f"the {parameter} mixture oracle requires equal solid moduli")
+    expected = void_modulus + psi * (propellant_modulus - void_modulus)
+    require(np.allclose(values, expected, rtol=1.0e-10, atol=1.0e-6),
+            f"{field_name} does not realize the configured finite-void mixture")
+    realized_minimum = float(np.min(values))
+    require(0.0 < realized_minimum < 1.0e6,
+            f"realized {field_name} minimum {realized_minimum:g} Pa is not "
+            "positive and sub-MPa")
+    require(float(np.max(values) / realized_minimum) >= 5.0,
+            f"the plot does not contain a meaningful {parameter} contrast")
+    for level, grids in grids_by_level.items():
+        level_values = np.concatenate([
+            grid_field_values(grid, field_name).ravel() for grid in grids
+        ])
+        level_psi = np.concatenate([
+            grid_field_values(grid, psi_name).ravel() for grid in grids
+        ])
+        level_expected = void_modulus + level_psi * (
+            propellant_modulus - void_modulus
+        )
+        require(np.allclose(level_values, level_expected,
+                            rtol=1.0e-10, atol=1.0e-6),
+                f"AMR level {level} has an inconsistent {field_name} mixture")
+        require(float(np.max(level_values) / np.min(level_values)) >= 5.0,
+                f"AMR level {level} lacks meaningful {parameter} heterogeneity")
+
+rhs_max = max(
+    float(np.max(np.abs(field_values(ad, name))))
+    for name in fields if name.startswith("rhs_")
+)
+residual_max = max(
+    float(np.max(np.abs(field_values(ad, name))))
+    for name in fields if name.startswith("res_")
+)
+require(rhs_max > 0.0, "plotted elastic RHS is zero")
+require(residual_max / rhs_max < 0.05,
+        f"plotted equilibrium ratio {residual_max / rhs_max:g} is not below 0.05")
+
+if dimension == 3:
+    required_3d_fields = {
+        "disp_x", "disp_y", "disp_z", "rhs_x", "rhs_y", "rhs_z",
+        "res_x", "res_y", "res_z",
+    }
+    require(required_3d_fields <= fields,
+            f"3-D plotfile is missing {sorted(required_3d_fields - fields)}")
+
+    z_invariant_fields = {psi_name, mu_name, kappa_name}
+    z_invariant_fields.update(
+        name for name in ("eta", "phi") if name in fields
+    )
+    for name in fields:
+        if re.fullmatch(r"(?:disp|rhs|res)_[xy]", name):
+            z_invariant_fields.add(name)
+        if re.fullmatch(r"(?:strain|stress)_[xy][xy]", name):
+            z_invariant_fields.add(name)
+        if re.fullmatch(r"model_F0[xy][xy]", name):
+            z_invariant_fields.add(name)
+
+    for level, grids in grids_by_level.items():
+        for name in sorted(z_invariant_fields):
+            values = assemble_level_field(grids, name, level)
+            require(values.shape[2] > 1,
+                    f"AMR level {level} {name} has no z extent")
+            spread = float(np.max(np.ptp(values, axis=2)))
+            scale = float(np.max(np.abs(values)))
+            tolerance = 1.0e-12 + 1.0e-8 * scale
+            require(spread <= tolerance,
+                    f"AMR level {level} {name} varies in periodic z: "
+                    f"spread {spread:g} exceeds {tolerance:g}")
+
+    rhs_xy_max = max(
+        float(np.max(np.abs(field_values(ad, name))))
+        for name in ("rhs_x", "rhs_y")
+    )
+    rhs_z_max = float(np.max(np.abs(field_values(ad, "rhs_z"))))
+    require(rhs_z_max <= 1.0e-12 * max(rhs_xy_max, 1.0),
+            f"out-of-plane RHS {rhs_z_max:g} is not negligible relative to "
+            f"in-plane RHS {rhs_xy_max:g}")
+
+    disp_xy_max = max(
+        float(np.max(np.abs(field_values(ad, name))))
+        for name in ("disp_x", "disp_y")
+    )
+    disp_z_max = float(np.max(np.abs(field_values(ad, "disp_z"))))
+    require(disp_z_max <= 1.0e-14 + 1.0e-8 * disp_xy_max,
+            f"out-of-plane displacement {disp_z_max:g} is not negligible "
+            f"relative to in-plane displacement {disp_xy_max:g}")
+
+work = np.zeros_like(field_values(
+    ad, next(name for name in fields if name.startswith("stress_"))
+))
+for name in fields:
+    if not name.startswith("stress_"):
+        continue
+    strain_name = "strain_" + name[len("stress_"):]
+    if strain_name in fields:
+        work += 0.5 * field_values(ad, name) * field_values(ad, strain_name)
+require(np.isfinite(work).all() and float(np.max(np.abs(work))) > 0.0,
+        "stress-strain work witness is non-finite or zero")

--- a/tests/RubberPlateHole/input
+++ b/tests/RubberPlateHole/input
@@ -10,6 +10,7 @@
 #@ check=false
 #@ coverage=true
 #@ args = solver.nriters=1
+#@ args = solver.nrtolerance=0
 #@ args = solver.fixed_iter=1
 #@
 
@@ -60,4 +61,3 @@ bc.tensiontest.disp = (0,1:0,0.5)
 solver.dump_on_fail = 1
 amrex.signal_handling = 0
 amrex.throw_exception = 1
-

--- a/tests/SCPSpheresElastic/test
+++ b/tests/SCPSpheresElastic/test
@@ -1,13 +1,67 @@
 #!/usr/bin/env python3
+import math
+import re
 import sys
 sys.path.insert(0,"../../scripts")
 import testlib
 import glob
 
+import numpy as np
+import yt
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
 outdir = sys.argv[1]
 reference = sys.argv[2]
 
 path = sorted(glob.glob("{}/*cell/".format(outdir)))[-1]
+
+stdout = open("{}/stdout".format(outdir)).read()
+require(not re.search(r"\b(?:abort|nan|inf(?:inity)?)\b", stdout, re.IGNORECASE),
+        "solver output contains an abort or non-finite value")
+require("MLMG failed" not in stdout and "Failed to converge" not in stdout and
+        "Failing to converge" not in stdout,
+        "the solver reported non-convergence")
+
+solve_blocks = stdout.split("ELASTIC SOLVE:")[1:]
+require(solve_blocks, "no elastic solve block was reported")
+step_pattern = re.compile(
+    r"MLMG: Initial rhs\s*=\s*([^\s]+).*?"
+    r"NR iteration\s+\d+,\s+alpha\s*=\s*([^,\s]+),\s+"
+    r"max norm\(ddisp\)\s*=\s*([^\s]+)",
+    re.DOTALL,
+)
+for solve_number, block in enumerate(solve_blocks, start=1):
+    steps = step_pattern.findall(block)
+    require(steps, f"elastic solve {solve_number} has no completed Newton iteration")
+    for rhs_text, alpha_text, update_text in steps:
+        rhs, alpha, update = map(float, (rhs_text, alpha_text, update_text))
+        require(all(map(math.isfinite, (rhs, alpha, update))),
+                "a Newton/MLMG iteration metric is non-finite")
+        require(0.0 < alpha <= 1.0, f"invalid line-search alpha {alpha:g}")
+        require(rhs == 0.0 or abs(update) > 0.0,
+                f"nonzero nonlinear RHS {rhs:g} accepted a zero Newton update")
+
+yt.set_log_level(50)
+ds = yt.load(path)
+ad = ds.all_data()
+fields = {name for field_type, name in ds.field_list if field_type == "boxlib"}
+for prefix in ("disp_", "stress_", "strain_", "rhs_", "res_"):
+    names = sorted(name for name in fields if name.startswith(prefix))
+    require(names, f"final plotfile has no {prefix} fields")
+    for name in names:
+        values = np.asarray(ad[("boxlib", name)])
+        require(np.isfinite(values).all(), f"{name} contains a non-finite value")
+
+disp_max = max(float(np.max(np.abs(np.asarray(ad[("boxlib", name)]))))
+               for name in fields if name.startswith("disp_"))
+stress_max = max(float(np.max(np.abs(np.asarray(ad[("boxlib", name)]))))
+                 for name in fields if name.startswith("stress_"))
+require(disp_max > 1.0e-12, "elastic displacement is trivially zero")
+require(stress_max > 0.0, "elastic stress is trivially zero")
 
 testlib.validate(path=path,
                  outdir=outdir,
@@ -20,8 +74,4 @@ testlib.validate(path=path,
                  generate_ref_data = False,
 )
 exit(0)
-
-
-
-
 


### PR DESCRIPTION
## Summary

- make elastic boundary-condition, stencil, matrix, and utility foundations device-safe
- improve elastic MLMG coefficient synchronization, conservative face operators, and retained hot-kernel paths
- harden Newton line search, rollback, non-finite handling, coefficient resynchronization, and accepted-step convergence
- wire finite-soft-void conservative elasticity into Flame
- add focused unit, AMR, MPI, 2D, and 3D regression coverage

## Validation

Post-rebase validation on current `development`:

- `bin/test-2d-g++` — PASS, 0 failures
- `bin/test-3d-g++` — PASS, 0 failures
- `scripts/runtests.py --dim=2 --comp=g++ --serial tests/ElasticSoftVoid` — PASS
- `scripts/runtests.py tests/ElasticSoftVoid --dim=2 --comp=g++ --sections 2d-parallel` — PASS
- `scripts/runtests.py --dim=3 --comp=g++ --serial tests/ElasticSoftVoid` — PASS
- focused reviewer pass and `git diff --check` — PASS

Original qualification also passed the complete 2D/3D CPU suites and existing mechanics regression matrix without refreshing or weakening references.