### PR TITLE
Feature/slurm helpers

### DIFF
--- a/docs/source/.gitignore
+++ b/docs/source/.gitignore
@@ -1,5 +1,6 @@
 Tests
 Tests.rst
+FilenameParsing.rst
 Inputs.generated.rst
 InputsReference/
 InputsSearch.rst

--- a/docs/source/Developers.rst
+++ b/docs/source/Developers.rst
@@ -290,10 +290,10 @@ are written to the terminal, including AMReX initialization and finalization
 messages. This keeps the complete simulation log with its plotfiles even when
 the terminal is managed by a batch scheduler.
 
-When a simulation runs in a Slurm allocation, the :code:`metadata` file also
-contains a :code:`SLURM DETAILS` section. It records the available job,
-allocation, submission, task, CPU, memory, GPU, array, and restart environment
-variables supplied by Slurm.
+When a simulation runs in a Slurm allocation, the available job, allocation,
+submission, task, CPU, memory, GPU, array, and restart environment variables
+are written directly to the :code:`metadata` file as :code:`NAME = value`
+entries.
     
 You may wish to *restart* the simulation without starting from the beginning.
 Perhaps the simulation was fine at :code:`00060` but became unstable at :code:`00070`, and you want to continue from that point with a different parameter value.

--- a/docs/source/Developers.rst
+++ b/docs/source/Developers.rst
@@ -283,6 +283,17 @@ and it produced the following output.
         celloutput.visit
         nodeoutput.visit
         metadata
+        out.log
+
+The :code:`out.log` file contains the same rank-zero stdout and stderr that
+are written to the terminal, including AMReX initialization and finalization
+messages. This keeps the complete simulation log with its plotfiles even when
+the terminal is managed by a batch scheduler.
+
+When a simulation runs in a Slurm allocation, the :code:`metadata` file also
+contains a :code:`SLURM DETAILS` section. It records the available job,
+allocation, submission, task, CPU, memory, GPU, array, and restart environment
+variables supplied by Slurm.
     
 You may wish to *restart* the simulation without starting from the beginning.
 Perhaps the simulation was fine at :code:`00060` but became unstable at :code:`00070`, and you want to continue from that point with a different parameter value.

--- a/docs/source/FilenameParsing.py
+++ b/docs/source/FilenameParsing.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "builder"))
+
+from reference import leading_documentation
+
+
+source = REPO_ROOT / "src/IO/FileNameParse.H"
+documentation = leading_documentation(source)
+if not documentation:
+    raise RuntimeError(f"No leading documentation found in {source}")
+
+Path(__file__).with_suffix(".rst").write_text(
+    documentation + "\n",
+    encoding="utf-8",
+)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,7 @@ import os, subprocess
 import sys
 sys.path.append(os.path.abspath('.'))
 import Tests
+import FilenameParsing
 # -- Project information ----------------------------------------------------
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -169,5 +169,6 @@ The development team gratefully acknowledges the funding sources that enable the
         Tests
         Inputs
         Builder
+        FilenameParsing
         Developers
         Questions

--- a/src/IO/FileNameParse.H
+++ b/src/IO/FileNameParse.H
@@ -1,25 +1,88 @@
 //
-// This manages the processing of the :code:`plot_file` input, which defines the output file.
-// Both variable substitution and time wildcards are supported.
+// ============================================
+// :fas:`file-code;fa-fw` Filename parsing
+// ============================================
 //
-// **Variable substitution**: you can use braces to substitute variable names in the input file.
-// For example, if your input file contains :code:`myinput.value = 3`, then you can specify
-// :code:`plot_file = output_{myinput.value}` to substitute the input's value.
+// The :code:`plot_file` input defines the simulation output directory. Alamo
+// supports time and dimension wildcards, input-variable substitution, and
+// Slurm environment substitution in this value.
 //
-// **Time and dimension wildcards**: You can use the following strings:
+// Time and dimension wildcards
+// ----------------------------
 //
-// - :code:`%Y`: 4-digit year
-// - :code:`%m`: 2-digit month (01-12)
-// - :code:`%d`: 2-digit day (00-31)
-// - :code:`%H`: 2 digit hour (00-23)
-// - :code:`%M`: 2 digit minute (00-59)
-// - :code:`%S`: 2 digit second (00-59)
-// - :code:`%f`: 2 digit microsecond (00-59)
-// - :code:`%D`: spatial dimension
+// The following wildcard strings are available:
 //
-// So a :code:`plot_file = output_%Y%m%d_%H%M%S` may resolve to
-// :code:`output_20250307_211201` (etc) depending on the time the
-// output was created.
+// .. code-block:: text
+//
+//    %Y  Four-digit year
+//    %m  Two-digit month (01-12)
+//    %d  Two-digit day of the month (01-31)
+//    %H  Two-digit hour (00-23)
+//    %M  Two-digit minute (00-59)
+//    %S  Two-digit second (00-59)
+//    %f  Microseconds within the current second
+//    %D  Spatial dimension
+//
+// For example:
+//
+// .. code-block:: makefile
+//
+//    plot_file = output_%Y%m%d_%H%M%S
+//
+// may resolve to:
+//
+// .. code-block:: text
+//
+//    output_20250307_211201
+//
+// Input variable substitution
+// ---------------------------
+//
+// Use braces to substitute a variable from the input file:
+//
+// .. code-block:: makefile
+//
+//    myinput.value = 3
+//    plot_file = output_{myinput.value}
+//
+// This resolves the output directory to:
+//
+// .. code-block:: text
+//
+//    output_3
+//
+// Slurm environment substitution
+// ------------------------------
+//
+// Any brace-delimited variable whose name begins with :code:`SLURM_` is read
+// from the process environment. Common substitutions include:
+//
+// .. code-block:: text
+//
+//    {SLURM_JOB_ID}
+//    {SLURM_JOB_NAME}
+//    {SLURM_JOB_PARTITION}
+//    {SLURM_CLUSTER_NAME}
+//    {SLURM_ARRAY_TASK_ID}
+//
+// For example:
+//
+// .. code-block:: makefile
+//
+//    plot_file = output_{SLURM_JOB_ID}
+//
+// may resolve to:
+//
+// .. code-block:: text
+//
+//    output_314159
+//
+// If the requested variable is unavailable or empty, its name is retained
+// without braces:
+//
+// .. code-block:: text
+//
+//    output_SLURM_JOB_ID
 
 #ifndef IO_FILENAMEPARSE_H
 #define IO_FILENAMEPARSE_H

--- a/src/IO/FileNameParse.cpp
+++ b/src/IO/FileNameParse.cpp
@@ -1,4 +1,5 @@
 #include "IO/FileNameParse.H"
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 #include <chrono>
@@ -35,9 +36,21 @@ void IO::FileNameParse(std::string &filename)
         if (!formatting_string.empty()) {
             Util::Exception(INFO,"Formatting strings are not supported yet");
         } else {
-            std::vector<std::string> variable_value;
-            pp.queryarr(variable_name.c_str(),variable_value);
-            Util::String::ReplaceAll(filename,"{"+variable_name+"}",Util::String::Join(variable_value,'_'));
+            if (variable_name.rfind("SLURM_", 0) == 0)
+            {
+                const char *variable_value = std::getenv(variable_name.c_str());
+                const std::string replacement =
+                    variable_value != nullptr && variable_value[0] != '\0' ?
+                    variable_value : variable_name;
+                Util::String::ReplaceAll(
+                    filename, "{" + variable_name + "}", replacement);
+            }
+            else
+            {
+                std::vector<std::string> variable_value;
+                pp.queryarr(variable_name.c_str(),variable_value);
+                Util::String::ReplaceAll(filename,"{"+variable_name+"}",Util::String::Join(variable_value,'_'));
+            }
         }
     }
 

--- a/src/IO/OutputLog.H
+++ b/src/IO/OutputLog.H
@@ -1,0 +1,23 @@
+#ifndef IO_OUTPUTLOG_H
+#define IO_OUTPUTLOG_H
+
+#include <string>
+
+namespace IO::OutputLog
+{
+
+/// Route stdout and stderr through the terminal/file tee.
+void Initialize();
+
+/// Open the rank-zero log after the output directory has been created.
+void Open(const std::string& path);
+
+/// Stop retaining output on ranks that do not own the log file.
+void DisableFile();
+
+/// Flush the log and restore the original terminal stream buffers.
+void Finalize();
+
+}
+
+#endif

--- a/src/IO/OutputLog.cpp
+++ b/src/IO/OutputLog.cpp
@@ -1,0 +1,171 @@
+#include "IO/OutputLog.H"
+
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <streambuf>
+#include <string>
+
+namespace
+{
+
+class LogSink
+{
+public:
+    void Write(const char* data, std::streamsize size)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_state == State::Buffering)
+            m_pending.append(data, static_cast<std::size_t>(size));
+        else if (m_state == State::Open)
+            m_file.write(data, size);
+    }
+
+    int Sync()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_state != State::Open) return 0;
+        m_file.flush();
+        return m_file.good() ? 0 : -1;
+    }
+
+    void Open(const std::string& path)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_file.open(path, std::ios::out | std::ios::trunc);
+        if (!m_file.is_open())
+            throw std::runtime_error("Could not open output log " + path);
+
+        m_state = State::Open;
+        m_file.write(
+            m_pending.data(),
+            static_cast<std::streamsize>(m_pending.size()));
+        m_pending.clear();
+        m_file.flush();
+    }
+
+    void Disable()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_pending.clear();
+        m_state = State::Disabled;
+    }
+
+    void Close()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_file.is_open())
+        {
+            m_file.flush();
+            m_file.close();
+        }
+        m_pending.clear();
+        m_state = State::Disabled;
+    }
+
+private:
+    enum class State
+    {
+        Buffering,
+        Open,
+        Disabled
+    };
+
+    std::mutex m_mutex;
+    std::ofstream m_file;
+    std::string m_pending;
+    State m_state = State::Buffering;
+};
+
+class TeeBuffer
+    : public std::streambuf
+{
+public:
+    TeeBuffer(std::streambuf* terminal, LogSink& log)
+        : m_terminal(terminal), m_log(log)
+    {
+    }
+
+protected:
+    int_type overflow(int_type character) override
+    {
+        if (traits_type::eq_int_type(character, traits_type::eof()))
+            return traits_type::not_eof(character);
+
+        const char value = traits_type::to_char_type(character);
+        if (traits_type::eq_int_type(
+                m_terminal->sputc(value), traits_type::eof()))
+            return traits_type::eof();
+        m_log.Write(&value, 1);
+        return character;
+    }
+
+    std::streamsize xsputn(
+        const char* data, std::streamsize size) override
+    {
+        const std::streamsize written = m_terminal->sputn(data, size);
+        m_log.Write(data, written);
+        return written;
+    }
+
+    int sync() override
+    {
+        const int terminal_status = m_terminal->pubsync();
+        const int log_status = m_log.Sync();
+        return terminal_status == 0 && log_status == 0 ? 0 : -1;
+    }
+
+private:
+    std::streambuf* m_terminal;
+    LogSink& m_log;
+};
+
+LogSink log_sink;
+std::streambuf* terminal_stdout = std::cout.rdbuf();
+std::streambuf* terminal_stderr = std::cerr.rdbuf();
+std::streambuf* terminal_stdlog = std::clog.rdbuf();
+TeeBuffer stdout_buffer(terminal_stdout, log_sink);
+TeeBuffer stderr_buffer(terminal_stderr, log_sink);
+TeeBuffer stdlog_buffer(terminal_stdlog, log_sink);
+bool initialized = false;
+
+}
+
+namespace IO::OutputLog
+{
+
+void Initialize()
+{
+    if (initialized) return;
+    std::cout.rdbuf(&stdout_buffer);
+    std::cerr.rdbuf(&stderr_buffer);
+    std::clog.rdbuf(&stdlog_buffer);
+    initialized = true;
+}
+
+void Open(const std::string& path)
+{
+    log_sink.Open(path);
+}
+
+void DisableFile()
+{
+    log_sink.Disable();
+}
+
+void Finalize()
+{
+    if (!initialized) return;
+
+    std::cout.flush();
+    std::cerr.flush();
+    std::clog.flush();
+    std::cout.rdbuf(terminal_stdout);
+    std::cerr.rdbuf(terminal_stderr);
+    std::clog.rdbuf(terminal_stdlog);
+    log_sink.Close();
+    initialized = false;
+}
+
+}

--- a/src/IO/WriteMetaData.cpp
+++ b/src/IO/WriteMetaData.cpp
@@ -1,9 +1,67 @@
 #include "WriteMetaData.H"
+#include <cstdlib>
 #include <sstream>
 #include <functional>
 #include "Util/Util.H"
 
 /// \todo We need to update ParmParse so that the FORMATTED input file gets recorded permanently.
+
+namespace
+{
+
+const char* const slurm_environment_variables[] = {
+    "SLURM_JOB_ID",
+    "SLURM_JOB_NAME",
+    "SLURM_CLUSTER_NAME",
+    "SLURM_JOB_ACCOUNT",
+    "SLURM_JOB_PARTITION",
+    "SLURM_JOB_QOS",
+    "SLURM_JOB_RESERVATION",
+    "SLURM_ARRAY_JOB_ID",
+    "SLURM_ARRAY_TASK_ID",
+    "SLURM_ARRAY_TASK_COUNT",
+    "SLURM_SUBMIT_HOST",
+    "SLURM_SUBMIT_DIR",
+    "SLURM_JOB_NODELIST",
+    "SLURM_JOB_NUM_NODES",
+    "SLURM_NTASKS",
+    "SLURM_NTASKS_PER_NODE",
+    "SLURM_TASKS_PER_NODE",
+    "SLURM_DISTRIBUTION",
+    "SLURM_JOB_CPUS_PER_NODE",
+    "SLURM_CPUS_PER_TASK",
+    "SLURM_CPUS_ON_NODE",
+    "SLURM_MEM_PER_NODE",
+    "SLURM_MEM_PER_CPU",
+    "SLURM_GPUS",
+    "SLURM_GPUS_PER_NODE",
+    "SLURM_GPUS_PER_TASK",
+    "SLURM_JOB_GPUS",
+    "SLURM_TRES_PER_TASK",
+    "SLURM_STEP_ID",
+    "SLURM_STEP_NUM_TASKS",
+    "SLURM_RESTART_COUNT",
+    "SLURM_JOB_START_TIME",
+    "SLURM_JOB_END_TIME",
+    "SLURM_HET_SIZE"
+};
+
+void WriteSlurmDetails(std::ostream &metadatafile)
+{
+    if (std::getenv("SLURM_JOB_ID") == nullptr) return;
+
+    metadatafile << std::endl;
+    metadatafile << "# SLURM DETAILS" << std::endl;
+    metadatafile << "# =============" << std::endl;
+    for (const char *variable : slurm_environment_variables)
+    {
+        const char *value = std::getenv(variable);
+        if (value != nullptr && value[0] != '\0')
+            metadatafile << variable << " = " << value << std::endl;
+    }
+}
+
+}
 
 namespace IO
 {
@@ -87,6 +145,8 @@ void WriteMetaData(std::string plot_file, Status status, int per)
 
             auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now_cr - starttime_cr);
             metadatafile << "Simulation_run_time = " << (float)milliseconds.count()/1000.0 << " " << std::endl;
+
+            WriteSlurmDetails(metadatafile);
 
             #ifdef GIT_DIFF_OUTPUT
             {

--- a/src/IO/WriteMetaData.cpp
+++ b/src/IO/WriteMetaData.cpp
@@ -46,13 +46,8 @@ const char* const slurm_environment_variables[] = {
     "SLURM_HET_SIZE"
 };
 
-void WriteSlurmDetails(std::ostream &metadatafile)
+void WriteSlurmVariables(std::ostream &metadatafile)
 {
-    if (std::getenv("SLURM_JOB_ID") == nullptr) return;
-
-    metadatafile << std::endl;
-    metadatafile << "# SLURM DETAILS" << std::endl;
-    metadatafile << "# =============" << std::endl;
     for (const char *variable : slurm_environment_variables)
     {
         const char *value = std::getenv(variable);
@@ -146,7 +141,7 @@ void WriteMetaData(std::string plot_file, Status status, int per)
             auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now_cr - starttime_cr);
             metadatafile << "Simulation_run_time = " << (float)milliseconds.count()/1000.0 << " " << std::endl;
 
-            WriteSlurmDetails(metadatafile);
+            WriteSlurmVariables(metadatafile);
 
             #ifdef GIT_DIFF_OUTPUT
             {

--- a/src/Util/Util.cpp
+++ b/src/Util/Util.cpp
@@ -18,6 +18,7 @@
 #include "IO/ParmParse.H"
 #include "IO/WriteMetaData.H"
 #include "IO/FileNameParse.H"
+#include "IO/OutputLog.H"
 #include "Color.H"
 #include "Numeric/Stencil.H"
 #include "Util/MPI.H"
@@ -224,6 +225,7 @@ void Initialize ()
 }
 void Initialize (int argc, char* argv[])
 {
+    IO::OutputLog::Initialize();
     srand (time(NULL));
 
     bool parse_args = false;
@@ -271,11 +273,22 @@ void Initialize (int argc, char* argv[])
 
     std::string filename = GetFileName();
 
-    if (!IO::ParmParse::InTraversalMode() &&
-        amrex::ParallelDescriptor::IOProcessor() && filename != "")
+    if (!IO::ParmParse::InTraversalMode() && filename != "")
     {
-        file_overwrite = Util::CreateCleanDirectory(filename, false);
-        IO::WriteMetaData(filename);
+        if (amrex::ParallelDescriptor::IOProcessor())
+        {
+            file_overwrite = Util::CreateCleanDirectory(filename, false);
+            IO::OutputLog::Open(filename + "/out.log");
+            IO::WriteMetaData(filename);
+        }
+        else
+        {
+            IO::OutputLog::DisableFile();
+        }
+    }
+    else
+    {
+        IO::OutputLog::DisableFile();
     }
 
     std::string length, time, mass, temperature, current, amount, luminousintensity;
@@ -382,6 +395,7 @@ void Finalize()
             IO::WriteMetaData(filename,IO::Status::Complete);
     }
     amrex::Finalize();
+    IO::OutputLog::Finalize();
     finalized = true;
 }
 

--- a/src/test.cc
+++ b/src/test.cc
@@ -2,6 +2,7 @@
 
 #include "Set/Matrix4.H"
 #include "Util/Util.H"
+#include "IO/FileNameParse.H"
 
 #include "Test/Numeric/Stencil.H"
 #include "Test/Set/Matrix4.H"
@@ -36,6 +37,33 @@ int main (int argc, char* argv[])
 
     Util::globalprefix = "  │  ";
 
+    Util::Test::Message("IO::FileNameParse test");
+    {
+        int subfailed = 0;
+        const char *original = std::getenv("SLURM_FILENAME_PARSE_TEST");
+        const bool restore_original = original != nullptr;
+        const std::string original_value = restore_original ? original : "";
+
+        setenv("SLURM_FILENAME_PARSE_TEST", "314159", 1);
+        std::string available = "output_{SLURM_FILENAME_PARSE_TEST}";
+        IO::FileNameParse(available);
+        subfailed += Util::Test::SubMessage(
+            "Slurm environment substitution", available != "output_314159");
+
+        unsetenv("SLURM_FILENAME_PARSE_TEST");
+        std::string unavailable = "output_{SLURM_FILENAME_PARSE_TEST}";
+        IO::FileNameParse(unavailable);
+        subfailed += Util::Test::SubMessage(
+            "Unavailable Slurm variable fallback",
+            unavailable != "output_SLURM_FILENAME_PARSE_TEST");
+
+        if (restore_original)
+            setenv("SLURM_FILENAME_PARSE_TEST", original_value.c_str(), 1);
+        else
+            unsetenv("SLURM_FILENAME_PARSE_TEST");
+
+        failed += Util::Test::SubFinalMessage(subfailed);
+    }
 
     #define MODELTEST(TYPE) \
         Util::Test::Message(#TYPE); \

--- a/src/test.cc
+++ b/src/test.cc
@@ -37,33 +37,6 @@ int main (int argc, char* argv[])
 
     Util::globalprefix = "  │  ";
 
-    Util::Test::Message("IO::FileNameParse test");
-    {
-        int subfailed = 0;
-        const char *original = std::getenv("SLURM_FILENAME_PARSE_TEST");
-        const bool restore_original = original != nullptr;
-        const std::string original_value = restore_original ? original : "";
-
-        setenv("SLURM_FILENAME_PARSE_TEST", "314159", 1);
-        std::string available = "output_{SLURM_FILENAME_PARSE_TEST}";
-        IO::FileNameParse(available);
-        subfailed += Util::Test::SubMessage(
-            "Slurm environment substitution", available != "output_314159");
-
-        unsetenv("SLURM_FILENAME_PARSE_TEST");
-        std::string unavailable = "output_{SLURM_FILENAME_PARSE_TEST}";
-        IO::FileNameParse(unavailable);
-        subfailed += Util::Test::SubMessage(
-            "Unavailable Slurm variable fallback",
-            unavailable != "output_SLURM_FILENAME_PARSE_TEST");
-
-        if (restore_original)
-            setenv("SLURM_FILENAME_PARSE_TEST", original_value.c_str(), 1);
-        else
-            unsetenv("SLURM_FILENAME_PARSE_TEST");
-
-        failed += Util::Test::SubFinalMessage(subfailed);
-    }
 
     #define MODELTEST(TYPE) \
         Util::Test::Message(#TYPE); \


### PR DESCRIPTION
This PR adds some utilities to make running jobs in SLURM environments easier. Specifically:
- standard output is now teed to `<plot_file>/out.log`
- metadata now contains SLURM environment variables (like `SLURM_JOB_ID`) 
- filenames can contain SLURM variables in their name: `plot_file=output_{SLURM_JOB_ID}` will resolve to `output_103919` (e.g.).